### PR TITLE
docs: add standardized GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,19 +1,51 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! Please fill out the form below.
+        Thanks for taking the time to report a bug! Please fill out the form below with as much detail as possible.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is the impact of this bug?
+      options:
+        - Critical (System crash, data loss, security issue)
+        - High (Major feature broken, no workaround)
+        - Medium (Feature partially broken, workaround exists)
+        - Low (Minor issue, cosmetic, edge case)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the framework is affected?
+      options:
+        - Agents (Custom Claude Code agents)
+        - Skills (Slash command skills)
+        - Scripts (Development automation scripts)
+        - Pipeline - Figma-to-React
+        - Pipeline - Canva-to-React
+        - Pipeline - Screenshot-to-App
+        - Templates (Starter configs)
+        - MCP Integration (Figma, Playwright, Chrome DevTools)
+        - Documentation
+        - Other
+    validations:
+      required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Bug Description
       description: A clear and concise description of the bug.
-      placeholder: Describe the bug...
+      placeholder: Describe what went wrong...
     validations:
       required: true
 
@@ -21,11 +53,17 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to Reproduce
-      description: Steps to reproduce the behavior.
+      description: Detailed steps to reproduce the behavior.
+      value: |
+        1.
+        2.
+        3.
+        4.
       placeholder: |
-        1. Run '...'
-        2. Open '...'
-        3. See error
+        1. Run command '...'
+        2. Open file '...'
+        3. Execute '...'
+        4. Observe error...
     validations:
       required: true
 
@@ -34,7 +72,7 @@ body:
     attributes:
       label: Expected Behavior
       description: What you expected to happen.
-      placeholder: Describe the expected behavior...
+      placeholder: I expected...
     validations:
       required: true
 
@@ -42,16 +80,27 @@ body:
     id: actual-behavior
     attributes:
       label: Actual Behavior
-      description: What actually happened.
-      placeholder: Describe what actually happened...
+      description: What actually happened instead.
+      placeholder: Instead, what happened was...
     validations:
       required: true
+
+  - type: textarea
+    id: error-logs
+    attributes:
+      label: Error Logs / Stack Trace
+      description: Paste any relevant error messages, logs, or stack traces.
+      render: shell
+      placeholder: |
+        Paste error output here...
+    validations:
+      required: false
 
   - type: input
     id: os
     attributes:
       label: Operating System
-      description: e.g. Windows 11, macOS 14.3, Ubuntu 22.04
+      description: e.g., Windows 11, macOS 14.3, Ubuntu 22.04
       placeholder: Windows 11
     validations:
       required: true
@@ -74,11 +123,42 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: claude-code-version
+    attributes:
+      label: Claude Code Version (if applicable)
+      description: Output of `claude --version`
+      placeholder: claude-code v1.0.0
+    validations:
+      required: false
+
   - type: textarea
     id: screenshots
     attributes:
-      label: Screenshots
-      description: If applicable, add screenshots to help explain the problem. Drag and drop images here.
-      placeholder: Drag and drop screenshots here...
+      label: Screenshots / Recordings
+      description: If applicable, add screenshots or screen recordings to help explain the problem.
+      placeholder: Drag and drop images or videos here...
     validations:
       required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, configuration files, or related information.
+      placeholder: Additional details...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched existing issues to ensure this bug hasn't been reported already.
+          required: true
+        - label: I have provided all the requested information above.
+          required: true
+        - label: I am using the latest version of the framework.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,11 @@ contact_links:
   - name: Questions & Discussions
     url: https://github.com/PMDevSolutions/Aurelius/discussions
     about: Ask questions and discuss ideas in GitHub Discussions
+
+  - name: Documentation
+    url: https://github.com/PMDevSolutions/Aurelius/tree/main/docs
+    about: Check the documentation before opening an issue
+
+  - name: Security Vulnerabilities
+    url: https://github.com/PMDevSolutions/Aurelius/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,17 +1,50 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["enhancement", "triage"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a feature! Please fill out the form below.
+        Thanks for suggesting a feature! Please fill out the form below to help us understand your request.
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      description: What type of feature is this?
+      options:
+        - New Feature (Something that doesn't exist yet)
+        - Enhancement (Improve existing functionality)
+        - Integration (Add support for new tool/service)
+        - Developer Experience (Improve workflow/usability)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target-component
+    attributes:
+      label: Target Component
+      description: Which part of the framework would this feature affect?
+      options:
+        - Agents (Custom Claude Code agents)
+        - Skills (Slash command skills)
+        - Scripts (Development automation scripts)
+        - Pipeline - Figma-to-React
+        - Pipeline - Canva-to-React
+        - Pipeline - Screenshot-to-App
+        - Templates (Starter configs)
+        - MCP Integration (Figma, Playwright, Chrome DevTools)
+        - Documentation
+        - Multiple Components
+        - New Component
+    validations:
+      required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Feature Description
       description: A clear and concise description of the feature you'd like.
       placeholder: Describe the feature...
     validations:
@@ -21,8 +54,11 @@ body:
     id: use-case
     attributes:
       label: Use Case
-      description: Describe the problem this feature would solve or the use case it enables.
-      placeholder: I want this feature because...
+      description: Describe the problem this feature would solve or the use case it enables. Help us understand the "why" behind this request.
+      placeholder: |
+        As a [type of user], I want to [do something] so that [benefit/value].
+
+        Currently, I have to... which is problematic because...
     validations:
       required: true
 
@@ -30,8 +66,12 @@ body:
     id: proposed-solution
     attributes:
       label: Proposed Solution
-      description: Describe how you'd like this feature to work.
-      placeholder: The feature should...
+      description: Describe how you'd like this feature to work. Be as specific as possible.
+      placeholder: |
+        The feature should:
+        1. ...
+        2. ...
+        3. ...
     validations:
       required: true
 
@@ -39,7 +79,63 @@ body:
     id: alternatives
     attributes:
       label: Alternatives Considered
-      description: Describe any alternative solutions or workarounds you've considered.
+      description: Describe any alternative solutions, workarounds, or approaches you've considered.
       placeholder: I've also considered...
     validations:
       required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope / Effort Estimate
+      description: How big of a change do you think this would be? (Your best guess)
+      options:
+        - Small (Minor change, few files)
+        - Medium (Moderate change, multiple files/components)
+        - Large (Significant change, new system/major refactor)
+        - Unknown (Not sure)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What would need to be true for this feature to be considered complete?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, examples, or references about the feature request.
+      placeholder: Additional context, links, or screenshots...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution Interest
+      description: Would you be interested in contributing to this feature?
+      options:
+        - label: I would be willing to submit a PR for this feature
+          required: false
+        - label: I would be willing to help test this feature
+          required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched existing issues and discussions to ensure this hasn't been requested already.
+          required: true
+        - label: I have read the project documentation and this feature is not already available.
+          required: true

--- a/.github/ISSUE_TEMPLATE/pipeline_issue.yml
+++ b/.github/ISSUE_TEMPLATE/pipeline_issue.yml
@@ -1,0 +1,233 @@
+name: Pipeline Issue
+description: Report an issue with the design-to-code conversion pipelines
+title: "[Pipeline]: "
+labels: ["pipeline", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report issues specific to the design-to-code conversion pipelines (Figma, Canva, or Screenshot/URL).
+
+  - type: dropdown
+    id: pipeline-type
+    attributes:
+      label: Pipeline Type
+      description: Which pipeline are you using?
+      options:
+        - Figma-to-React (/build-from-figma)
+        - Canva-to-React (/build-from-canva)
+        - Screenshot-to-App (/build-from-screenshot)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: output-target
+    attributes:
+      label: Output Target Framework
+      description: What framework are you generating code for?
+      options:
+        - React (Next.js)
+        - React (Vite)
+        - React (Remix)
+        - Vue 3
+        - Svelte / SvelteKit
+        - React Native (Expo)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pipeline-phase
+    attributes:
+      label: Pipeline Phase
+      description: At which phase did the issue occur?
+      options:
+        - "Phase 0: Token Sync (sync-tokens.sh)"
+        - "Phase 1: Intake (figma-intake / canva-intake / screenshot-intake)"
+        - "Phase 2: Token Lock (design-token-lock / canva-token-inference)"
+        - "Phase 3: TDD (tdd-from-figma)"
+        - "Phase 4: Build (component generation)"
+        - "Phase 4.5: Storybook Generation"
+        - "Phase 5: Visual Diff (pixelmatch)"
+        - "Phase 5.5: Dark Mode Verification"
+        - "Phase 6: E2E Tests"
+        - "Phase 7: Cross-Browser Testing"
+        - "Phase 7.5: Visual Regression"
+        - "Phase 8: Quality Gate"
+        - "Phase 8.5: Responsive Verification"
+        - "Phase 9: Report Generation"
+        - "Unknown / Multiple Phases"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: app-type
+    attributes:
+      label: App Type
+      description: What type of application are you building?
+      options:
+        - Web App (Standard)
+        - Chrome Extension
+        - PWA (Progressive Web App)
+        - React Native Mobile App
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: A clear and concise description of the issue.
+      placeholder: Describe what went wrong during the pipeline execution...
+    validations:
+      required: true
+
+  - type: input
+    id: design-url
+    attributes:
+      label: Design Source URL
+      description: The Figma/Canva URL or indicate if using screenshots.
+      placeholder: https://figma.com/file/... or "Local screenshots"
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the issue.
+      value: |
+        1. Run command: `/build-from-figma <URL>`
+        2.
+        3.
+        4.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected the pipeline to do.
+      placeholder: I expected the pipeline to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+      placeholder: Instead, the pipeline...
+    validations:
+      required: true
+
+  - type: textarea
+    id: build-spec
+    attributes:
+      label: build-spec.json (if available)
+      description: Paste the contents of your build-spec.json file if it was generated.
+      render: json
+      placeholder: |
+        {
+          "appType": "...",
+          "outputTarget": "...",
+          ...
+        }
+    validations:
+      required: false
+
+  - type: textarea
+    id: token-lockfile
+    attributes:
+      label: design-tokens.lock.json Issues
+      description: If the issue is token-related, describe any problems with the design token lockfile.
+      placeholder: |
+        Describe any issues with:
+        - Missing tokens
+        - Incorrect values
+        - Token drift detected
+    validations:
+      required: false
+
+  - type: textarea
+    id: visual-diff
+    attributes:
+      label: Visual Diff Details
+      description: If the issue is related to visual QA, describe the visual differences or provide diff images.
+      placeholder: |
+        - Diff percentage: X%
+        - Affected regions: ...
+        - Number of iterations attempted: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: error-logs
+    attributes:
+      label: Error Logs / Pipeline Output
+      description: Paste relevant error messages or pipeline output.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: e.g., Windows 11, macOS 14.3, Ubuntu 22.04
+      placeholder: Windows 11
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: Output of `node --version`
+      placeholder: v20.11.0
+    validations:
+      required: true
+
+  - type: input
+    id: claude-code-version
+    attributes:
+      label: Claude Code Version
+      description: Output of `claude --version`
+      placeholder: claude-code v1.0.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: mcp-status
+    attributes:
+      label: MCP Server Status
+      description: Are all required MCP servers connected? (Figma, Playwright, Chrome DevTools)
+      placeholder: |
+        - Figma MCP: Connected / Not connected
+        - Playwright MCP: Connected / Not connected
+        - Chrome DevTools MCP: Connected / Not connected
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Visual Evidence
+      description: Attach screenshots of design, generated output, visual diffs, etc.
+      placeholder: Drag and drop images here...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched existing issues to ensure this hasn't been reported already.
+          required: true
+        - label: I have verified that required MCP servers are properly configured.
+          required: true
+        - label: I have included the relevant build-spec.json or error output.
+          required: false


### PR DESCRIPTION
- Enhanced bug report template with severity levels, component dropdowns, structured reproduction steps, and error log sections
- Enhanced feature request template with feature type, scope estimates, acceptance criteria, and contribution interest options
- Added new pipeline issue template for Figma/Canva/Screenshot conversion issues with phase tracking, build-spec input, and MCP status fields
- Updated config.yml with documentation and security advisory links

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Chore (dependency updates, CI changes, refactoring)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Tests pass (`pnpm vitest run`)
- [ ] Linting passes (`pnpm eslint .`)
- [ ] Types check (`pnpm tsc --noEmit`)
- [ ] Documentation updated (if applicable)
