### PR TITLE
chore: rename project to Aurelius and add community files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: PMDevSolutions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to Aurelius
+
+Welcome, and thank you for your interest in contributing to Aurelius. Named after the Roman Emperor Marcus Aurelius — a leader known for discipline, thoughtful decision-making, and principled action — this project strives to bring those same qualities to modern app development. Aurelius is a Claude Code-integrated multi-framework app development framework built by PMDevSolutions, and contributions from the community are what make it better.
+
+Whether you are fixing a bug, adding a feature, improving documentation, or suggesting an idea, we appreciate your time and effort.
+
+---
+
+## Getting Started
+
+1. **Fork and clone the repository:**
+
+   ```bash
+   git clone https://github.com/<your-username>/aurelius.git
+   cd aurelius
+   ```
+
+2. **Install pnpm** if you do not already have it. This project uses pnpm exclusively — npm and yarn are not supported.
+
+   ```bash
+   corepack enable
+   corepack prepare pnpm@latest --activate
+   ```
+
+3. **Run the setup script** to initialize your local environment:
+
+   ```bash
+   ./scripts/setup-project.sh
+   ```
+
+---
+
+## Development Setup
+
+After cloning, install all dependencies:
+
+```bash
+pnpm install
+```
+
+The following scripts are used throughout development. Run them before submitting any pull request:
+
+| Script | Purpose |
+|--------|---------|
+| `./scripts/lint-and-format.sh` | Run ESLint and Prettier across the codebase |
+| `./scripts/run-tests.sh` | Run the full Vitest test suite with coverage |
+| `./scripts/check-types.sh` | TypeScript type checking (strict mode) |
+| `./scripts/check-accessibility.sh` | Accessibility linting (WCAG 2.1 AA) |
+| `./scripts/verify-tokens.sh` | Verify design token usage (no hardcoded values) |
+| `./scripts/check-security.sh` | Security audit for dependency vulnerabilities |
+
+All checks must pass before a pull request will be reviewed.
+
+---
+
+## Branch Naming Conventions
+
+Use the following prefixes when creating branches:
+
+| Prefix | Use Case | Example |
+|--------|----------|---------|
+| `feat/` | New features or capabilities | `feat/vue-converter-improvements` |
+| `fix/` | Bug fixes | `fix/token-drift-detection` |
+| `docs/` | Documentation updates | `docs/update-pipeline-guide` |
+| `chore/` | Maintenance, refactoring, tooling | `chore/upgrade-vitest-config` |
+
+Branch names should be lowercase, use hyphens as separators, and be descriptive enough to understand the scope of the change at a glance.
+
+---
+
+## Pull Request Process
+
+1. **Create a focused branch** from `main` using the naming conventions above.
+
+2. **Make your changes.** Write tests for any new functionality and ensure existing tests continue to pass.
+
+3. **Run all checks locally** before pushing:
+
+   ```bash
+   ./scripts/lint-and-format.sh
+   ./scripts/run-tests.sh
+   ./scripts/check-types.sh
+   ```
+
+4. **Push your branch** and open a pull request against `main`.
+
+5. **Write a clear pull request title and description:**
+   - The title should be concise and under 70 characters.
+   - The description should explain what changed and why.
+   - Reference any related issues (e.g., `Closes #42`).
+
+6. **Use conventional commit messages.** Examples:
+
+   ```
+   feat: add dark mode support to svelte-converter
+   fix: resolve token sync race condition
+   docs: clarify setup instructions for Windows
+   chore: update Playwright to v1.50
+   ```
+
+7. **All CI checks must pass.** Pull requests with failing tests, lint errors, or type errors will not be merged until resolved.
+
+8. **Be responsive to review feedback.** Reviewers may request changes — this is a normal and constructive part of the process.
+
+---
+
+## Claude Code Agents
+
+Aurelius includes 51 specialized Claude Code agents and 18 skills that automate significant portions of the development workflow — from design-to-code conversion to testing, accessibility, and deployment.
+
+If you have Claude Code installed, these agents and skills are available to you automatically when working in this repository. They can assist with component development, test writing, visual QA, and much more.
+
+For full documentation on available agents and how to use them:
+
+- **Agents catalog:** [`.claude/CUSTOM-AGENTS-GUIDE.md`](.claude/CUSTOM-AGENTS-GUIDE.md)
+- **Skills reference:** [`.claude/skills/README.md`](.claude/skills/README.md)
+
+Contributors are encouraged to leverage these tools, but they are not required. All contributions are welcome regardless of whether you use Claude Code.
+
+---
+
+## Roadmap and Priorities
+
+The project roadmap is maintained publicly on the GitHub project board. You can view upcoming features, planned improvements, and known issues there.
+
+Community members are encouraged to vote on priorities and propose new ideas via GitHub Discussions. If you are considering a large contribution, please open a discussion first so we can align on scope and approach before significant work begins.
+
+---
+
+## Code of Conduct
+
+We follow standard open source etiquette. All contributors are expected to:
+
+- Be respectful and constructive in all interactions.
+- Provide clear, actionable feedback in code reviews.
+- Assume good intent from other contributors.
+- Keep discussions focused on the project and its goals.
+
+Harassment, discrimination, and disruptive behavior will not be tolerated. Maintainers reserve the right to remove content or restrict access for anyone who violates these principles.
+
+---
+
+Thank you for contributing to Aurelius. Your work helps make multi-framework development more accessible, reliable, and efficient for everyone.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# React App Development Framework
+# Aurelius
 
-A Claude Code-integrated framework for building React applications with TypeScript, Tailwind CSS, and an automated Figma-to-React pipeline.
+A Claude Code-integrated multi-framework app development framework with TypeScript, Tailwind CSS, and automated design-to-code pipelines.
 
 ## What This Framework Provides
 
@@ -16,7 +16,7 @@ A Claude Code-integrated framework for building React applications with TypeScri
 ```bash
 # Clone the repository
 git clone <repository-url>
-cd coding-framework
+cd aurelius
 
 # Initialize a new project (Next.js or Vite)
 ./scripts/setup-project.sh my-app --vite    # or --next

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release on the `main` branch is actively supported with security updates. If you are using an older version, please update to the latest release before reporting an issue.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` (latest) | Yes |
+| All other branches / older releases | No |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Aurelius, please report it responsibly. **Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Send an email to **paul@pmds.info** with the following details:
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- The potential impact or severity
+- Any suggested fixes, if applicable
+
+### Response Timeline
+
+- **Acknowledgment:** Within 48 hours of receiving your report
+- **Initial assessment:** Within 7 days of acknowledgment
+- **Resolution:** Dependent on severity and complexity; we will keep you informed of progress
+
+### Credit
+
+Reporters will be credited in the release notes and changelog for the fix unless they prefer to remain anonymous. Please indicate your preference when submitting your report.
+
+## Scope
+
+### In Scope
+
+- Framework source code
+- Scripts (all files in `scripts/`)
+- Templates (all files in `templates/`)
+- Agent definitions (all files in `.claude/agents/`)
+- Pipeline configuration and skill definitions
+
+### Out of Scope
+
+- **Third-party dependencies** -- please report vulnerabilities in upstream packages through their own security reporting channels (e.g., npm advisories, GitHub Security Advisories for the respective project)
+- Issues that require physical access to a user's machine
+- Social engineering attacks
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process. We ask that you give us reasonable time to investigate and address the issue before making any information public. We are committed to working with security researchers to resolve issues promptly and transparently.
+
+---
+
+Maintained by [PMDevSolutions](https://github.com/PMDevSolutions)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-react-framework",
+  "name": "aurelius",
   "version": "0.5.0",
   "description": "Claude Code-integrated React app development framework with specialized agents, skills, and Figma-to-React pipeline",
   "private": true,
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PMDevSolutions/Coding-Framework.git"
+    "url": "https://github.com/PMDevSolutions/Aurelius.git"
   },
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

- Rename all project references from "Coding-Framework" to "Aurelius" (named after Roman Emperor Marcus Aurelius — all PMDS FOSS projects are named after Roman Emperors)
- Update `README.md` title, description, and clone path
- Update `package.json` name field to `aurelius` and repo URL to `Aurelius.git`
- Add `CONTRIBUTING.md` with getting started, dev setup, branch naming, PR process, Claude Code agents section, and roadmap/priorities
- Add `SECURITY.md` with responsible disclosure policy (contact: paul@pmds.info)
- Add `.github/FUNDING.yml` linking to Patreon (PMDevSolutions)

## Test plan

- [ ] Verify README.md renders correctly on GitHub with new title
- [ ] Verify CONTRIBUTING.md, SECURITY.md render correctly
- [ ] Verify GitHub Sponsor button appears (from FUNDING.yml)
- [ ] Confirm no remaining "Coding-Framework" text references in updated files
- [ ] After merge, rename the GitHub repo from Coding-Framework to Aurelius

🤖 Generated with [Claude Code](https://claude.com/claude-code)