### PR TITLE
docs: add Patreon supporter voting process documentation

### DIFF
--- a/docs/community/patreon-voting.md
+++ b/docs/community/patreon-voting.md
@@ -1,0 +1,166 @@
+# Patreon Supporter Voting Process
+
+This document outlines the roadmap voting process for Patreon supporters of the Aurelius project.
+
+## Overview
+
+Patreon supporters have direct influence over Aurelius development priorities through GitHub Discussions voting. Feature proposals are submitted, discussed, and voted on in the **Roadmap** category.
+
+## Getting Started
+
+### 1. Link Your Accounts
+
+To participate in voting, you need to link your Patreon and GitHub accounts:
+
+1. Go to your [Patreon settings](https://www.patreon.com/settings/apps)
+2. Connect your GitHub account
+3. Join the [Aurelius Patreon community](https://www.patreon.com/aurelius) (if not already a member)
+4. Visit [Aurelius Discussions](https://github.com/PMDevSolutions/Aurelius/discussions)
+
+### 2. Access the Roadmap Category
+
+Navigate to the **Roadmap** category in GitHub Discussions to see all active feature proposals.
+
+**Direct link:** [Aurelius Roadmap Discussions](https://github.com/PMDevSolutions/Aurelius/discussions/categories/roadmap)
+
+## How to Vote
+
+### Casting Your Vote
+
+1. **Browse** the Roadmap category for feature proposals
+2. **Read** the full proposal and existing comments
+3. **React** with a thumbs up (:+1:) on proposals you support
+4. **Comment** to provide additional context or suggestions
+
+### Voting Rules
+
+- **One reaction per proposal** - Your thumbs up counts as your vote
+- **Change your vote anytime** - Remove or add reactions as priorities change
+- **No duplicate proposals** - Search before creating new proposals
+- **Stay constructive** - Focus on feature value and use cases
+
+## Voting Power by Tier
+
+Your Patreon tier determines your voting influence:
+
+| Tier | Monthly | Voting Power | Additional Benefits |
+|------|---------|--------------|---------------------|
+| **Supporter** | $5 | 1x weight | Roadmap access, Discord role |
+| **Contributor** | $15 | 2x weight | Early beta access, monthly updates |
+| **Champion** | $30 | 3x weight | Implementation input, priority support |
+
+Voting weights are applied when calculating feature priority scores.
+
+## Proposing Features
+
+### Before You Propose
+
+1. **Search existing proposals** - Your idea may already exist
+2. **Check the roadmap** - It might be planned or in progress
+3. **Review guidelines** - Ensure your proposal fits project scope
+
+### Creating a Proposal
+
+Create a new discussion in the Roadmap category with:
+
+**Title:** Clear, concise feature name (e.g., "Add dark mode support")
+
+**Body template:**
+```markdown
+## Summary
+[One paragraph describing the feature]
+
+## Problem
+[What problem does this solve?]
+
+## Proposed Solution
+[How should it work?]
+
+## Use Cases
+- [Use case 1]
+- [Use case 2]
+
+## Alternatives Considered
+[Other approaches you considered]
+
+## Additional Context
+[Screenshots, mockups, links, etc.]
+```
+
+## Priority Calculation
+
+Features are prioritized using a weighted scoring system:
+
+```
+Priority Score = (Supporter Votes × 1) + (Contributor Votes × 2) + (Champion Votes × 3)
+                 + Technical Feasibility Score + Alignment Score
+```
+
+### Factors Considered
+
+1. **Weighted vote count** - Sum of tier-weighted votes
+2. **Technical feasibility** - Effort and complexity assessment
+3. **Project alignment** - Fit with Aurelius vision and architecture
+4. **Community discussion** - Quality of feedback and refinements
+5. **Dependencies** - Required groundwork and prerequisites
+
+## Voting Timeline
+
+### Monthly Cycle
+
+| Week | Activity |
+|------|----------|
+| Week 1-2 | Proposal submission and discussion |
+| Week 3 | Voting period (final votes cast) |
+| Week 4 | Priority review and sprint planning |
+
+### Updates
+
+- **Weekly:** New proposals announced in Discord
+- **Monthly:** Top-voted features announced, roadmap updated
+- **Quarterly:** Major milestone review and retrospective
+
+## Transparency
+
+### Public Metrics
+
+We publish voting results and decision rationale:
+
+- Vote counts (anonymized by tier)
+- Priority scores and rankings
+- Selection decisions with explanations
+- Implementation progress updates
+
+### Feedback Loop
+
+After features ship:
+1. Announcement in Discussions
+2. Feedback thread created
+3. Retrospective shared with voters
+
+## FAQ
+
+### Can I vote without being a Patreon supporter?
+Community members can participate in discussions, but voting power is reserved for Patreon supporters.
+
+### How soon are voted features implemented?
+Top-voted features are added to upcoming sprints. Implementation timing depends on complexity and current workload.
+
+### Can I change my vote?
+Yes, add or remove reactions anytime before voting closes.
+
+### What happens to rejected proposals?
+Proposals may be revisited in future cycles. We provide feedback on why proposals weren't selected.
+
+### How do I verify my tier is recognized?
+Your GitHub username appears in our Patreon supporter list. Contact us if there are discrepancies.
+
+## Contact
+
+- **Discussion questions:** Comment in the relevant thread
+- **Voting issues:** Open a Discussion in Q&A category
+- **Patreon issues:** Email support@aurelius.dev
+
+---
+
+*Last updated: 2026-03-30*


### PR DESCRIPTION
Document the roadmap voting process for Patreon supporters including:
- Account linking and access instructions
- Voting mechanics and tier-based voting weights
- Feature proposal guidelines and template
- Priority calculation methodology
- Monthly voting cycle timeline

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Chore (dependency updates, CI changes, refactoring)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Tests pass (`pnpm vitest run`)
- [ ] Linting passes (`pnpm eslint .`)
- [ ] Types check (`pnpm tsc --noEmit`)
- [ ] Documentation updated (if applicable)
