### PR TITLE
Fix #27: Add `verify-tokens.sh` as a CI step to catch hardcoded design values on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,17 @@ jobs:
               fi
             fi
           done
+
+  token-verification:
+    name: Verify Design Tokens
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run token verification
+        run: |
+          if [ -f "scripts/verify-tokens.sh" ] && [ -d "app/src" ]; then
+            cd app && bash ../scripts/verify-tokens.sh
+          else
+            echo "No app source found — skipping token check"
+          fi


### PR DESCRIPTION
## Summary

Add a new `token-verification` job to `.github/workflows/ci.yml` that runs `scripts/verify-tokens.sh` on every push/PR to main, with a conditional check for `app/src` existence.

## Approach

Append a new job named `token-verification` to the existing CI workflow in `.github/workflows/ci.yml`. The job will use `actions/checkout@v4`, then conditionally run `bash ../scripts/verify-tokens.sh` from the `app/` directory only if both `scripts/verify-tokens.sh` and `app/src` exist. This ensures the check runs on every push and PR to main but gracefully skips when no scaffolded project is present. The job should be independent (no `needs` dependency on other jobs) so it runs in parallel with existing checks.

## Files Changed

- `.github/workflows/ci.yml`

## Related Issue

Fixes #27

## Testing

No tests were added with this change. Happy to add them if needed.
