### PR TITLE
docs: developer onboarding guide and quickstart documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,17 @@ Details: `.claude/PLUGINS-REFERENCE.md`
 
 | Document | Location | Description |
 |----------|----------|-------------|
+| **Developer onboarding** | `docs/onboarding/README.md` | Start here -- quickstart, architecture, configuration, troubleshooting |
+| Quickstart guide | `docs/onboarding/quickstart.md` | Clone to running project in 10 minutes |
+| Architecture overview | `docs/onboarding/architecture.md` | All 53 agents, 19 skills, 3 pipelines, and how they connect |
+| Pipeline configuration | `docs/onboarding/pipeline-configuration.md` | Every setting in pipeline.config.json explained |
+| Troubleshooting FAQ | `docs/onboarding/troubleshooting.md` | Common issues and solutions |
 | Project instructions | `CLAUDE.md` | Full project config for Claude Code |
 | Figma pipeline guide | `docs/figma-to-react/README.md` | Pipeline overview and troubleshooting |
 | React standards | `docs/react-development/README.md` | TypeScript, Tailwind, testing conventions |
 | Canva pipeline guide | `docs/canva-to-react/README.md` | Canva pipeline overview and troubleshooting |
-| Agent catalog | `.claude/CUSTOM-AGENTS-GUIDE.md` | All 48 agents with use cases |
-| Skills catalog | `.claude/skills/README.md` | All 17 skills with triggers |
+| Agent catalog | `.claude/CUSTOM-AGENTS-GUIDE.md` | All 53 agents with use cases |
+| Skills catalog | `.claude/skills/README.md` | All 19 skills with triggers |
 | Plugin reference | `.claude/PLUGINS-REFERENCE.md` | Plugin configuration and commands |
 | Scripts reference | `scripts/README.md` | All scripts with usage examples |
 | Templates reference | `templates/README.md` | Starter configs and how to use them |

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -1,0 +1,74 @@
+# Developer Onboarding Guide
+
+Welcome to **Aurelius** -- a Claude Code-integrated multi-framework app development framework. Named after the Roman Emperor Marcus Aurelius, this project brings discipline, thoughtful automation, and principled engineering to modern app development.
+
+This guide will get you productive with the framework quickly, whether you are building a new app from scratch, converting a Figma design into working code, or contributing to the framework itself.
+
+---
+
+## Documentation Map
+
+| Document | What You Will Learn |
+|----------|-------------------|
+| [Quickstart Guide](quickstart.md) | Clone, install, create your first project, and run your first pipeline in under 10 minutes |
+| [Architecture Overview](architecture.md) | How the 53 agents, 19 skills, 3 pipelines, and 8 hooks fit together |
+| [Pipeline Configuration](pipeline-configuration.md) | Every setting in `pipeline.config.json` explained, with examples |
+| [Troubleshooting FAQ](troubleshooting.md) | Common issues, error messages, and how to resolve them |
+
+---
+
+## Who Is This For?
+
+- **New contributors** who want to understand the project structure before making changes
+- **App developers** using Aurelius to build production applications from Figma, Canva, or screenshot designs
+- **Claude Code users** who want to understand how the agents and skills enhance their workflow
+- **Framework maintainers** who need to add new agents, skills, or pipeline phases
+
+---
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+| Requirement | Version | Check Command |
+|-------------|---------|---------------|
+| Node.js | 18+ | `node --version` |
+| pnpm | 8+ | `pnpm --version` |
+| Git | 2.30+ | `git --version` |
+| Claude Code | Latest | `claude --version` |
+
+Optional (for specific workflows):
+
+| Tool | Required For |
+|------|-------------|
+| Figma Desktop App | Figma MCP integration (local design access) |
+| GitHub CLI (`gh`) | PR creation, issue management |
+| Playwright browsers | Cross-browser testing (`./scripts/setup-playwright.sh`) |
+
+---
+
+## Quick Links
+
+- [Main README](../../README.md) -- Project overview
+- [Contributing Guide](../../CONTRIBUTING.md) -- Branch naming, PR process, commit conventions
+- [Agent Catalog](../../.claude/CUSTOM-AGENTS-GUIDE.md) -- All 53 agents with use cases
+- [Skills Catalog](../../.claude/skills/README.md) -- All 19 skills with triggers
+- [Plugin Reference](../../.claude/PLUGINS-REFERENCE.md) -- Installed plugins and commands
+- [Pipeline Config](../../.claude/pipeline.config.json) -- Thresholds and app-type definitions
+- [React Development Standards](../react-development/README.md) -- TypeScript, Tailwind, testing conventions
+- [Figma Pipeline Guide](../figma-to-react/README.md) -- Figma-to-React pipeline deep dive
+- [Canva Pipeline Guide](../canva-to-react/README.md) -- Canva-to-React pipeline deep dive
+- [Screenshot Pipeline Guide](../screenshot-to-app/README.md) -- Screenshot/URL-to-app pipeline
+- [Multi-Framework Guide](../multi-framework/README.md) -- Vue, Svelte, React Native output targets
+
+---
+
+## How to Read These Docs
+
+**If you are setting up for the first time**, start with the [Quickstart Guide](quickstart.md).
+
+**If you want to understand how things work**, read the [Architecture Overview](architecture.md).
+
+**If you are customizing pipeline behavior**, go to [Pipeline Configuration](pipeline-configuration.md).
+
+**If something is not working**, check the [Troubleshooting FAQ](troubleshooting.md).

--- a/docs/onboarding/architecture.md
+++ b/docs/onboarding/architecture.md
@@ -1,0 +1,403 @@
+# Architecture Overview
+
+This document explains how Aurelius is structured and how its components work together: agents, skills, pipelines, scripts, templates, plugins, hooks, and MCP servers.
+
+---
+
+## System Architecture
+
+```
+                         ┌─────────────────────────┐
+                         │      Claude Code         │
+                         │   (orchestration layer)  │
+                         └────────┬────────────────┘
+                                  │
+             ┌────────────────────┼─────────────────────┐
+             │                    │                      │
+     ┌───────▼──────┐   ┌────────▼────────┐   ┌────────▼────────┐
+     │   53 Agents   │   │    19 Skills    │   │    4 Plugins    │
+     │ (specialized  │   │  (workflow      │   │ (extensions:    │
+     │  task workers) │   │   automation)  │   │  memory, git,   │
+     └───────┬──────┘   └────────┬────────┘   │  superpowers)   │
+             │                    │            └────────┬────────┘
+             │           ┌────────▼────────┐            │
+             │           │  3 Pipelines    │            │
+             │           │ (Figma, Canva,  │            │
+             │           │  Screenshot)    │            │
+             │           └────────┬────────┘            │
+             │                    │                      │
+     ┌───────▼────────────────────▼──────────────────────▼───────┐
+     │                    Infrastructure                          │
+     │  ┌──────────┐  ┌───────────┐  ┌──────────┐  ┌──────────┐ │
+     │  │ 30+      │  │ 8         │  │ 6 MCP    │  │ Templates│ │
+     │  │ Scripts   │  │ Hooks     │  │ Servers  │  │ (8 sets) │ │
+     │  └──────────┘  └───────────┘  └──────────┘  └──────────┘ │
+     └───────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Agents (53 Total)
+
+Agents are specialized Claude Code sub-processes that handle complex, multi-step tasks. Each agent is a markdown file in `.claude/agents/` with frontmatter defining its tools, capabilities, and instructions. Claude Code selects agents automatically based on your task context.
+
+### Engineering Agents (12)
+
+| Agent | Purpose | Key Tools |
+|-------|---------|-----------|
+| `frontend-developer` | Build React/Vue/Angular components, handle state management, optimize frontend performance | Write, Read, Bash, Grep, Glob |
+| `backend-architect` | Design APIs, implement databases, architect scalable backend services | Write, Read, Bash, Grep |
+| `rapid-prototyper` | Scaffold projects, build MVPs and proof-of-concepts quickly | Write, Bash, Read, Glob, Task |
+| `test-writer-fixer` | Write tests, run suites, analyze failures, fix broken tests | All tools |
+| `error-boundary-architect` | Design error handling, React error boundaries, Sentry integration | Write, Read, Bash, Grep, Glob |
+| `migration-specialist` | Upgrade React versions, migrate frameworks (CRA to Vite), run codemods | Write, Read, Bash, Grep, Glob, WebSearch |
+| `i18n-engineer` | Add internationalization, manage translations, implement RTL support | Write, Read, Bash, Grep, Glob, WebSearch |
+| `animation-optimizer` | Optimize animations, profile jank, ensure reduced-motion accessibility | Read, Write, Bash, Grep, Glob + Chrome DevTools MCP |
+| `bundle-analyzer` | Analyze bundles, audit tree-shaking, optimize code splitting | Read, Write, Bash, Grep, Glob |
+| `ai-engineer` | Integrate AI/ML features, build recommendation systems | Write, Read, Bash, WebFetch |
+| `devops-automator` | Set up CI/CD, configure cloud infrastructure, automate deployments | Write, Read, Bash, Grep |
+| `mobile-app-builder` | Develop React Native/Expo mobile apps, optimize mobile performance | Write, Read, Bash, Grep |
+
+### Design Agents (5)
+
+| Agent | Purpose |
+|-------|---------|
+| `ui-designer` | Create user interfaces, design systems, visual hierarchy |
+| `ux-researcher` | Conduct user research, analyze behavior, create journey maps |
+| `brand-guardian` | Enforce brand consistency, manage brand assets |
+| `visual-storyteller` | Create data visualizations, infographics, presentations |
+| `whimsy-injector` | Add micro-interactions and delightful UI details (runs proactively after UI changes) |
+
+### Design-to-Code Agents (6)
+
+| Agent | Purpose | Output |
+|-------|---------|--------|
+| `figma-react-converter` | Convert Figma designs to React components via Figma MCP | React + TypeScript + Tailwind |
+| `canva-react-converter` | Convert Canva designs using screenshots and vision analysis | React + TypeScript + Tailwind |
+| `vue-converter` | Convert designs to Vue 3 components | Vue 3 + `<script setup>` + TypeScript |
+| `svelte-converter` | Convert designs to Svelte 5 components | SvelteKit + TypeScript + Tailwind |
+| `react-native-converter` | Convert designs to React Native components | Expo + TypeScript + NativeWind |
+| `asset-cataloger` | Catalog and semantically map project image assets | Mapping JSON + validation |
+
+### Testing and QA Agents (7)
+
+| Agent | Purpose |
+|-------|---------|
+| `visual-qa-agent` | Pixel-diff regression testing, cross-browser visual verification |
+| `accessibility-auditor` | WCAG 2.1 AA compliance: Lighthouse audits, ARIA, contrast, keyboard nav |
+| `api-tester` | REST/GraphQL API testing: performance, load, contract tests |
+| `performance-benchmarker` | Profiling, Lighthouse audits, bottleneck identification |
+| `test-results-analyzer` | Analyze test results, identify trends, generate quality metrics |
+| `tool-evaluator` | Evaluate development tools, frameworks, and services |
+| `workflow-optimizer` | Optimize human-agent collaboration and workflow efficiency |
+
+### Product Agents (3)
+
+| Agent | Purpose |
+|-------|---------|
+| `sprint-prioritizer` | Plan sprints, prioritize features, manage roadmaps |
+| `feedback-synthesizer` | Analyze user feedback, identify patterns, prioritize features |
+| `trend-researcher` | Research market trends, viral content, emerging user behaviors |
+
+### Marketing Agents (7)
+
+| Agent | Purpose |
+|-------|---------|
+| `content-creator` | Blog posts, video scripts, cross-platform content |
+| `growth-hacker` | User acquisition, viral loops, growth experiments |
+| `app-store-optimizer` | App store keywords, metadata optimization, conversion rates |
+| `instagram-curator` | Instagram content strategy, Stories, Reels |
+| `reddit-community-builder` | Authentic Reddit engagement and community growth |
+| `tiktok-strategist` | TikTok campaigns, viral content, algorithm optimization |
+| `twitter-engager` | Tweet threads, trending topics, community building |
+
+### Project Management Agents (3)
+
+| Agent | Purpose |
+|-------|---------|
+| `studio-producer` | Cross-functional coordination, resource management |
+| `project-shipper` | Launch coordination, release processes, go-to-market |
+| `experiment-tracker` | Track A/B tests, feature experiments, iteration results |
+
+### Operations Agents (5)
+
+| Agent | Purpose |
+|-------|---------|
+| `analytics-reporter` | Metrics analysis, performance reports, data-driven insights |
+| `finance-tracker` | Budget management, cost optimization, revenue forecasting |
+| `infrastructure-maintainer` | System health monitoring, scaling, reliability |
+| `legal-compliance-checker` | Privacy policies, regulatory compliance, licensing |
+| `support-responder` | Customer support, documentation, response automation |
+
+### Documentation, Meta, and Bonus Agents (5)
+
+| Agent | Purpose |
+|-------|---------|
+| `docusaurus-expert` | Docusaurus documentation sites, MDX content management |
+| `agent-expert` | Create and design new specialized Claude Code agents |
+| `command-expert` | Create CLI commands with argument parsing and automation |
+| `joker` | Dad jokes, programming puns, startup humor |
+| `studio-coach` | Performance coaching for agents, motivation, coordination |
+
+---
+
+## Skills (19 Total)
+
+Skills are automated workflows triggered by slash commands or keyword detection. Unlike agents (which are general-purpose workers), skills encode specific multi-step processes.
+
+### Pipeline Skills (Phase-Specific)
+
+| Skill | Pipeline Phase | What It Does |
+|-------|---------------|-------------|
+| `figma-intake` | Phase 1 (Figma) | Auto-discovers Figma file structure, asks 3-5 targeted questions, produces `build-spec.json` |
+| `canva-intake` | Phase 1 (Canva) | Vision-based discovery from Canva screenshots via MCP |
+| `screenshot-intake` | Phase 1 (Screenshot) | Captures URL or reads images, vision-based analysis |
+| `design-token-lock` | Phase 2 | Extracts design tokens into `design-tokens.lock.json` + Tailwind config |
+| `canva-token-inference` | Phase 2 (Canva/Screenshot) | AI-powered token extraction with confidence scoring |
+| `tdd-from-figma` | Phase 3 | Writes failing tests for every component (RED phase, app-type-aware) |
+| `figma-to-react-workflow` | Phase 4 | Orchestrates component generation with enforced TDD and visual QA |
+| `e2e-test-generator` | Phase 6 | Generates Playwright E2E tests (web app, Chrome extension, PWA) |
+| `visual-qa-verification` | Phase 5 | Automated pixel-diff using pixelmatch, up to 5 iterations |
+| `parallel-orchestration` | Phases 4-9 | Concurrent phase execution with dependency graph |
+
+### React Development Skills
+
+| Skill | Trigger Keywords |
+|-------|-----------------|
+| `react-component-development` | "create component", "custom hook", component patterns |
+| `react-testing-workflows` | "write tests", "test coverage", Vitest, Playwright |
+| `react-performance-optimization` | "performance", "bundle size", profiling, Web Vitals |
+| `react-accessibility` | "accessibility", "a11y", "ARIA", WCAG patterns |
+| `state-management` | "state management", "zustand", "data fetching" |
+| `form-handling` | "form", "validation", "react hook form", Zod |
+| `auth-flows` | "auth", "login", "session", "OAuth" |
+| `animation-motion` | "animation", "framer motion", "transition" |
+| `seo-metadata` | "SEO", "metadata", "open graph", JSON-LD |
+
+---
+
+## Pipelines
+
+Three autonomous pipelines convert designs into working, tested applications. All three share phases 3-9; they differ only in how they discover the design and extract tokens.
+
+### Pipeline Flow
+
+```
+INPUT SOURCE                    SHARED PIPELINE
+─────────────                   ───────────────
+Figma URL ──► figma-intake      [3] TDD Scaffold (hard gate)
+Canva URL ──► canva-intake      [4] Component Build
+Screenshot ──► screenshot-intake [5] Visual Diff (pixelmatch loop)
+              │                  [6] E2E Tests (Playwright)
+              ▼                  [7] Cross-Browser Screenshots
+         build-spec.json         [8] Quality Gate (5 parallel checks)
+              │                  [9] Build Report
+              ▼
+         Token Extraction
+         (Figma: direct API,
+          Canva/Screenshot:
+          AI inference)
+              │
+              ▼
+         design-tokens.lock.json
+```
+
+### Key Enforcement Rules
+
+- **TDD is mandatory.** Phase 3 gates Phase 4 -- components cannot be built until tests exist.
+- **Visual QA uses pixel diff.** `pixelmatch`-based comparison with a 2% threshold, not manual review.
+- **Design tokens are locked.** A lockfile prevents hardcoded color/spacing/font values in components.
+- **E2E tests are app-type-aware.** Chrome extensions, PWAs, and web apps each get tailored test strategies.
+
+### Parallel Orchestration (Phases 4-9)
+
+After TDD scaffolding, the pipeline runs phases concurrently where dependencies allow:
+
+```
+         tdd-scaffold (blocking)
+              │
+              ▼
+         component-build (blocking)
+              │
+    ┌─────────┼─────────────┬──────────────┬──────────────┐
+    │         │             │              │              │
+    ▼         ▼             ▼              ▼              ▼
+storybook  visual-diff  dark-mode    cross-browser   quality-gate
+(non-blk)  (blocking)   (non-blk)    (non-blk)      (blocking)
+              │                                          │
+              ▼                                          │
+           e2e-tests (blocking)                          │
+              │                                          │
+              └──────────────────────────────────────────┘
+                                  │
+                                  ▼
+                               report
+```
+
+Maximum 3 phases run concurrently (configurable). Resource tagging prevents write conflicts.
+
+### Supported App Types
+
+| App Type | Detection | E2E Strategy | Test Harness |
+|----------|-----------|-------------|-------------|
+| Web App | Default | Page navigation, forms, responsive | Playwright |
+| Chrome Extension | `manifest.json` with `manifest_version` | Extension load, popup, content scripts | Playwright (persistent context) |
+| PWA | `manifest.json` with `start_url` | Install prompt, offline fallback, SW lifecycle | Playwright |
+| React Native | Expo project | App launch, screen navigation, deep links | Maestro |
+
+### Multi-Framework Output
+
+The `outputTarget` field in `build-spec.json` controls which framework the pipeline generates:
+
+| Target | Converter Agent | Test Library |
+|--------|----------------|-------------|
+| `"react"` | figma-react-converter / canva-react-converter | Vitest + React Testing Library |
+| `"vue"` | vue-converter | Vitest + @vue/test-utils |
+| `"svelte"` | svelte-converter | Vitest + @testing-library/svelte |
+| `"react-native"` | react-native-converter | Jest + @testing-library/react-native |
+
+Auto-detection: if not specified, the pipeline reads `package.json` and config files to determine the framework.
+
+---
+
+## Scripts (30+)
+
+Located in `scripts/`. These are the automation backbone that agents and pipelines invoke.
+
+### Code Quality
+
+| Script | Purpose |
+|--------|---------|
+| `lint-and-format.sh` | ESLint + Prettier |
+| `check-types.sh` | TypeScript `--noEmit` |
+| `check-bundle-size.sh` | Bundle size warnings (threshold in pipeline config) |
+| `check-accessibility.sh` | jsx-a11y scanning |
+| `check-dead-code.sh` | Unused exports, files, dependencies (knip) |
+| `check-security.sh` | Dependency vulnerabilities + anti-pattern detection |
+
+### Testing
+
+| Script | Purpose |
+|--------|---------|
+| `run-tests.sh` | Vitest with coverage |
+| `cross-browser-test.sh` | Playwright multi-browser screenshots |
+| `setup-playwright.sh` | One-time browser engine installation |
+| `capture-baselines.sh` | Capture baseline screenshots for regression |
+| `regression-test.sh` | Visual regression testing against baselines |
+
+### Pipeline and Verification
+
+| Script | Purpose |
+|--------|---------|
+| `verify-tokens.sh` | Catch hardcoded design values |
+| `verify-test-coverage.sh` | Ensure every component has a test file |
+| `visual-diff.js` | Pixel-level screenshot comparison (single + batch) |
+| `sync-tokens.sh` | Token drift detection between lockfile and source |
+| `check-dark-mode.sh` | Dark mode screenshot comparison |
+| `check-responsive.sh` | Screenshots at 5 breakpoints (320-1920px) |
+| `audit-cross-browser-css.sh` | Cross-browser CSS compatibility audit |
+
+### Project and Documentation
+
+| Script | Purpose |
+|--------|---------|
+| `setup-project.sh` | Initialize new project (`--next`, `--vite`) |
+| `generate-stories.sh` | Auto-generate Storybook stories |
+| `generate-component-docs.sh` | Generate MDX component documentation |
+| `generate-api-client.sh` | OpenAPI spec to typed TypeScript client |
+
+---
+
+## Templates (8 Sets)
+
+Located in `templates/`. Starter configurations applied by `setup-project.sh` and pipelines.
+
+| Directory | Contents |
+|-----------|---------|
+| `shared/` | ESLint, Prettier, Tailwind, TypeScript, Vitest, Playwright, CSS reset (12 files) |
+| `nextjs/` | Next.js config |
+| `vite/` | Vite config |
+| `vue/` | Vue 3 package.json, vite, tsconfig, vitest config |
+| `sveltekit/` | SvelteKit config, vite, tsconfig, vitest |
+| `expo/` | Expo package.json, app.json, tsconfig, babel config |
+| `chrome-extension/` | Playwright fixtures for extension E2E testing |
+| `pwa/` | Playwright config for PWA E2E testing (offline, install, SW) |
+
+---
+
+## Plugins (4 + gh CLI)
+
+Plugins extend Claude Code with persistent capabilities.
+
+| Plugin | Purpose | Key Commands |
+|--------|---------|-------------|
+| `episodic-memory` | Persistent memory across conversations | Search past conversations, recall decisions |
+| `commit-commands` | Git workflow automation | `/commit`, `/commit-push-pr`, `/clean_gone` |
+| `superpowers` | Advanced development workflows | TDD, planning, debugging, code review, brainstorming |
+| `ai-taskmaster` (local) | Task management and development planning | Task creation and tracking |
+
+GitHub integration is via the `gh` CLI (not a plugin): `gh pr create`, `gh issue create`, etc.
+
+---
+
+## Hooks (8 Automated)
+
+Configured in `.claude/settings.json` as `PostToolUse` hooks on the `Bash` matcher. These run automatically after specific commands.
+
+| Hook | Triggers On | Action |
+|------|-------------|--------|
+| Post-build QA reminder | `pnpm build` succeeds | Suggests running quality gate checks |
+| Pre-commit token guard | `git commit` detected | Runs `verify-tokens.sh`, warns on violations |
+| Dark mode reminder | `visual-diff.js` passes | Suggests running dark mode verification |
+| Coverage enforcement | `vitest` with coverage output | Reminds to check 80% threshold |
+| Lighthouse CI | `pnpm build` succeeds | Suggests Lighthouse audit with config thresholds |
+| Bundle size guard | `git commit` detected | Warns if build exceeds `maxSizeKb` |
+| Mutation testing reminder | All vitest tests pass | Suggests running Stryker for test quality |
+| Regression reminder | `pnpm build` succeeds | Suggests regression test if baselines exist |
+
+---
+
+## MCP Servers (6)
+
+Model Context Protocol servers provide external tool access to agents.
+
+| Server | Purpose | Required For |
+|--------|---------|-------------|
+| Figma Desktop MCP | Local Figma integration (port 3845) | Figma pipeline phases 1-2, 5 |
+| Figma Remote MCP | Fallback remote Figma access | Figma pipeline (when desktop unavailable) |
+| Chrome DevTools MCP | Screenshots, Lighthouse, DOM inspection | Visual QA, quality gate |
+| Playwright MCP | Cross-browser testing (Chromium, Firefox, WebKit) | E2E and cross-browser phases |
+| Canva AI Connector | Search, export, interact with Canva designs | Canva pipeline phases 1-2 |
+| Sentry | Error monitoring | Production error tracking |
+
+---
+
+## Key Artifacts
+
+These files are generated and consumed by the pipeline:
+
+| File | Created By | Used By | Purpose |
+|------|-----------|---------|---------|
+| `build-spec.json` | Intake skills | All pipeline phases | Machine-readable build plan (app type, components, output target, E2E flows) |
+| `design-tokens.lock.json` | Token lock / inference skills | Component build, token verification | Single source of truth for all design values |
+| `build-report.md` | Report phase | Developer review | Final pipeline report with screenshots and metrics |
+| `pipeline.config.json` | Manual configuration | All pipeline phases | Thresholds, app types, orchestration settings |
+
+---
+
+## How Components Connect
+
+A typical workflow through the system:
+
+1. **User provides a Figma URL** via `/build-from-figma`
+2. **`figma-intake` skill** discovers the design, asks questions, produces `build-spec.json`
+3. **`design-token-lock` skill** extracts tokens into `design-tokens.lock.json`
+4. **`tdd-from-figma` skill** writes failing tests (RED phase)
+5. **`figma-react-converter` agent** builds components using the `figma-to-react-workflow` skill
+6. **`visual-qa-agent`** runs pixel-diff verification using `visual-diff.js`
+7. **`e2e-test-generator` skill** creates Playwright tests based on app type from `build-spec.json`
+8. **Hooks** fire automatically: token guard on commit, coverage check after tests, bundle size on commit
+9. **Quality gate** runs 5 parallel checks per `pipeline.config.json` thresholds
+10. **Final report** is generated with all results
+
+Each step reads configuration from `pipeline.config.json` and respects the orchestration dependency graph.

--- a/docs/onboarding/pipeline-configuration.md
+++ b/docs/onboarding/pipeline-configuration.md
@@ -1,0 +1,439 @@
+# Pipeline Configuration Guide
+
+All pipeline behavior is controlled by `.claude/pipeline.config.json`. This document explains every section, what the defaults are, and how to customize them.
+
+---
+
+## File Location
+
+```
+.claude/pipeline.config.json
+```
+
+The file is version-controlled and shared across all developers. Changes to thresholds affect all pipeline runs in the repository.
+
+---
+
+## Configuration Sections
+
+### Visual Diff (`visualDiff`)
+
+Controls the pixel-level screenshot comparison engine used in Phase 5.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `threshold` | `0.02` (2%) | Maximum pixel mismatch ratio to pass. Lower = stricter. |
+| `antialiasing` | `true` | Detect and ignore anti-aliasing differences |
+| `diffColorRgb` | `[255, 0, 255]` | Color used to highlight diff pixels (magenta) |
+| `alphaBlending` | `0.3` | Transparency of the diff overlay |
+| `subPixelClassification` | `true` | Classify diffs as sub-pixel (cosmetic) vs structural |
+| `subPixelMaxClusterSize` | `2` | Max cluster size considered sub-pixel |
+| `typographyAnalysis` | `true` | Detect font weight and fallback differences |
+| `fontWeightThreshold` | `15` | Maximum font weight variance before flagging |
+| `fontFallbackDensityThreshold` | `0.05` | Density threshold for font fallback detection |
+| `layoutDriftAnalysis` | `true` | Detect element position shifts |
+| `layoutShiftThresholdPx` | `2` | Max pixel shift before flagging layout drift |
+
+**Breakpoints** (responsive screenshots):
+
+| Name | Width |
+|------|-------|
+| `mobile` | 375px |
+| `tablet` | 768px |
+| `desktop` | 1440px |
+| `wide` | 1920px |
+
+Required breakpoints for visual diff: `mobile`, `tablet`, `desktop`.
+
+**Output:** Diff images are saved to `.claude/visual-qa/diffs/`.
+
+---
+
+### Iteration Loop (`iterationLoop`)
+
+Controls the visual diff iteration cycle in Phase 5. When a diff fails, the pipeline attempts fixes and re-compares.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maxVisualIterations` | `5` | Maximum fix-and-recompare attempts |
+| `maxFixAttemptsPerCheck` | `2` | Max fix attempts per individual check |
+| `diffPassThreshold` | `0.02` (2%) | Mismatch ratio required to pass |
+| `diffWarnThreshold` | `0.05` (5%) | Mismatch ratio that triggers a warning (but still passes) |
+| `regionAnalysis` | `true` | Divide screenshot into grid regions for targeted fixes |
+| `regionGridSize` | `4` | Grid divisions (4 = 4x4 = 16 regions) |
+| `stopOnFirstPassingIteration` | `true` | Stop iterating once diff passes |
+
+**Example:** With defaults, the pipeline will attempt up to 5 visual fix iterations. If the diff is under 2%, it passes. Between 2-5%, it warns. Above 5%, the fix loop continues. After 5 failed iterations, the pipeline reports the remaining diff.
+
+---
+
+### TDD Enforcement (`tdd`)
+
+Controls the Test-Driven Development gate at Phase 3. This is the strictest enforcement in the pipeline.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enforced` | `true` | TDD is mandatory -- cannot be disabled without changing this |
+| `redPhaseRequired` | `true` | Tests must be written before components |
+| `greenPhaseRequired` | `true` | Components must make tests pass |
+| `refactorPhaseOptional` | `true` | Refactor step is optional |
+| `testExistenceGate` | `true` | Phase 4 is blocked until Phase 3 produces test files |
+| `coverageThreshold` | `80` | Minimum test coverage percentage |
+| `componentTestRequired` | `true` | Every component must have a corresponding test |
+| `lockfileAssertionsRequired` | `true` | Tests must assert against design token lockfile values |
+
+> **This is a hard gate.** If `testExistenceGate` is `true`, the build phase cannot start until test files exist for every component in the build spec.
+
+---
+
+### E2E Testing (`e2e`)
+
+Controls Playwright end-to-end test generation and execution.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable E2E test generation |
+| `conditionalOnAppType` | `true` | Tailor E2E strategy to the detected app type |
+| `browsers` | `["chromium", "firefox", "webkit"]` | Browsers for E2E execution |
+| `crossBrowserRequired` | `true` | Require cross-browser screenshots |
+| `timeoutMs` | `30000` | Test timeout per test (30 seconds) |
+| `retries` | `2` | Retry count for flaky tests |
+| `mobileBrowsers` | `["mobile-chrome", "mobile-safari"]` | Mobile browser emulation targets |
+| `crossBrowserDiffThreshold` | `0.03` (3%) | Acceptable visual diff between browsers |
+
+---
+
+### Quality Gate (`qualityGate`)
+
+The quality gate runs 5 parallel checks after component build. All blocking checks must pass for the pipeline to succeed.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `testsRequired` | `true` | Vitest suite must pass |
+| `typescriptRequired` | `true` | `tsc --noEmit` must pass |
+| `buildRequired` | `true` | `pnpm build` must succeed |
+| `tokenVerificationRequired` | `true` | `verify-tokens.sh` must find no violations |
+| `lighthouseRequired` | `true` | Lighthouse audit must meet thresholds |
+| `e2eRequired` | `true` | E2E tests must pass |
+| `testCoverageEnforced` | `true` | Coverage must meet TDD threshold (80%) |
+
+**Lighthouse Thresholds:**
+
+| Category | Minimum Score |
+|----------|--------------|
+| Performance | 80 |
+| Accessibility | 90 |
+| Best Practices | 90 |
+| SEO | 90 |
+
+**Mutation Testing** (opt-in):
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `mutationScore.enabled` | `false` | Disabled by default |
+| `mutationScore.threshold` | `80` | Minimum mutation score if enabled |
+| `mutationScore.tool` | `"stryker"` | Mutation testing framework |
+| `mutationScore.blocking` | `false` | Does not block pipeline even if enabled |
+
+---
+
+### App Types (`appTypes`)
+
+Defines behavior for each supported application type. The pipeline reads the app type from `build-spec.json` and applies the matching configuration.
+
+#### Web App (`web-app`)
+
+```json
+{
+  "e2eStrategy": "navigate-interact-verify",
+  "defaultE2eFlows": ["page-navigation", "form-submission", "responsive-layout"],
+  "testHarness": "playwright",
+  "devServer": true,
+  "browsers": ["chromium", "firefox", "webkit"],
+  "mobileBrowsers": ["mobile-chrome", "mobile-safari"]
+}
+```
+
+#### Chrome Extension (`chrome-extension`)
+
+```json
+{
+  "e2eStrategy": "load-extension-interact",
+  "defaultE2eFlows": ["extension-load", "popup-open", "popup-interact", "content-script-inject", "manifest-v3-compat"],
+  "testHarness": "playwright-chromium-persistent",
+  "devServer": false,
+  "browsers": ["chromium"],
+  "firefoxWebExtSupport": true,
+  "browserContextOptions": {
+    "headless": false,
+    "args": ["--disable-extensions-except=${extensionPath}", "--load-extension=${extensionPath}"]
+  },
+  "buildCommand": "pnpm build",
+  "extensionPathDefault": "dist"
+}
+```
+
+> Chrome extensions require a non-headless Chromium browser with persistent context. The extension path is resolved from the build output.
+
+#### PWA (`pwa`)
+
+```json
+{
+  "e2eStrategy": "navigate-interact-verify-offline",
+  "defaultE2eFlows": ["page-navigation", "install-prompt", "offline-fallback", "push-notification", "sw-lifecycle"],
+  "testHarness": "playwright",
+  "devServer": true,
+  "browsers": ["chromium", "firefox", "webkit"]
+}
+```
+
+#### React Native (`react-native`)
+
+```json
+{
+  "e2eStrategy": "launch-app-interact-verify",
+  "defaultE2eFlows": ["app-launch", "screen-navigation", "form-interaction", "deep-link"],
+  "testHarness": "maestro",
+  "devServer": true,
+  "buildCommand": "expo build",
+  "platforms": ["ios", "android"]
+}
+```
+
+---
+
+### Screenshot Capture (`screenshotCapture`)
+
+Controls how screenshots are taken during visual QA.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `fullPage` | `true` | Capture full page (not just viewport) |
+| `format` | `"png"` | Image format |
+| `quality` | `100` | Image quality (100 = lossless) |
+| `waitForNetworkIdle` | `true` | Wait for network activity to stop |
+| `waitAfterLoadMs` | `1000` | Additional wait after page load (ms) |
+| `outputDir` | `.claude/visual-qa/screenshots` | Where screenshots are saved |
+
+---
+
+### Dark Mode (`darkMode`)
+
+Controls dark mode screenshot verification.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable dark mode checks |
+| `diffThreshold` | `0.03` (3%) | Acceptable diff between light and dark modes |
+| `emulateMediaFeature` | `"prefers-color-scheme: dark"` | CSS media query to emulate |
+| `compareAgainst` | `"light"` | Compare dark screenshots against light baseline |
+| `screenshotDir` | `.claude/visual-qa/screenshots/dark` | Dark mode screenshot output |
+
+---
+
+### Storybook (`storybook`)
+
+Controls auto-generation of Storybook stories.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `autoGenerate` | `true` | Automatically create stories for new components |
+| `includeResponsiveViewports` | `true` | Include mobile/tablet/desktop viewport stories |
+| `viewports` | `["mobile", "tablet", "desktop"]` | Viewport variants to generate |
+| `skipPatterns` | `["**/index.ts", "**/*.test.*", "**/*.stories.*"]` | Files to exclude |
+
+---
+
+### Token Sync (`tokenSync`)
+
+Controls design token drift detection between the lockfile and source code.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `autoCheck` | `true` | Automatically check for token drift |
+| `warnOnDrift` | `true` | Warn when drift is detected |
+| `autoUpdate` | `false` | Do not auto-update lockfile (requires manual review) |
+
+---
+
+### Security (`security`)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable security auditing |
+| `auditLevel` | `"moderate"` | Minimum vulnerability level to report |
+| `failOnVulnerability` | `true` | Fail pipeline on vulnerabilities |
+| `checkLockfile` | `true` | Audit the lockfile for known issues |
+
+---
+
+### Bundle Size (`bundleSize`)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable bundle size checks |
+| `maxSizeKb` | `200` | Maximum bundle size (KB) before failing |
+| `warnSizeKb` | `150` | Size (KB) that triggers a warning |
+
+---
+
+### Error Monitoring (`errorMonitoring`)
+
+Sentry integration for production error tracking.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `provider` | `"sentry"` | Error monitoring provider |
+| `dsn` | `""` | Sentry DSN (must be configured per project) |
+| `environment` | `"production"` | Sentry environment tag |
+| `sampleRate` | `1` | Error event sample rate (1 = 100%) |
+| `tracesSampleRate` | `0.2` | Performance trace sample rate (20%) |
+| `enableInDev` | `false` | Disable in development |
+| `sourceMapUpload` | `true` | Upload source maps for readable stack traces |
+
+---
+
+### Deploy Preview (`deployPreview`)
+
+Vercel-based deploy preview integration.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable deploy previews |
+| `provider` | `"vercel"` | Deploy platform |
+| `autoDeployOnPR` | `true` | Auto-deploy on pull request |
+| `runVisualQAOnPreview` | `true` | Run visual QA on preview deployments |
+| `runLighthouseOnPreview` | `true` | Run Lighthouse on preview deployments |
+
+---
+
+### Responsive Verification (`responsiveVerification`)
+
+Controls multi-breakpoint responsive screenshot checks.
+
+| Breakpoint | Width |
+|------------|-------|
+| `small-mobile` | 320px |
+| `mobile` | 375px |
+| `tablet` | 768px |
+| `desktop` | 1440px |
+| `wide` | 1920px |
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `diffThreshold` | `0.03` (3%) | Acceptable diff between expected and actual |
+| `blocking` | `false` | Non-blocking -- reports but does not fail pipeline |
+
+---
+
+### Regression Testing (`regressionTesting`)
+
+Visual regression testing against stored baselines.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `baselineDir` | `.claude/visual-qa/baselines` | Stored baseline screenshots |
+| `threshold` | `0.02` (2%) | Acceptable diff from baseline |
+| `failOnMissingBaseline` | `false` | Do not fail if baseline does not exist yet |
+| `updateBaselinesOnPass` | `false` | Do not auto-update baselines |
+| `routes` | `["/"]` | Routes to test |
+| `browsers` | `["chromium"]` | Browsers for regression |
+| `waitAfterLoadMs` | `1500` | Wait time before capture |
+
+---
+
+### Canva Pipeline (`canva`)
+
+Canva-specific pipeline configuration.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `tokenInference.confirmWithUser` | `true` | Require user confirmation of inferred tokens |
+| `tokenInference.confidenceThreshold` | `"medium"` | Minimum confidence for auto-acceptance |
+| `export.format` | `"png"` | Export format from Canva |
+| `export.scale` | `2` | Export scale (2x for retina) |
+| `mcpServer` | `"canva"` | MCP server name for Canva API |
+| `retry.maxAttempts` | `3` | Retry count for Canva API failures |
+| `retry.backoffMultiplier` | `2` | Exponential backoff multiplier |
+
+---
+
+### Screenshot Pipeline (`screenshot`)
+
+Screenshot/URL capture configuration.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `tokenInference.confirmWithUser` | `true` | Require user confirmation of inferred tokens |
+| `capture.fullPage` | `true` | Capture full page |
+| `capture.scale` | `2` | Capture scale (2x) |
+| `urlCapture.viewports` | Desktop (1440x900), Mobile (375x812) | Viewport sizes for URL capture |
+
+---
+
+### Orchestration (`orchestration`)
+
+Controls parallel phase execution.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `true` | Enable parallel orchestration |
+| `maxConcurrent` | `3` | Maximum phases running simultaneously |
+
+**Phase dependency graph:** Defined in `orchestration.phases`. Each phase declares:
+- `depends` -- phases that must complete first
+- `resources` -- filesystem/port resources the phase uses (prevents conflicts)
+- `blocking` -- whether the pipeline waits for this phase
+- `description` -- human-readable purpose
+
+**Quality gate subtasks** (5 parallel checks):
+- `coverage` -- vitest with 80% threshold
+- `typecheck` -- tsc --noEmit
+- `build` -- pnpm build
+- `token-verify` -- verify-tokens.sh
+- `lighthouse` -- Lighthouse audit per page
+
+---
+
+## Customization Examples
+
+### Relax the visual diff threshold for early prototyping
+
+```json
+"visualDiff": {
+  "threshold": 0.05
+},
+"iterationLoop": {
+  "diffPassThreshold": 0.05,
+  "maxVisualIterations": 3
+}
+```
+
+### Disable non-blocking checks for faster iteration
+
+```json
+"darkMode": { "enabled": false },
+"storybook": { "autoGenerate": false },
+"responsiveVerification": { "enabled": false }
+```
+
+### Enable mutation testing
+
+```json
+"qualityGate": {
+  "mutationScore": {
+    "enabled": true,
+    "threshold": 80,
+    "blocking": true
+  }
+}
+```
+
+### Lower bundle size limits for mobile-first apps
+
+```json
+"bundleSize": {
+  "maxSizeKb": 100,
+  "warnSizeKb": 75
+}
+```

--- a/docs/onboarding/quickstart.md
+++ b/docs/onboarding/quickstart.md
@@ -1,0 +1,218 @@
+# Quickstart Guide
+
+Get from zero to a running project in under 10 minutes.
+
+---
+
+## 1. Clone and Install
+
+```bash
+# Clone the repository
+git clone https://github.com/PMDevSolutions/Aurelius.git
+cd Aurelius
+
+# Install pnpm if you do not have it
+corepack enable
+corepack prepare pnpm@latest --activate
+```
+
+> **Important:** This project uses pnpm exclusively. npm and yarn are not supported.
+
+---
+
+## 2. Create a New Project
+
+The `setup-project.sh` script scaffolds a new application with all framework configs pre-applied:
+
+```bash
+# Next.js project
+./scripts/setup-project.sh my-app --next
+
+# Vite project (lighter, faster)
+./scripts/setup-project.sh my-app --vite
+```
+
+This creates an `app/` directory (or the name you specified) with:
+- TypeScript strict mode
+- Tailwind CSS with design token structure
+- ESLint + Prettier configured
+- Vitest + React Testing Library ready
+- Playwright for E2E (run `./scripts/setup-playwright.sh` once for browser engines)
+
+```bash
+cd my-app
+pnpm install
+pnpm dev
+```
+
+Your dev server is now running at `http://localhost:3000` (Next.js) or `http://localhost:5173` (Vite).
+
+---
+
+## 3. Verify Your Setup
+
+Run the code quality scripts to confirm everything works:
+
+```bash
+# From your app directory
+./scripts/lint-and-format.sh       # ESLint + Prettier
+./scripts/check-types.sh           # TypeScript type checking
+./scripts/run-tests.sh             # Vitest with coverage
+./scripts/check-accessibility.sh   # WCAG 2.1 AA linting
+```
+
+All four should pass on a fresh project.
+
+---
+
+## 4. Build from a Design (Autonomous Pipelines)
+
+Aurelius can convert designs into fully working, tested applications with a single command. Three pipelines are available:
+
+### From Figma
+
+```
+/build-from-figma https://figma.com/file/abc123/My-Design
+```
+
+This runs a 10-phase autonomous pipeline:
+1. **Token Sync** -- checks for drift if a lockfile exists
+2. **Intake** -- discovers Figma structure, asks 3-5 questions, produces `build-spec.json`
+3. **Token Lock** -- extracts design tokens into `design-tokens.lock.json`
+4. **TDD (Hard Gate)** -- writes failing tests before any component code
+5. **Build** -- generates React components that pass the tests
+6. **Visual Diff** -- pixel-level comparison loop (up to 5 iterations, 2% threshold)
+7. **E2E Tests** -- Playwright tests tailored to your app type
+8. **Cross-Browser** -- Firefox/WebKit screenshot verification
+9. **Quality Gate** -- coverage, TypeScript, build, tokens, Lighthouse
+10. **Report** -- final build report with diff images and docs
+
+### From Canva
+
+```
+/build-from-canva https://www.canva.com/design/DAGxyz.../My-Design
+```
+
+Same pipeline with AI-powered token inference (Canva does not expose raw tokens like Figma).
+
+### From a Screenshot or URL
+
+```
+/build-from-screenshot https://example.com
+/build-from-screenshot ./designs/homepage.png ./designs/about.png
+```
+
+Captures the page, analyzes it with vision, and builds a working app. Supports all output targets: React, Vue 3, Svelte, and React Native.
+
+---
+
+## 5. Using Claude Code Agents
+
+When you work with Claude Code in this repository, **53 specialized agents** are available automatically. You do not need to invoke them manually -- Claude Code selects the right agent based on your task.
+
+### Examples
+
+```
+User: "Build a hero component with a CTA button"
+Claude: [Uses frontend-developer agent]
+
+User: "Write tests for the auth hook"
+Claude: [Uses test-writer-fixer agent]
+
+User: "Check this page for accessibility issues"
+Claude: [Uses accessibility-auditor agent]
+
+User: "Optimize the bundle size"
+Claude: [Uses bundle-analyzer agent]
+
+User: "Create a PR for this feature"
+Claude: [Uses commit-commands plugin: /commit-push-pr]
+```
+
+See the full [Architecture Overview](architecture.md) for the complete agent catalog.
+
+---
+
+## 6. Using Skills (Slash Commands)
+
+Skills are invoked with slash commands. Key ones:
+
+| Command | What It Does |
+|---------|-------------|
+| `/build-from-figma <URL>` | Full Figma-to-app pipeline |
+| `/build-from-canva <URL>` | Full Canva-to-app pipeline |
+| `/build-from-screenshot <URL>` | Full screenshot-to-app pipeline |
+| `/commit` | Structured git commit |
+| `/commit-push-pr` | Commit, push, and create PR |
+| `/lint` | Run ESLint + Prettier |
+| `/test` | Run test suite |
+
+---
+
+## 7. Code Quality Checklist
+
+Before submitting any pull request, run these checks:
+
+```bash
+./scripts/lint-and-format.sh          # Linting and formatting
+./scripts/run-tests.sh                # Unit and component tests
+./scripts/check-types.sh              # TypeScript strict mode
+./scripts/check-accessibility.sh      # WCAG 2.1 AA
+./scripts/verify-tokens.sh            # No hardcoded design values
+./scripts/check-security.sh           # Dependency vulnerabilities
+```
+
+All must pass. The [Contributing Guide](../../CONTRIBUTING.md) has details on branch naming, commit conventions, and the PR process.
+
+---
+
+## 8. Multi-Framework Output
+
+By default, pipelines generate React components. To target a different framework, set `outputTarget` in `build-spec.json`:
+
+| Target | Value | What You Get |
+|--------|-------|-------------|
+| React | `"react"` | React + TypeScript + Tailwind (Next.js or Vite) |
+| Vue 3 | `"vue"` | Vue 3 + `<script setup>` + TypeScript + Tailwind |
+| Svelte | `"svelte"` | SvelteKit + TypeScript + Tailwind |
+| React Native | `"react-native"` | Expo + TypeScript + NativeWind |
+
+The pipeline auto-detects the framework from `package.json` if `outputTarget` is not specified.
+
+---
+
+## 9. Project Structure at a Glance
+
+```
+Aurelius/
+├── .claude/
+│   ├── agents/              # 53 specialized agents
+│   ├── skills/              # 19 development skills
+│   ├── commands/            # Slash commands (/build-from-figma, /lint, /test)
+│   ├── hooks/               # Hook scripts (8 automated hooks)
+│   ├── pipeline.config.json # All pipeline thresholds and behavior
+│   ├── CUSTOM-AGENTS-GUIDE.md
+│   ├── PLUGINS-REFERENCE.md
+│   └── settings.json        # Claude Code settings and hook config
+├── scripts/                 # 30+ automation scripts
+├── templates/               # Starter configs (Next.js, Vite, Vue, Svelte, Expo)
+├── docs/                    # Documentation
+│   ├── onboarding/          # You are here
+│   ├── figma-to-react/
+│   ├── canva-to-react/
+│   ├── screenshot-to-app/
+│   ├── multi-framework/
+│   ├── react-development/
+│   └── regression-testing/
+├── CLAUDE.md                # Claude Code project instructions
+├── CONTRIBUTING.md          # Contribution guide
+└── README.md                # Project overview
+```
+
+---
+
+## Next Steps
+
+- Read the [Architecture Overview](architecture.md) to understand how agents, skills, and pipelines connect
+- Explore [Pipeline Configuration](pipeline-configuration.md) if you need to customize thresholds
+- Check the [Troubleshooting FAQ](troubleshooting.md) if you run into issues

--- a/docs/onboarding/troubleshooting.md
+++ b/docs/onboarding/troubleshooting.md
@@ -1,0 +1,368 @@
+# Troubleshooting FAQ
+
+Common issues, error messages, and solutions when working with the Aurelius framework.
+
+---
+
+## Setup Issues
+
+### pnpm is not recognized / command not found
+
+**Problem:** Running `pnpm install` returns "command not found".
+
+**Solution:**
+```bash
+corepack enable
+corepack prepare pnpm@latest --activate
+```
+
+If `corepack` is not available, install pnpm directly:
+```bash
+npm install -g pnpm
+```
+
+> Aurelius requires pnpm. npm and yarn are not supported.
+
+---
+
+### setup-project.sh fails with permission denied
+
+**Problem:** `./scripts/setup-project.sh` returns "Permission denied".
+
+**Solution:**
+```bash
+chmod +x scripts/*.sh
+./scripts/setup-project.sh my-app --vite
+```
+
+On Windows with Git Bash, scripts should work without `chmod`. If they do not, run:
+```bash
+bash scripts/setup-project.sh my-app --vite
+```
+
+---
+
+### Playwright browsers not installed
+
+**Problem:** Cross-browser tests fail with "browser not found" or "executable doesn't exist".
+
+**Solution:**
+```bash
+./scripts/setup-playwright.sh
+```
+
+This installs Chromium, Firefox, and WebKit browser engines. It only needs to be run once per machine.
+
+---
+
+## Pipeline Issues
+
+### Phase 3 (TDD) blocks Phase 4 -- "test files do not exist"
+
+**Problem:** The pipeline will not proceed to the component build phase.
+
+**Cause:** TDD enforcement is a hard gate. Phase 4 cannot start until Phase 3 has created test files for every component listed in `build-spec.json`.
+
+**Solution:** This is by design. The pipeline writes tests first (RED phase), then builds components to pass them (GREEN phase). If Phase 3 is failing:
+
+1. Check `build-spec.json` for the list of expected components
+2. Verify the `tdd-from-figma` skill has write access to the test directory
+3. Check for TypeScript errors in generated test files
+
+To see the TDD configuration:
+```bash
+cat .claude/pipeline.config.json | grep -A 10 '"tdd"'
+```
+
+---
+
+### Visual diff keeps failing / never reaches 2% threshold
+
+**Problem:** Phase 5 iterates 5 times and still reports pixel mismatch above threshold.
+
+**Solutions:**
+
+1. **Check if the design has complex gradients or shadows.** These are hard to match pixel-perfectly. Consider relaxing the threshold temporarily:
+   ```json
+   "iterationLoop": { "diffPassThreshold": 0.05 }
+   ```
+
+2. **Font rendering differences.** System fonts render differently across OS. Use web fonts (Google Fonts, Fontsource) to ensure consistency.
+
+3. **Anti-aliasing issues.** Ensure `antialiasing: true` is set in `visualDiff` config.
+
+4. **View the diff images.** Check `.claude/visual-qa/diffs/` for highlighted differences. The magenta overlay shows exactly which pixels differ.
+
+5. **Sub-pixel classification.** If diffs are mostly sub-pixel (cosmetic), the pipeline should classify them as such. Check the diff report for "sub-pixel" vs "structural" categorization.
+
+---
+
+### Token verification fails -- "hardcoded values detected"
+
+**Problem:** `verify-tokens.sh` reports hardcoded colors, spacing, or font values in component files.
+
+**Cause:** Components are using raw values (like `#3B82F6` or `16px`) instead of design tokens from the lockfile.
+
+**Solution:**
+
+1. Check which values are flagged:
+   ```bash
+   ./scripts/verify-tokens.sh
+   ```
+
+2. Replace hardcoded values with Tailwind utility classes that reference your design tokens:
+   ```tsx
+   // Bad: hardcoded color
+   <div className="bg-[#3B82F6]">
+
+   // Good: design token via Tailwind config
+   <div className="bg-primary-500">
+   ```
+
+3. If the lockfile is outdated, re-sync:
+   ```bash
+   ./scripts/sync-tokens.sh
+   ```
+
+---
+
+### Lighthouse scores below threshold
+
+**Problem:** Quality gate fails because Lighthouse scores are under the configured minimums.
+
+**Default thresholds:** Performance 80, Accessibility 90, Best Practices 90, SEO 90.
+
+**Common fixes:**
+
+| Issue | Category | Fix |
+|-------|----------|-----|
+| Large bundle | Performance | Code split with `React.lazy()`, analyze with `./scripts/check-bundle-size.sh` |
+| Missing alt text | Accessibility | Add `alt` attributes to all `<img>` elements |
+| No meta description | SEO | Add `<meta name="description">` to `<head>` |
+| HTTP resources on HTTPS | Best Practices | Use HTTPS for all external resources |
+| Missing viewport meta | Accessibility | Add `<meta name="viewport" content="width=device-width, initial-scale=1">` |
+| Render-blocking CSS | Performance | Inline critical CSS or use `media` attributes |
+
+Run a standalone audit to see detailed recommendations:
+```bash
+# Using Chrome DevTools MCP or Lighthouse CLI
+npx lighthouse http://localhost:3000 --output html --output-path ./lighthouse-report.html
+```
+
+---
+
+### Cross-browser screenshots differ too much
+
+**Problem:** Firefox or WebKit screenshots diverge from Chromium beyond the 3% threshold.
+
+**Common causes:**
+- Font rendering (Firefox renders text differently from Chromium)
+- Scrollbar styling (WebKit does not support `::-webkit-scrollbar` in Firefox)
+- CSS feature gaps (check with `./scripts/audit-cross-browser-css.sh`)
+
+**Solutions:**
+1. Use the CSS reset template: `templates/shared/css/cross-browser-reset.css`
+2. Audit CSS compatibility: `./scripts/audit-cross-browser-css.sh --json`
+3. Relax the threshold if differences are cosmetic:
+   ```json
+   "e2e": { "crossBrowserDiffThreshold": 0.05 }
+   ```
+
+---
+
+### Pipeline hangs or seems stuck
+
+**Problem:** A pipeline phase appears to hang without progress.
+
+**Possible causes:**
+
+1. **Dev server not starting.** Check if port 3000/5173 is already in use:
+   ```bash
+   lsof -i :3000  # macOS/Linux
+   netstat -ano | findstr :3000  # Windows
+   ```
+
+2. **Playwright waiting for element.** E2E tests have a 30-second timeout. If the page is slow to render, increase:
+   ```json
+   "e2e": { "timeoutMs": 60000 }
+   ```
+
+3. **Network idle wait.** Screenshot capture waits for network idle. If the page makes ongoing requests (WebSocket, polling), increase or disable:
+   ```json
+   "screenshotCapture": { "waitForNetworkIdle": false, "waitAfterLoadMs": 3000 }
+   ```
+
+---
+
+## Agent Issues
+
+### Claude Code does not use the expected agent
+
+**Problem:** You ask Claude to do something, but it does not invoke the specialized agent you expected.
+
+**Explanation:** Agents are selected based on task context, not explicit invocation. Claude Code reads your prompt and chooses the most relevant agent.
+
+**Tips:**
+- Be specific about what you want: "Build a React hero component" triggers `frontend-developer`
+- Mention the domain: "Write Playwright E2E tests" triggers `test-writer-fixer` or `api-tester`
+- For design conversion, provide the URL: "Convert this Figma design" triggers `figma-react-converter`
+
+---
+
+### Agent runs out of context
+
+**Problem:** A complex agent task fails partway through because the context window fills up.
+
+**Solutions:**
+- Break the task into smaller steps
+- Use the `/session-handoff` skill to create a handoff document for the next session
+- For large codebases, point the agent to specific files rather than asking it to explore broadly
+
+---
+
+## MCP Server Issues
+
+### Figma MCP cannot connect
+
+**Problem:** Figma pipeline fails with "MCP connection failed" or "server not available".
+
+**Solution:**
+
+1. Ensure the Figma desktop app is running (required for Figma Desktop MCP)
+2. Check that port 3845 is not blocked:
+   ```bash
+   curl http://localhost:3845/health
+   ```
+3. The remote Figma MCP is a fallback -- ensure your Figma access token is configured in `.claude/settings.json`
+
+---
+
+### Canva MCP returns empty results
+
+**Problem:** Canva pipeline intake phase finds no designs.
+
+**Solutions:**
+1. Verify the Canva URL is a direct design link (format: `canva.com/design/DAG.../`)
+2. Check that the Canva AI Connector MCP server is configured and running
+3. The Canva pipeline retries up to 3 times with exponential backoff -- check logs for retry messages
+
+---
+
+## Design Token Issues
+
+### Token drift detected by sync-tokens.sh
+
+**Problem:** `sync-tokens.sh` reports that design tokens in source code have drifted from the lockfile.
+
+**What this means:** Someone (or an agent) modified token values in the Tailwind config or CSS variables without updating the lockfile, or the Figma design changed.
+
+**Solution:**
+```bash
+# See what drifted
+./scripts/sync-tokens.sh --dry-run --json
+
+# To update the lockfile from current source (if source is correct)
+# Re-run the design-token-lock skill with the Figma URL
+
+# To update source from lockfile (if lockfile is correct)
+# The pipeline will auto-correct during the next build phase
+```
+
+---
+
+### build-spec.json is missing or invalid
+
+**Problem:** Pipeline phases fail because `build-spec.json` does not exist or has unexpected structure.
+
+**Cause:** The intake phase (Phase 1) either did not run or failed silently.
+
+**Solution:**
+1. Re-run the intake skill manually:
+   ```
+   # For Figma
+   /build-from-figma <URL>
+
+   # The intake phase will re-discover the design
+   ```
+
+2. If manually creating `build-spec.json`, ensure it has these required fields:
+   - `appType`: `"web-app"`, `"chrome-extension"`, `"pwa"`, or `"react-native"`
+   - `outputTarget`: `"react"`, `"vue"`, `"svelte"`, or `"react-native"`
+   - `components`: array of component definitions
+   - `e2eFlows`: array of test flow definitions
+
+---
+
+## Script Issues
+
+### Scripts fail on Windows
+
+**Problem:** Shell scripts do not run on Windows outside of Git Bash or WSL.
+
+**Solution:** Use Git Bash (included with Git for Windows) or WSL. All scripts are written for bash and use Unix-style paths.
+
+```bash
+# In Git Bash or WSL
+./scripts/lint-and-format.sh
+```
+
+---
+
+### check-dead-code.sh reports false positives
+
+**Problem:** `check-dead-code.sh` flags files or exports that are actually used.
+
+**Cause:** knip (the dead code detector) may not detect dynamic imports or framework-specific patterns.
+
+**Solution:** The config excludes test, story, and E2E files by default. If you have additional patterns to exclude, update `pipeline.config.json`:
+```json
+"deadCode": {
+  "ignorePatterns": [
+    "**/*.stories.*",
+    "**/*.test.*",
+    "**/*.e2e.*",
+    "**/your-pattern.*"
+  ]
+}
+```
+
+---
+
+## Git and PR Issues
+
+### Pre-commit hook blocks commit with token violations
+
+**Problem:** The pre-commit token guard hook prevents your commit.
+
+**Cause:** Your changes contain hardcoded design values that should use tokens from the lockfile.
+
+**Solution:**
+1. Run `./scripts/verify-tokens.sh` to see the violations
+2. Replace hardcoded values with Tailwind token classes
+3. Commit again
+
+> Do not bypass hooks with `--no-verify`. The token guard exists to prevent design inconsistencies.
+
+---
+
+### Bundle size guard warns on commit
+
+**Problem:** The bundle size hook warns that the build output exceeds `maxSizeKb`.
+
+**Solution:**
+1. Check your bundle: `./scripts/check-bundle-size.sh`
+2. Look for large dependencies: `pnpm why <package-name>`
+3. Consider code splitting, tree-shaking, or replacing heavy libraries
+4. The default limit is 200KB. Adjust in `pipeline.config.json` if your app legitimately needs more:
+   ```json
+   "bundleSize": { "maxSizeKb": 300 }
+   ```
+
+---
+
+## Still Stuck?
+
+1. **Check existing docs:** The [Architecture Overview](architecture.md) and [Pipeline Configuration](pipeline-configuration.md) may have the answer
+2. **Search past conversations:** Use the `episodic-memory` plugin to search previous Claude Code sessions for similar issues
+3. **Open an issue:** [GitHub Issues](https://github.com/PMDevSolutions/Aurelius/issues) for bugs and feature requests
+4. **Start a discussion:** [GitHub Discussions](https://github.com/PMDevSolutions/Aurelius/discussions) for questions and ideas


### PR DESCRIPTION
## Summary
- Adds comprehensive developer onboarding documentation suite under `docs/onboarding/` with 5 new files: index page, quickstart guide, architecture overview (all 53 agents, 19 skills, 3 pipelines), pipeline configuration reference, and troubleshooting FAQ
- Updates `README.md` documentation index with onboarding links and corrects agent count (48 → 53) and skill count (17 → 19)

## Test plan
- [ ] Verify all internal links between onboarding docs resolve correctly
- [ ] Verify links from `README.md` documentation index to new onboarding docs
- [ ] Confirm agent count (53) and skill count (19) match actual `.claude/agents/` and `.claude/skills/` contents
- [ ] Review pipeline configuration doc against `.claude/pipeline.config.json` for accuracy

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)