### PR TITLE
Fix documentation count inconsistencies across project files

### DIFF
--- a/.claude/AGENT-NAMING-GUIDE.md
+++ b/.claude/AGENT-NAMING-GUIDE.md
@@ -1,10 +1,10 @@
 # Agent Naming Guide
 
-**Last Updated:** 2026-03-18
+**Last Updated:** 2026-04-02
 
 ## Naming Convention
 
-All 48 agents use unique, hyphenated names (e.g., `frontend-developer`, `figma-react-converter`). There are no naming conflicts in the current agent set.
+All 53 agents use unique, hyphenated names (e.g., `frontend-developer`, `figma-react-converter`). There are no naming conflicts in the current agent set.
 
 Agent files live in `.claude/agents/` as `<agent-name>.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,5 +534,7 @@ node scripts/metrics-dashboard.js summary  # Quick metrics summary
 
 ---
 
-**Last Updated:** 2026-03-30
-**Architecture:** 53 agents, 19 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 25 scripts, 8 hooks
+**Last Updated:** 2026-04-02
+**Architecture:** 53 agents, 19 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 29 scripts, 8 hooks
+
+> **Keeping counts in sync:** When adding or removing agents, skills, scripts, or hooks, update all count references across the project. Search for the old count number in `*.md` files to find all references: `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/onboarding/`, `docs/react-development/`, and `.claude/AGENT-NAMING-GUIDE.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Branch names should be lowercase, use hyphens as separators, and be descriptive 
 
 ## Claude Code Agents
 
-Aurelius includes 51 specialized Claude Code agents and 18 skills that automate significant portions of the development workflow — from design-to-code conversion to testing, accessibility, and deployment.
+Aurelius includes 53 specialized Claude Code agents and 19 skills that automate significant portions of the development workflow — from design-to-code conversion to testing, accessibility, and deployment.
 
 If you have Claude Code installed, these agents and skills are available to you automatically when working in this repository. They can assist with component development, test writing, visual QA, and much more.
 

--- a/docs/react-development/README.md
+++ b/docs/react-development/README.md
@@ -203,8 +203,8 @@ pnpm build
 
 - `docs/figma-to-react/README.md` -- Figma-to-React conversion pipeline
 - `docs/canva-to-react/README.md` -- Canva-to-React conversion pipeline
-- `.claude/skills/README.md` -- Skills catalog (17 skills)
-- `.claude/CUSTOM-AGENTS-GUIDE.md` -- Agent catalog (48 agents)
+- `.claude/skills/README.md` -- Skills catalog (19 skills)
+- `.claude/CUSTOM-AGENTS-GUIDE.md` -- Agent catalog (53 agents)
 - `.claude/PLUGINS-REFERENCE.md` -- Plugin reference
 - `scripts/README.md` -- Scripts reference
 - `templates/README.md` -- Template configs reference


### PR DESCRIPTION
## Summary
- Audited actual counts: **53 agents**, **19 skills**, **29 scripts**
- Fixed stale counts in `CONTRIBUTING.md` (51→53 agents, 18→19 skills), `.claude/AGENT-NAMING-GUIDE.md` (48→53 agents), `docs/react-development/README.md` (17→19 skills, 48→53 agents), and `CLAUDE.md` (25→29 scripts)
- Added "Keeping counts in sync" reminder note to `CLAUDE.md` footer to prevent future drift

## Test plan
- [ ] Verify no remaining stale counts: `grep -rn "51 agents\|48 agents\|18 skills\|17 skills\|25 scripts" *.md .claude/*.md docs/**/*.md`
- [ ] Confirm actual file counts match documented numbers

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)