### PR TITLE
feat: /export-design-system command for publishable component libraries

### DIFF
--- a/.claude/commands/export-design-system.md
+++ b/.claude/commands/export-design-system.md
@@ -1,0 +1,95 @@
+---
+allowed-tools: Skill, Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+---
+
+# /export-design-system — Export Components as a Publishable Library
+
+Export the generated components and design tokens from this project as a publishable pnpm workspace with a framework-agnostic token package and a framework-specific component library (Vite library mode for web, `tsc` for React Native).
+
+## Input
+
+`$ARGUMENTS` — optional flags forwarded to the export script. Common patterns:
+
+- _(none)_ — default: detect framework from `build-spec.json`, scope from `package.json`, output to `dist/design-system/`.
+- `--scope @acme` — override the npm scope.
+- `--output packages/design-system` — pick a different output location.
+- `--framework vue` — override detected framework.
+- `--dry-run` — preview without writing.
+- `--force` — overwrite existing output dir.
+- `--json` — machine-readable summary.
+
+## Preconditions
+
+This command requires:
+1. **`design-tokens.lock.json`** in `src/styles/` or project root (produced by the `design-token-lock` skill or any of the `/build-from-*` pipelines).
+2. **At least one component** in `src/components/` (or pass `--components-dir`).
+3. **Framework discoverable** via `build-spec.json` (`outputTarget`), `package.json` deps, or `--framework` flag.
+
+If any precondition is missing, stop and tell the user which one and how to fix it (run a build pipeline, pass a flag, etc.) — do not attempt to repair the project automatically.
+
+## Steps
+
+### 1. Sanity check inputs
+
+Run a quick detection pass before invoking the skill:
+
+```bash
+test -f src/styles/design-tokens.lock.json || test -f design-tokens.lock.json
+ls src/components 2>/dev/null | head -1
+```
+
+If lockfile is missing, surface the error and recommend running `/build-from-figma`, `/build-from-canva`, or `/build-from-screenshot` first.
+
+### 2. Confirm scope and output (only if user did not pass them)
+
+If the user did not provide `--scope` or `--output`, ask them once via `AskUserQuestion`:
+
+- **Scope:** "What npm scope should the packages publish under? (e.g. `@acme`)" — default to the value detected from the project's `package.json`, or `@my-app`.
+- **Output dir:** offer `dist/design-system` as the default and let them confirm or override.
+
+Skip the prompt if `$ARGUMENTS` already includes either flag.
+
+### 3. Invoke the skill
+
+Use the `export-design-system` skill with the resolved arguments.
+
+The skill calls the underlying script:
+
+```bash
+./scripts/export-design-system.sh [resolved flags]
+```
+
+If the user passed `--dry-run` or `--json`, forward them as-is.
+
+### 4. Report
+
+After the script returns, report to the user:
+
+- Framework and scope used.
+- Package names generated (`<scope>/design-tokens` and `<scope>/<framework>-components`).
+- Number of components exported.
+- Output directory path.
+- Next steps:
+  ```bash
+  cd <output>
+  pnpm install
+  pnpm build
+  ```
+- Note any framework-specific caveats (especially: React Native uses `tsc`, not Vite).
+
+If the script exited non-zero, surface the exit code and the stderr message verbatim — do not attempt remediation without confirming with the user.
+
+## Failure modes
+
+- **Lockfile missing (exit 2):** Tell the user to run a build pipeline first.
+- **Framework undetectable (exit 2):** Ask the user which framework to target via `--framework`.
+- **Output directory exists (exit 1):** Ask the user whether to `--force` overwrite or pick a new path.
+- **Unsupported framework (exit 3):** Only `react`, `vue`, `svelte`, `react-native` are supported.
+
+## Out of scope
+
+This command does NOT:
+- Run `pnpm install` or `pnpm build` in the generated workspace.
+- Publish to npm.
+- Modify files inside the source project.
+- Re-extract tokens from Figma (use `/build-from-figma` or the `design-token-lock` skill for that).

--- a/.claude/skills/export-design-system/SKILL.md
+++ b/.claude/skills/export-design-system/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: export-design-system
+description: Exports generated components + design-tokens.lock.json as a publishable pnpm workspace. Generates a framework-agnostic tokens package and a framework-specific component library (React/Vue/Svelte via Vite library mode, React Native via tsc). Includes Tailwind preset, ThemeProvider, Changesets versioning, and a properly configured exports map. Keywords: design system export, component library, npm package, vite lib mode, tailwind preset, changesets, monorepo, publishable
+---
+
+# Export Design System — Publishable Component Library Generator
+
+## Purpose
+
+Take generated components and a `design-tokens.lock.json` and emit a versioned, publishable pnpm workspace:
+
+- **`@scope/design-tokens`** — framework-agnostic. Ships CSS custom properties, a typed token export, a Tailwind preset, and a JSON snapshot of the lockfile. Anyone (web app, RN app, Storybook, docs site) can consume it.
+- **`@scope/<framework>-components`** — framework-specific. Ships compiled components, a `ThemeProvider` + `useTheme`, and proper peer dependencies. React/Vue/Svelte build with **Vite library mode**; React Native uses `tsc` (Vite is not part of the RN runtime).
+
+The tokens package is the bridge — every component package depends on it via `workspace:^`, so updating tokens cascades through every framework target.
+
+## When to Use
+
+- After a successful `/build-from-figma`, `/build-from-canva`, or `/build-from-screenshot` run, when you want to extract the result as a reusable library rather than ship the full app.
+- When a design system needs to be published to a private npm registry or installed across multiple consumer apps.
+- When migrating from a single-app codebase to a shared component package.
+
+This skill is **not** part of the autonomous build pipeline — it is invoked on demand via `/export-design-system`.
+
+## Inputs
+
+- **Required:**
+  - `design-tokens.lock.json` (auto-detected at `src/styles/design-tokens.lock.json` or `design-tokens.lock.json`)
+  - At least one component file under `src/components/` (or override with `--components-dir`)
+- **Optional:**
+  - `build-spec.json` (auto-detected at `.claude/plans/build-spec.json` or `build-spec.json`) — read for `outputTarget`. If absent, framework is inferred from `package.json` deps or supplied via `--framework`.
+  - `--scope <name>` — npm scope. Defaults to the existing `package.json` scope, or `@my-app`.
+  - `--output <dir>` — where to write the workspace. Default: `dist/design-system/`.
+
+## Outputs
+
+A complete pnpm workspace at `<output>/`:
+
+```
+<output>/
+├── package.json                # workspace root with pnpm scripts and changesets
+├── pnpm-workspace.yaml
+├── tsconfig.base.json
+├── .changeset/                 # versioning config
+├── .npmrc, .gitignore
+├── README.md
+└── packages/
+    ├── design-tokens/
+    │   ├── package.json        # exports map for ".", "./tokens.css", "./tailwind-preset"
+    │   ├── tsconfig.json
+    │   ├── vite.config.ts      # vite lib mode
+    │   ├── README.md
+    │   └── src/
+    │       ├── index.ts        # barrel
+    │       ├── tokens.ts       # typed token export
+    │       ├── tokens.css      # CSS custom properties
+    │       ├── tokens.json     # raw lockfile snapshot
+    │       └── tailwind-preset.ts
+    └── <framework>-components/
+        ├── package.json        # peerDeps: react|vue|svelte; depends on design-tokens via workspace:^
+        ├── tsconfig.json
+        ├── vite.config.ts      # vite lib mode (or omitted for react-native)
+        ├── README.md
+        └── src/
+            ├── index.ts        # barrel re-exports ThemeProvider + every component
+            ├── components/     # copied from project, tests/stories/types stripped
+            └── theme/
+                └── ThemeProvider.{tsx,ts,svelte}
+```
+
+## Process
+
+### Step 1: Detection
+
+Auto-detect inputs in this order:
+- `lockfile`: `src/styles/design-tokens.lock.json` → `design-tokens.lock.json`
+- `buildSpec`: `.claude/plans/build-spec.json` → `build-spec.json`
+- `componentsDir`: `src/components` → `components` → `src/lib/components`
+- `framework`: `buildSpec.outputTarget` → `package.json` deps fallback
+
+Refuse with a clear error if lockfile is missing or framework cannot be determined.
+
+### Step 2: Workspace scaffolding
+
+Write the workspace root files: `package.json`, `pnpm-workspace.yaml`, `tsconfig.base.json`, `.changeset/`, `.npmrc`, `.gitignore`, `README.md`.
+
+`tsconfig.base.json` enables `strict`, `isolatedModules`, `bundler` resolution. Both packages extend it.
+
+### Step 3: Tokens package
+
+Generate `packages/design-tokens/`:
+- `tokens.ts` — typed `tokens` constant from the lockfile (`as const` for inference).
+- `tokens.css` — `:root { --color-...: ...; --space-...; --radius-...; }` derived from lockfile.
+- `tokens.json` — verbatim copy of the lockfile.
+- `tailwind-preset.ts` — Tailwind preset that consumers extend; pulls colors, spacing, radii, fontFamily from the lockfile.
+- `vite.config.ts` — Vite lib mode with `vite-plugin-dts` for declaration rollup. Two entries: `index` and `tailwind-preset`.
+- `package.json` — declares `exports` map for `.`, `./tokens.css`, `./tailwind-preset`, `./tokens.json`. `sideEffects: ["./dist/tokens.css"]`.
+
+### Step 4: Components package
+
+Generate `packages/<framework>-components/`:
+- Copy components from the source project into `src/components/`, **excluding** `*.test.*`, `*.spec.*`, `*.stories.*`, and `*.d.ts` files (filter by extension matching the framework: `.tsx`/`.ts` for React/RN, `.vue`/`.ts` for Vue, `.svelte`/`.ts` for Svelte).
+- Generate `theme/ThemeProvider.{tsx,ts,svelte}` with framework-idiomatic context API and a `useTheme` hook.
+- Generate `src/index.ts` barrel that re-exports `ThemeProvider`, `useTheme`, and every detected component.
+- Generate `vite.config.ts` (Vite lib mode) for React/Vue/Svelte. Externalize the framework runtime (`react`, `react-dom`, `react/jsx-runtime`; `vue`; `svelte`, `svelte/internal`).
+- Generate `package.json` with `peerDependencies` for the framework, `dependencies: { @scope/design-tokens: workspace:^ }`, proper `exports` map, `sideEffects` including CSS.
+- For `react-native`: skip `vite.config.ts`, use `tsc -p tsconfig.json` for build, set `peerDependencies` to react + react-native. Add a clear note in the README.
+
+### Step 5: Versioning
+
+If `--no-changesets` is not set, scaffold `.changeset/config.json` with sensible defaults (commit: false, access: public, baseBranch: main). Workspace root scripts: `pnpm changeset`, `pnpm version`, `pnpm release`.
+
+### Step 6: Report
+
+Emit a summary (text or JSON via `--json`):
+- Framework + scope + output path
+- Package names
+- Component count and files copied
+- Total files written
+- Next steps: `pnpm install && pnpm build`
+
+## Invocation
+
+Direct script (the slash command wraps this):
+
+```bash
+node scripts/export-design-system.js [options]
+
+# or via wrapper:
+./scripts/export-design-system.sh [options]
+```
+
+Common flag combinations:
+
+```bash
+# Use detected outputTarget, default scope, default output dir
+./scripts/export-design-system.sh
+
+# Override scope and pick custom output
+./scripts/export-design-system.sh --scope @acme --output packages/
+
+# Dry-run to preview
+./scripts/export-design-system.sh --dry-run
+
+# Force overwrite of existing output
+./scripts/export-design-system.sh --force
+
+# Skip Storybook scaffolding and Changesets
+./scripts/export-design-system.sh --no-storybook --no-changesets
+
+# Machine-readable
+./scripts/export-design-system.sh --json
+```
+
+## Error Recovery
+
+- **No `design-tokens.lock.json`** → exit 2. Run the relevant build pipeline (`/build-from-figma`, etc.) first to produce a lockfile.
+- **Cannot detect framework** → exit 2. Pass `--framework <react|vue|svelte|react-native>` or set `outputTarget` in `build-spec.json`.
+- **Output directory exists** → exit 1. Either pass `--force` to overwrite, or pick a different `--output`.
+- **Unsupported framework** → exit 3. Only `react`, `vue`, `svelte`, `react-native` are supported.
+
+## Constraints & Gotchas
+
+- **Vite lib mode does not apply to React Native.** RN apps run on Metro and have their own JSX/runtime concerns. The script falls back to `tsc -p tsconfig.json` for RN. Documented in the generated README.
+- **Tokens are a snapshot.** Re-running this skill regenerates the token package from the current lockfile. Bump versions via Changesets when the lockfile changes.
+- **Peer dependencies are conservative.** React peer is `^18.0.0 || ^19.0.0`. Vue is `^3.4.0`. Svelte is `^5.0.0`. Adjust per-package after generation if your consumers require narrower ranges.
+- **The script does not run `pnpm install` or `pnpm build`.** It only writes files. The user runs install/build to verify the workspace.
+- **Component file filtering is conservative.** `*.test.*`, `*.spec.*`, `*.stories.*`, `*.d.ts` are excluded. Co-located CSS modules and helper files with matching framework extensions ARE included.
+
+## Reference
+
+- Script: `scripts/export-design-system.js`
+- Wrapper: `scripts/export-design-system.sh`
+- Slash command: `/export-design-system`
+- Inputs: `design-tokens.lock.json` (from `design-token-lock` skill), `build-spec.json` (from `figma-intake`/`canva-intake`/`screenshot-intake` skills)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,9 @@ node scripts/visual-diff.js --batch <actual-dir> <expected-dir> [--output-dir di
 # Run visual regression tests against baselines
 ./scripts/regression-test.sh [url] [--update-baselines] [--json]
 
+# Export generated components as a publishable design-system workspace
+./scripts/export-design-system.sh [--scope @org] [--output dir] [--framework <react|vue|svelte|react-native>] [--dry-run] [--json]
+
 # Incremental build with caching and profiling
 ./scripts/incremental-build.sh [phase|all] [--force] [--parallel]
 
@@ -215,7 +218,7 @@ Agents are invoked automatically based on task context.
 
 ---
 
-### Skills (19 Total)
+### Skills (20 Total)
 
 | Skill | Purpose | Triggers |
 |-------|---------|----------|
@@ -238,6 +241,7 @@ Agents are invoked automatically based on task context.
 | animation-motion | Framer Motion, CSS transitions, reduced-motion a11y | "animation", "framer motion", "transition" |
 | seo-metadata | Next.js Metadata API, JSON-LD, OG images, sitemaps | "SEO", "metadata", "open graph" |
 | parallel-orchestration | Concurrent phase runner for pipeline parallelization | Invoked by pipeline commands after Phase 3 |
+| export-design-system | Exports components + tokens as a publishable pnpm workspace (Vite lib mode for web, tsc for RN) | Invoked by `/export-design-system` |
 
 **Full catalog:** `.claude/skills/README.md`
 
@@ -492,6 +496,7 @@ Claude: [Uses test-writer-fixer agent]
 /build-from-figma <URL>       # Full autonomous Figma pipeline
 /build-from-canva <URL>       # Full autonomous Canva pipeline
 /build-from-screenshot <URL or paths>  # Full autonomous screenshot pipeline
+/export-design-system [flags] # Export components + tokens as publishable pnpm workspace
 ```
 
 **Git Workflows (via commit-commands):**
@@ -528,6 +533,7 @@ gh issue create               # Create issue
 ./scripts/audit-cross-browser-css.sh   # Cross-browser CSS audit
 ./scripts/capture-baselines.sh          # Capture regression baselines
 ./scripts/regression-test.sh            # Visual regression testing
+./scripts/export-design-system.sh       # Export components + tokens as pnpm workspace
 ```
 
 **Build Performance & Caching:**
@@ -545,6 +551,6 @@ node scripts/metrics-dashboard.js summary  # Quick metrics summary
 ---
 
 **Last Updated:** 2026-04-14
-**Architecture:** 53 agents, 19 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 29 scripts, 8 hooks
+**Architecture:** 53 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 31 scripts, 8 hooks
 
 > **Keeping counts in sync:** When adding or removing agents, skills, scripts, or hooks, update all count references across the project. Search for the old count number in `*.md` files to find all references: `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/onboarding/`, `docs/react-development/`, and `.claude/AGENT-NAMING-GUIDE.md`.

--- a/scripts/export-design-system.js
+++ b/scripts/export-design-system.js
@@ -1,0 +1,990 @@
+#!/usr/bin/env node
+/**
+ * export-design-system.js
+ *
+ * Export generated components as a publishable design-system workspace.
+ *
+ * Reads:
+ *   - build-spec.json   (for outputTarget: react|vue|svelte|react-native)
+ *   - design-tokens.lock.json (single source of truth for tokens)
+ *   - src/components/  (or configured dir) — components to package
+ *
+ * Writes a pnpm workspace to <output> containing:
+ *   - packages/design-tokens/      framework-agnostic token package
+ *   - packages/<fw>-components/    framework-specific component library
+ *
+ * Web targets (react/vue/svelte) build with Vite library mode.
+ * react-native builds with `tsc` only (Vite is incompatible with the RN runtime).
+ *
+ * Exit codes: 0 ok, 1 generic error, 2 missing inputs, 3 unsupported framework.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ---------- CLI ----------
+
+function parseArgs(argv) {
+  const args = {
+    output: 'dist/design-system',
+    scope: null,
+    componentsDir: null,
+    lockfile: null,
+    buildSpec: null,
+    framework: null,
+    storybook: true,
+    changesets: true,
+    dryRun: false,
+    json: false,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case '--output': args.output = next(); break;
+      case '--scope': args.scope = next(); break;
+      case '--components-dir': args.componentsDir = next(); break;
+      case '--lockfile': args.lockfile = next(); break;
+      case '--build-spec': args.buildSpec = next(); break;
+      case '--framework': args.framework = next(); break;
+      case '--no-storybook': args.storybook = false; break;
+      case '--no-changesets': args.changesets = false; break;
+      case '--dry-run': args.dryRun = true; break;
+      case '--json': args.json = true; break;
+      case '--force': args.force = true; break;
+      case '-h': case '--help': printHelp(); process.exit(0);
+      default:
+        if (a.startsWith('--')) die(`Unknown flag: ${a}`, 1);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: export-design-system.js [options]
+
+Generate a publishable pnpm workspace from generated components + design tokens.
+
+Options:
+  --output <dir>           Output directory (default: dist/design-system)
+  --scope <name>           NPM scope (e.g. @my-org). Inferred from package.json if omitted.
+  --components-dir <dir>   Source components dir (default: src/components)
+  --lockfile <path>        design-tokens.lock.json (auto-detected if omitted)
+  --build-spec <path>      build-spec.json (auto-detected if omitted)
+  --framework <name>       Override outputTarget: react|vue|svelte|react-native
+  --no-storybook           Skip Storybook docs scaffolding
+  --no-changesets          Skip Changesets versioning setup
+  --force                  Overwrite existing output directory
+  --dry-run                Report what would be written; do not write
+  --json                   Emit a JSON summary
+  -h, --help               Show this help
+`);
+}
+
+// ---------- helpers ----------
+
+function die(msg, code = 1) {
+  process.stderr.write(`✗ ${msg}\n`);
+  process.exit(code);
+}
+
+function readJsonIfExists(p) {
+  if (!p || !fs.existsSync(p)) return null;
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (e) {
+    die(`Failed to parse JSON at ${p}: ${e.message}`, 1);
+  }
+}
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function writeFile(target, content, opts) {
+  if (opts.dryRun) {
+    opts._written.push(target);
+    return;
+  }
+  ensureDir(path.dirname(target));
+  fs.writeFileSync(target, content);
+  opts._written.push(target);
+}
+
+function copyDirRecursive(src, dest, filterFn, opts) {
+  if (!fs.existsSync(src)) return 0;
+  let count = 0;
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const sp = path.join(src, entry.name);
+    const dp = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      count += copyDirRecursive(sp, dp, filterFn, opts);
+    } else if (entry.isFile()) {
+      if (filterFn && !filterFn(sp)) continue;
+      if (!opts.dryRun) {
+        ensureDir(path.dirname(dp));
+        fs.copyFileSync(sp, dp);
+      }
+      opts._copied.push(dp);
+      count++;
+    }
+  }
+  return count;
+}
+
+// ---------- detection ----------
+
+function autoDetect(args) {
+  const candidates = {
+    lockfile: ['src/styles/design-tokens.lock.json', 'design-tokens.lock.json'],
+    buildSpec: ['.claude/plans/build-spec.json', 'build-spec.json'],
+    componentsDir: ['src/components', 'components', 'src/lib/components'],
+  };
+  for (const k of Object.keys(candidates)) {
+    if (args[k]) continue;
+    for (const c of candidates[k]) {
+      if (fs.existsSync(c)) { args[k] = c; break; }
+    }
+  }
+}
+
+function detectFramework(buildSpec) {
+  if (buildSpec && buildSpec.outputTarget) return buildSpec.outputTarget;
+  // Fallback: infer from package.json deps
+  const pkg = readJsonIfExists('package.json') || {};
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  if (deps['react-native'] || deps['expo']) return 'react-native';
+  if (deps['vue'] || deps['@vue/runtime-core']) return 'vue';
+  if (deps['svelte'] || deps['@sveltejs/kit']) return 'svelte';
+  if (deps['react'] || deps['next']) return 'react';
+  return null;
+}
+
+function defaultScope() {
+  const pkg = readJsonIfExists('package.json') || {};
+  if (typeof pkg.name === 'string' && pkg.name.startsWith('@')) {
+    const slash = pkg.name.indexOf('/');
+    if (slash > 0) return pkg.name.slice(0, slash);
+  }
+  return '@my-app';
+}
+
+// ---------- per-framework descriptors ----------
+
+const FRAMEWORKS = {
+  react: {
+    label: 'React',
+    componentExt: ['.tsx', '.ts', '.jsx', '.js'],
+    pkgSuffix: 'react-components',
+    bundler: 'vite',
+    peers: { react: '^18.0.0 || ^19.0.0', 'react-dom': '^18.0.0 || ^19.0.0' },
+    devDeps: {
+      '@types/react': '^19.0.0',
+      '@types/react-dom': '^19.0.0',
+      '@vitejs/plugin-react': '^4.3.0',
+      'vite-plugin-dts': '^4.0.0',
+    },
+  },
+  vue: {
+    label: 'Vue 3',
+    componentExt: ['.vue', '.ts', '.tsx'],
+    pkgSuffix: 'vue-components',
+    bundler: 'vite',
+    peers: { vue: '^3.4.0' },
+    devDeps: {
+      '@vitejs/plugin-vue': '^5.2.0',
+      'vue-tsc': '^2.2.0',
+      'vite-plugin-dts': '^4.0.0',
+    },
+  },
+  svelte: {
+    label: 'Svelte 5',
+    componentExt: ['.svelte', '.ts'],
+    pkgSuffix: 'svelte-components',
+    bundler: 'vite',
+    peers: { svelte: '^5.0.0' },
+    devDeps: {
+      '@sveltejs/package': '^2.3.0',
+      '@sveltejs/vite-plugin-svelte': '^5.0.0',
+      'svelte-check': '^4.0.0',
+    },
+  },
+  'react-native': {
+    label: 'React Native',
+    componentExt: ['.tsx', '.ts'],
+    pkgSuffix: 'native-components',
+    bundler: 'tsc',
+    peers: { react: '^18.0.0', 'react-native': '>=0.74.0' },
+    devDeps: {
+      '@types/react': '^18.3.0',
+      typescript: '^5.7.0',
+    },
+  },
+};
+
+// ---------- file generators ----------
+
+function tokensCss(lock) {
+  const lines = [':root {'];
+  const colors = (lock && lock.colors) || {};
+  const flat = flattenObject(colors, 'color');
+  for (const [k, v] of Object.entries(flat)) {
+    if (typeof v === 'string') lines.push(`  --${k}: ${v};`);
+  }
+  const spacing = (lock && lock.spacing) || {};
+  for (const [k, v] of Object.entries(spacing)) {
+    if (typeof v === 'string' || typeof v === 'number') {
+      lines.push(`  --space-${k}: ${typeof v === 'number' ? `${v}px` : v};`);
+    }
+  }
+  const radii = (lock && lock.radii) || (lock && lock.borderRadius) || {};
+  for (const [k, v] of Object.entries(radii)) {
+    if (typeof v === 'string' || typeof v === 'number') {
+      lines.push(`  --radius-${k}: ${typeof v === 'number' ? `${v}px` : v};`);
+    }
+  }
+  lines.push('}');
+  return lines.join('\n') + '\n';
+}
+
+function flattenObject(obj, prefix) {
+  const out = {};
+  if (!obj || typeof obj !== 'object') return out;
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}-${k}` : k;
+    if (v && typeof v === 'object' && !Array.isArray(v) && !('value' in v)) {
+      Object.assign(out, flattenObject(v, key));
+    } else if (v && typeof v === 'object' && 'value' in v) {
+      out[key] = v.value;
+    } else {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+function tokensTs(lock) {
+  return `// Auto-generated from design-tokens.lock.json. Do not edit by hand.
+// Re-run \`/export-design-system\` to refresh.
+
+export const tokens = ${JSON.stringify(lock || {}, null, 2)} as const;
+
+export type Tokens = typeof tokens;
+
+export default tokens;
+`;
+}
+
+function tokensIndexTs() {
+  return `export { tokens, default } from './tokens';
+export type { Tokens } from './tokens';
+export { default as preset } from './tailwind-preset';
+`;
+}
+
+function tailwindPreset(lock) {
+  const colors = (lock && lock.colors) || {};
+  const spacing = (lock && lock.spacing) || {};
+  const radii = (lock && lock.radii) || (lock && lock.borderRadius) || {};
+  const fonts = (lock && lock.typography && lock.typography.fontFamily) || {};
+  return `// Auto-generated Tailwind preset from design-tokens.lock.json
+import type { Config } from 'tailwindcss';
+
+const preset: Partial<Config> = {
+  theme: {
+    extend: {
+      colors: ${JSON.stringify(colors, null, 6)},
+      spacing: ${JSON.stringify(spacing, null, 6)},
+      borderRadius: ${JSON.stringify(radii, null, 6)},
+      fontFamily: ${JSON.stringify(fonts, null, 6)},
+    },
+  },
+};
+
+export default preset;
+`;
+}
+
+function tokensPackageJson(scope, version) {
+  return JSON.stringify({
+    name: `${scope}/design-tokens`,
+    version,
+    description: 'Framework-agnostic design tokens (CSS variables, Tailwind preset, typed exports).',
+    type: 'module',
+    sideEffects: ['./dist/tokens.css'],
+    main: './dist/index.cjs',
+    module: './dist/index.js',
+    types: './dist/index.d.ts',
+    exports: {
+      '.': {
+        types: './dist/index.d.ts',
+        import: './dist/index.js',
+        require: './dist/index.cjs',
+      },
+      './tokens.css': './dist/tokens.css',
+      './tailwind-preset': {
+        types: './dist/tailwind-preset.d.ts',
+        import: './dist/tailwind-preset.js',
+        require: './dist/tailwind-preset.cjs',
+      },
+      './tokens.json': './dist/tokens.json',
+    },
+    files: ['dist'],
+    scripts: {
+      build: 'vite build && node scripts/postbuild.mjs',
+      dev: 'vite build --watch',
+      'type-check': 'tsc --noEmit',
+    },
+    devDependencies: {
+      typescript: '^5.7.0',
+      vite: '^6.0.0',
+      'vite-plugin-dts': '^4.0.0',
+      tailwindcss: '^4.0.0',
+    },
+    publishConfig: { access: 'public' },
+  }, null, 2) + '\n';
+}
+
+function tokensViteConfig() {
+  return `import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  plugins: [dts({ rollupTypes: true })],
+  build: {
+    lib: {
+      entry: {
+        index: resolve(__dirname, 'src/index.ts'),
+        'tailwind-preset': resolve(__dirname, 'src/tailwind-preset.ts'),
+      },
+      formats: ['es', 'cjs'],
+    },
+    sourcemap: true,
+  },
+});
+`;
+}
+
+function tokensPostbuildScript() {
+  return `// Cross-platform copy of static token files into dist/.
+// Vite library mode does not emit non-imported assets, so we copy them here.
+import { cpSync, existsSync, mkdirSync } from 'node:fs';
+
+if (!existsSync('dist')) mkdirSync('dist', { recursive: true });
+cpSync('src/tokens.css', 'dist/tokens.css');
+cpSync('src/tokens.json', 'dist/tokens.json');
+`;
+}
+
+function tokensTsconfig() {
+  return JSON.stringify({
+    extends: '../../tsconfig.base.json',
+    compilerOptions: {
+      outDir: 'dist',
+      declaration: true,
+      declarationDir: 'dist',
+      moduleResolution: 'bundler',
+    },
+    include: ['src/**/*'],
+  }, null, 2) + '\n';
+}
+
+// ---------- components package ----------
+
+function componentsPackageJson(scope, version, framework, fwDesc, hasTokens) {
+  const name = `${scope}/${fwDesc.pkgSuffix}`;
+  const tokenDep = hasTokens ? { [`${scope}/design-tokens`]: `workspace:^${version}` } : {};
+  const isVite = fwDesc.bundler === 'vite';
+
+  const exportsField = isVite
+    ? {
+        '.': {
+          types: './dist/index.d.ts',
+          import: './dist/index.js',
+          require: './dist/index.cjs',
+        },
+        './styles.css': './dist/styles.css',
+      }
+    : {
+        '.': {
+          types: './dist/index.d.ts',
+          import: './dist/index.js',
+        },
+      };
+
+  const scripts = isVite
+    ? {
+        build: 'vite build',
+        dev: 'vite build --watch',
+        'type-check': framework === 'vue' ? 'vue-tsc --noEmit' : 'tsc --noEmit',
+      }
+    : {
+        build: 'tsc -p tsconfig.json',
+        'type-check': 'tsc --noEmit',
+      };
+
+  return JSON.stringify({
+    name,
+    version,
+    description: `${fwDesc.label} component library generated from design tokens.`,
+    type: 'module',
+    sideEffects: isVite ? ['*.css'] : false,
+    main: isVite ? './dist/index.cjs' : './dist/index.js',
+    module: './dist/index.js',
+    types: './dist/index.d.ts',
+    exports: exportsField,
+    files: ['dist'],
+    scripts,
+    peerDependencies: fwDesc.peers,
+    dependencies: tokenDep,
+    devDependencies: {
+      ...fwDesc.devDeps,
+      typescript: '^5.7.0',
+      vite: isVite ? '^6.0.0' : undefined,
+    },
+    publishConfig: { access: 'public' },
+  }, (k, v) => v === undefined ? undefined : v, 2) + '\n';
+}
+
+function componentsViteConfig(framework) {
+  const plugin = {
+    react: { import: "import react from '@vitejs/plugin-react';", call: 'react()' },
+    vue: { import: "import vue from '@vitejs/plugin-vue';", call: 'vue()' },
+    svelte: {
+      import: "import { svelte } from '@sveltejs/vite-plugin-svelte';",
+      call: 'svelte()',
+    },
+  }[framework];
+
+  const externals = {
+    react: ['react', 'react-dom', 'react/jsx-runtime'],
+    vue: ['vue'],
+    svelte: ['svelte', 'svelte/internal'],
+  }[framework];
+
+  const dtsPlugin = framework === 'svelte'
+    ? '' // SvelteKit/svelte-package handles types separately; keep it simple here
+    : "import dts from 'vite-plugin-dts';\n";
+
+  const dtsCall = framework === 'svelte' ? '' : ', dts({ rollupTypes: true })';
+
+  return `import { defineConfig } from 'vite';
+${plugin.import}
+${dtsPlugin}import { resolve } from 'node:path';
+
+export default defineConfig({
+  plugins: [${plugin.call}${dtsCall}],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es', 'cjs'],
+      fileName: (format) => \`index.\${format === 'es' ? 'js' : 'cjs'}\`,
+    },
+    rollupOptions: {
+      external: ${JSON.stringify(externals)},
+    },
+    sourcemap: true,
+    cssCodeSplit: false,
+  },
+});
+`;
+}
+
+function componentsTsconfig(framework) {
+  const base = {
+    extends: '../../tsconfig.base.json',
+    compilerOptions: {
+      outDir: 'dist',
+      declaration: true,
+      declarationDir: 'dist',
+      moduleResolution: 'bundler',
+      jsx: framework === 'react' || framework === 'react-native' ? 'react-jsx' : undefined,
+    },
+    include: ['src/**/*'],
+  };
+  if (framework === 'react-native') {
+    base.compilerOptions.module = 'esnext';
+    base.compilerOptions.target = 'esnext';
+    base.compilerOptions.lib = ['esnext'];
+  }
+  return JSON.stringify(base, (k, v) => v === undefined ? undefined : v, 2) + '\n';
+}
+
+function themeProvider(framework, scope, hasTokens) {
+  const tokenImport = hasTokens
+    ? `import { tokens } from '${scope}/design-tokens';\n`
+    : '';
+  switch (framework) {
+    case 'react':
+      return `import { createContext, useContext, useMemo, type ReactNode } from 'react';
+${tokenImport}
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export interface ThemeProviderProps {
+  theme?: Theme;
+  children: ReactNode;
+}
+
+export function ThemeProvider({ theme = 'light', children }: ThemeProviderProps) {
+  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? 'tokens' : '{}'} }), [theme]);
+  return (
+    <ThemeContext.Provider value={value}>
+      <div data-theme={theme}>{children}</div>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside <ThemeProvider>');
+  return ctx;
+}
+`;
+    case 'vue':
+      return `import { defineComponent, provide, inject, computed, h, type InjectionKey, type PropType } from 'vue';
+${tokenImport}
+type Theme = 'light' | 'dark';
+
+interface ThemeContext {
+  theme: Theme;
+  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+}
+
+export const ThemeKey: InjectionKey<ThemeContext> = Symbol('theme');
+
+export const ThemeProvider = defineComponent({
+  name: 'ThemeProvider',
+  props: {
+    theme: { type: String as PropType<Theme>, default: 'light' },
+  },
+  setup(props, { slots }) {
+    const ctx = computed<ThemeContext>(() => ({ theme: props.theme, tokens: ${hasTokens ? 'tokens' : '{}'} }));
+    provide(ThemeKey, ctx.value);
+    return () => h('div', { 'data-theme': props.theme }, slots.default?.());
+  },
+});
+
+export function useTheme(): ThemeContext {
+  const ctx = inject(ThemeKey);
+  if (!ctx) throw new Error('useTheme must be used inside <ThemeProvider>');
+  return ctx;
+}
+`;
+    case 'svelte':
+      return `<script lang="ts" context="module">
+${tokenImport.trim()}
+  export type Theme = 'light' | 'dark';
+  export const themeContextKey = Symbol('theme');
+  export interface ThemeContext {
+    theme: Theme;
+    tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+  }
+</script>
+
+<script lang="ts">
+  import { setContext } from 'svelte';
+  export let theme: Theme = 'light';
+  $: setContext<ThemeContext>(themeContextKey, { theme, tokens: ${hasTokens ? 'tokens' : '{}'} });
+</script>
+
+<div data-theme={theme}>
+  <slot />
+</div>
+`;
+    case 'react-native':
+      return `import { createContext, useContext, useMemo, type ReactNode } from 'react';
+${tokenImport}
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export interface ThemeProviderProps {
+  theme?: Theme;
+  children: ReactNode;
+}
+
+export function ThemeProvider({ theme = 'light', children }: ThemeProviderProps) {
+  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? 'tokens' : '{}'} }), [theme]);
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside <ThemeProvider>');
+  return ctx;
+}
+`;
+    default:
+      return '';
+  }
+}
+
+function themeProviderFilename(framework) {
+  switch (framework) {
+    case 'react': return 'ThemeProvider.tsx';
+    case 'vue': return 'ThemeProvider.ts';
+    case 'svelte': return 'ThemeProvider.svelte';
+    case 'react-native': return 'ThemeProvider.tsx';
+    default: return 'ThemeProvider.ts';
+  }
+}
+
+function buildBarrelIndex(framework, componentNames) {
+  const themeFile = themeProviderFilename(framework).replace(/\.(tsx|ts|svelte)$/, '');
+  const themeImport = framework === 'svelte'
+    ? `export { default as ThemeProvider } from './theme/${themeFile}.svelte';\n`
+    : `export { ThemeProvider, useTheme } from './theme/${themeFile}';\n` +
+      `export type { ThemeProviderProps } from './theme/${themeFile}';\n`;
+
+  const componentExports = componentNames
+    .map(name => {
+      if (framework === 'svelte') return `export { default as ${name} } from './components/${name}.svelte';`;
+      if (framework === 'vue') return `export { default as ${name} } from './components/${name}.vue';`;
+      return `export * from './components/${name}';`;
+    })
+    .join('\n');
+
+  return `${themeImport}\n${componentExports}\n`;
+}
+
+// ---------- workspace-level files ----------
+
+function workspaceRootPackageJson(scope) {
+  return JSON.stringify({
+    name: `${scope.replace(/^@/, '')}-design-system`,
+    private: true,
+    version: '0.0.0',
+    scripts: {
+      build: 'pnpm -r --filter "./packages/**" run build',
+      'type-check': 'pnpm -r --filter "./packages/**" run type-check',
+      changeset: 'changeset',
+      version: 'changeset version',
+      release: 'pnpm build && changeset publish',
+    },
+    devDependencies: {
+      '@changesets/cli': '^2.27.0',
+      typescript: '^5.7.0',
+    },
+    packageManager: 'pnpm@9.0.0',
+  }, null, 2) + '\n';
+}
+
+function workspacePnpmYaml() {
+  return `packages:\n  - 'packages/*'\n`;
+}
+
+function workspaceTsconfigBase() {
+  return JSON.stringify({
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      isolatedModules: true,
+      resolveJsonModule: true,
+      forceConsistentCasingInFileNames: true,
+    },
+  }, null, 2) + '\n';
+}
+
+function changesetsConfig() {
+  return JSON.stringify({
+    $schema: 'https://unpkg.com/@changesets/config@3.0.0/schema.json',
+    changelog: '@changesets/cli/changelog',
+    commit: false,
+    fixed: [],
+    linked: [],
+    access: 'public',
+    baseBranch: 'main',
+    updateInternalDependencies: 'patch',
+    ignore: [],
+  }, null, 2) + '\n';
+}
+
+function workspaceReadme(ctx) {
+  const { scope, framework, fwDesc, componentCount, version } = ctx;
+  const rnNote = framework === 'react-native'
+    ? `\n> **React Native note:** components build with \`tsc\` (Vite is not used for the RN runtime).\n`
+    : '';
+  return `# ${scope.replace(/^@/, '')}-design-system
+
+Generated design-system workspace from your project's tokens and components.
+${rnNote}
+## Packages
+
+- \`${scope}/design-tokens\` — Framework-agnostic tokens (CSS variables, Tailwind preset, typed exports).
+- \`${scope}/${fwDesc.pkgSuffix}\` — ${fwDesc.label} component library (${componentCount} components).
+
+## Develop
+
+\`\`\`bash
+pnpm install
+pnpm build
+\`\`\`
+
+## Versioning & publishing
+
+This workspace uses [Changesets](https://github.com/changesets/changesets):
+
+\`\`\`bash
+pnpm changeset           # describe a change
+pnpm version             # bump versions per changeset
+pnpm release             # build + publish to npm
+\`\`\`
+
+Set the npm scope (\`${scope}\`) to one you control before publishing, or change it in each package.json.
+
+## Layout
+
+\`\`\`
+packages/
+  design-tokens/
+    src/
+      index.ts
+      tokens.ts            # typed token export
+      tokens.css           # CSS custom properties
+      tokens.json          # raw lockfile snapshot
+      tailwind-preset.ts   # Tailwind preset
+  ${fwDesc.pkgSuffix}/
+    src/
+      index.ts             # barrel export
+      components/          # generated components
+      theme/               # ThemeProvider + useTheme
+\`\`\`
+
+Initial version: \`${version}\`.
+`;
+}
+
+function componentsReadme(scope, fwDesc, componentNames) {
+  return `# ${scope}/${fwDesc.pkgSuffix}
+
+${fwDesc.label} component library.
+
+## Install
+
+\`\`\`bash
+pnpm add ${scope}/${fwDesc.pkgSuffix} ${scope}/design-tokens
+\`\`\`
+
+## Use
+
+\`\`\`ts
+import { ThemeProvider${componentNames.length ? ', ' + componentNames.slice(0, 3).join(', ') : ''} } from '${scope}/${fwDesc.pkgSuffix}';
+\`\`\`
+
+## Components
+
+${componentNames.length ? componentNames.map(n => `- \`${n}\``).join('\n') : '_No components detected._'}
+`;
+}
+
+function tokensReadme(scope) {
+  return `# ${scope}/design-tokens
+
+Framework-agnostic design tokens.
+
+## Install
+
+\`\`\`bash
+pnpm add ${scope}/design-tokens
+\`\`\`
+
+## Use
+
+\`\`\`ts
+import { tokens } from '${scope}/design-tokens';
+import preset from '${scope}/design-tokens/tailwind-preset';
+import '${scope}/design-tokens/tokens.css';
+\`\`\`
+
+## Files
+
+- \`tokens.ts\` — typed token object
+- \`tokens.css\` — CSS custom properties
+- \`tokens.json\` — raw lockfile snapshot
+- \`tailwind-preset\` — Tailwind preset to extend in your app
+`;
+}
+
+// ---------- main ----------
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  autoDetect(args);
+
+  const buildSpec = readJsonIfExists(args.buildSpec);
+  const lock = readJsonIfExists(args.lockfile);
+  const framework = args.framework || detectFramework(buildSpec);
+
+  if (!framework) {
+    die('Could not determine outputTarget. Pass --framework <react|vue|svelte|react-native> or ensure build-spec.json has outputTarget set.', 2);
+  }
+  const fwDesc = FRAMEWORKS[framework];
+  if (!fwDesc) {
+    die(`Unsupported framework: ${framework}. Supported: ${Object.keys(FRAMEWORKS).join(', ')}.`, 3);
+  }
+  if (!lock) {
+    die(`No design-tokens.lock.json found. Looked at: src/styles/design-tokens.lock.json, design-tokens.lock.json. Pass --lockfile <path> to override.`, 2);
+  }
+
+  const scope = args.scope || defaultScope();
+  const componentsDir = args.componentsDir || 'src/components';
+  const version = '0.0.1';
+
+  const outRoot = path.resolve(args.output);
+  if (fs.existsSync(outRoot) && !args.force && !args.dryRun) {
+    die(`Output directory already exists: ${outRoot}. Pass --force to overwrite or pick a different --output.`, 1);
+  }
+  if (fs.existsSync(outRoot) && args.force && !args.dryRun) {
+    fs.rmSync(outRoot, { recursive: true, force: true });
+  }
+
+  const opts = { dryRun: args.dryRun, _written: [], _copied: [] };
+  const tokensPkgDir = path.join(outRoot, 'packages', 'design-tokens');
+  const compPkgDir = path.join(outRoot, 'packages', fwDesc.pkgSuffix);
+
+  // ----- workspace root -----
+  writeFile(path.join(outRoot, 'package.json'), workspaceRootPackageJson(scope), opts);
+  writeFile(path.join(outRoot, 'pnpm-workspace.yaml'), workspacePnpmYaml(), opts);
+  writeFile(path.join(outRoot, 'tsconfig.base.json'), workspaceTsconfigBase(), opts);
+  writeFile(path.join(outRoot, '.npmrc'), 'auto-install-peers=true\nstrict-peer-dependencies=false\n', opts);
+  writeFile(path.join(outRoot, '.gitignore'), 'node_modules\ndist\n.turbo\n.changeset/.cache\n', opts);
+
+  if (args.changesets) {
+    writeFile(path.join(outRoot, '.changeset', 'config.json'), changesetsConfig(), opts);
+    writeFile(path.join(outRoot, '.changeset', 'README.md'),
+      '# Changesets\n\nRun `pnpm changeset` to describe a change before merging.\n', opts);
+  }
+
+  // ----- design-tokens package -----
+  writeFile(path.join(tokensPkgDir, 'package.json'), tokensPackageJson(scope, version), opts);
+  writeFile(path.join(tokensPkgDir, 'tsconfig.json'), tokensTsconfig(), opts);
+  writeFile(path.join(tokensPkgDir, 'vite.config.ts'), tokensViteConfig(), opts);
+  writeFile(path.join(tokensPkgDir, 'README.md'), tokensReadme(scope), opts);
+  writeFile(path.join(tokensPkgDir, 'src', 'tokens.ts'), tokensTs(lock), opts);
+  writeFile(path.join(tokensPkgDir, 'src', 'tokens.css'), tokensCss(lock), opts);
+  writeFile(path.join(tokensPkgDir, 'src', 'tokens.json'), JSON.stringify(lock, null, 2) + '\n', opts);
+  writeFile(path.join(tokensPkgDir, 'src', 'tailwind-preset.ts'), tailwindPreset(lock), opts);
+  writeFile(path.join(tokensPkgDir, 'src', 'index.ts'), tokensIndexTs(), opts);
+  writeFile(path.join(tokensPkgDir, 'scripts', 'postbuild.mjs'), tokensPostbuildScript(), opts);
+
+  // ----- components package -----
+  const componentNames = collectComponents(componentsDir, fwDesc.componentExt);
+  writeFile(path.join(compPkgDir, 'package.json'),
+    componentsPackageJson(scope, version, framework, fwDesc, true), opts);
+  writeFile(path.join(compPkgDir, 'tsconfig.json'), componentsTsconfig(framework), opts);
+  if (fwDesc.bundler === 'vite') {
+    writeFile(path.join(compPkgDir, 'vite.config.ts'), componentsViteConfig(framework), opts);
+  }
+  writeFile(path.join(compPkgDir, 'README.md'), componentsReadme(scope, fwDesc, componentNames), opts);
+  writeFile(
+    path.join(compPkgDir, 'src', 'theme', themeProviderFilename(framework)),
+    themeProvider(framework, scope, true), opts);
+  writeFile(path.join(compPkgDir, 'src', 'index.ts'), buildBarrelIndex(framework, componentNames), opts);
+
+  // Copy components
+  let copiedCount = 0;
+  if (fs.existsSync(componentsDir)) {
+    const filter = (filepath) => {
+      const ext = path.extname(filepath);
+      if (!fwDesc.componentExt.includes(ext)) return false;
+      // Skip tests, stories, type defs
+      if (/\.(test|spec|stories)\.[a-z]+$/.test(filepath)) return false;
+      if (filepath.endsWith('.d.ts')) return false;
+      return true;
+    };
+    copiedCount = copyDirRecursive(
+      componentsDir,
+      path.join(compPkgDir, 'src', 'components'),
+      filter,
+      opts
+    );
+  }
+
+  // ----- workspace README -----
+  writeFile(path.join(outRoot, 'README.md'), workspaceReadme({
+    scope, framework, fwDesc, componentCount: componentNames.length, version,
+  }), opts);
+
+  // ----- summary -----
+  const summary = {
+    status: 'ok',
+    framework,
+    scope,
+    output: outRoot,
+    packages: [
+      `${scope}/design-tokens`,
+      `${scope}/${fwDesc.pkgSuffix}`,
+    ],
+    components: componentNames,
+    componentsCopied: copiedCount,
+    filesWritten: opts._written.length,
+    dryRun: args.dryRun,
+    bundler: fwDesc.bundler,
+    nextSteps: [
+      `cd ${path.relative(process.cwd(), outRoot) || '.'}`,
+      'pnpm install',
+      'pnpm build',
+    ],
+  };
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
+  } else {
+    const tag = args.dryRun ? '[dry-run] ' : '';
+    process.stdout.write(`${tag}Exported ${fwDesc.label} design system to ${outRoot}\n`);
+    process.stdout.write(`  Packages: ${summary.packages.join(', ')}\n`);
+    process.stdout.write(`  Components: ${componentNames.length} (${copiedCount} files copied)\n`);
+    process.stdout.write(`  Files written: ${opts._written.length}\n`);
+    if (framework === 'react-native') {
+      process.stdout.write(`  Note: react-native uses \`tsc\` (Vite is not used for RN).\n`);
+    }
+    process.stdout.write(`\nNext: ${summary.nextSteps.join(' && ')}\n`);
+  }
+}
+
+function collectComponents(dir, exts) {
+  if (!fs.existsSync(dir)) return [];
+  const names = new Set();
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      // Look for an index file or same-named file inside
+      const sub = path.join(dir, entry.name);
+      const innerFiles = fs.readdirSync(sub);
+      const hasComponent = innerFiles.some(f => {
+        const ext = path.extname(f);
+        const base = path.basename(f, ext);
+        return exts.includes(ext)
+          && !/\.(test|spec|stories)$/.test(base)
+          && !f.endsWith('.d.ts');
+      });
+      if (hasComponent) names.add(entry.name);
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name);
+      const base = path.basename(entry.name, ext);
+      if (exts.includes(ext)
+        && !/\.(test|spec|stories)$/.test(base)
+        && base !== 'index'
+        && !entry.name.endsWith('.d.ts')) {
+        names.add(base);
+      }
+    }
+  }
+  return Array.from(names).sort();
+}
+
+main();

--- a/scripts/export-design-system.js
+++ b/scripts/export-design-system.js
@@ -18,14 +18,14 @@
  *
  * Exit codes: 0 ok, 1 generic error, 2 missing inputs, 3 unsupported framework.
  */
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from "node:fs";
+import path from "node:path";
 
 // ---------- CLI ----------
 
 function parseArgs(argv) {
   const args = {
-    output: 'dist/design-system',
+    output: "dist/design-system",
     scope: null,
     componentsDir: null,
     lockfile: null,
@@ -41,20 +41,46 @@ function parseArgs(argv) {
     const a = argv[i];
     const next = () => argv[++i];
     switch (a) {
-      case '--output': args.output = next(); break;
-      case '--scope': args.scope = next(); break;
-      case '--components-dir': args.componentsDir = next(); break;
-      case '--lockfile': args.lockfile = next(); break;
-      case '--build-spec': args.buildSpec = next(); break;
-      case '--framework': args.framework = next(); break;
-      case '--no-storybook': args.storybook = false; break;
-      case '--no-changesets': args.changesets = false; break;
-      case '--dry-run': args.dryRun = true; break;
-      case '--json': args.json = true; break;
-      case '--force': args.force = true; break;
-      case '-h': case '--help': printHelp(); process.exit(0);
+      case "--output":
+        args.output = next();
+        break;
+      case "--scope":
+        args.scope = next();
+        break;
+      case "--components-dir":
+        args.componentsDir = next();
+        break;
+      case "--lockfile":
+        args.lockfile = next();
+        break;
+      case "--build-spec":
+        args.buildSpec = next();
+        break;
+      case "--framework":
+        args.framework = next();
+        break;
+      case "--no-storybook":
+        args.storybook = false;
+        break;
+      case "--no-changesets":
+        args.changesets = false;
+        break;
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "--force":
+        args.force = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+        break;
       default:
-        if (a.startsWith('--')) die(`Unknown flag: ${a}`, 1);
+        if (a.startsWith("--")) die(`Unknown flag: ${a}`, 1);
     }
   }
   return args;
@@ -90,7 +116,9 @@ function die(msg, code = 1) {
 
 function readJsonIfExists(p) {
   if (!p || !fs.existsSync(p)) return null;
-  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (e) {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch (e) {
     die(`Failed to parse JSON at ${p}: ${e.message}`, 1);
   }
 }
@@ -134,14 +162,17 @@ function copyDirRecursive(src, dest, filterFn, opts) {
 
 function autoDetect(args) {
   const candidates = {
-    lockfile: ['src/styles/design-tokens.lock.json', 'design-tokens.lock.json'],
-    buildSpec: ['.claude/plans/build-spec.json', 'build-spec.json'],
-    componentsDir: ['src/components', 'components', 'src/lib/components'],
+    lockfile: ["src/styles/design-tokens.lock.json", "design-tokens.lock.json"],
+    buildSpec: [".claude/plans/build-spec.json", "build-spec.json"],
+    componentsDir: ["src/components", "components", "src/lib/components"],
   };
   for (const k of Object.keys(candidates)) {
     if (args[k]) continue;
     for (const c of candidates[k]) {
-      if (fs.existsSync(c)) { args[k] = c; break; }
+      if (fs.existsSync(c)) {
+        args[k] = c;
+        break;
+      }
     }
   }
 }
@@ -149,73 +180,73 @@ function autoDetect(args) {
 function detectFramework(buildSpec) {
   if (buildSpec && buildSpec.outputTarget) return buildSpec.outputTarget;
   // Fallback: infer from package.json deps
-  const pkg = readJsonIfExists('package.json') || {};
+  const pkg = readJsonIfExists("package.json") || {};
   const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
-  if (deps['react-native'] || deps['expo']) return 'react-native';
-  if (deps['vue'] || deps['@vue/runtime-core']) return 'vue';
-  if (deps['svelte'] || deps['@sveltejs/kit']) return 'svelte';
-  if (deps['react'] || deps['next']) return 'react';
+  if (deps["react-native"] || deps["expo"]) return "react-native";
+  if (deps["vue"] || deps["@vue/runtime-core"]) return "vue";
+  if (deps["svelte"] || deps["@sveltejs/kit"]) return "svelte";
+  if (deps["react"] || deps["next"]) return "react";
   return null;
 }
 
 function defaultScope() {
-  const pkg = readJsonIfExists('package.json') || {};
-  if (typeof pkg.name === 'string' && pkg.name.startsWith('@')) {
-    const slash = pkg.name.indexOf('/');
+  const pkg = readJsonIfExists("package.json") || {};
+  if (typeof pkg.name === "string" && pkg.name.startsWith("@")) {
+    const slash = pkg.name.indexOf("/");
     if (slash > 0) return pkg.name.slice(0, slash);
   }
-  return '@my-app';
+  return "@my-app";
 }
 
 // ---------- per-framework descriptors ----------
 
 const FRAMEWORKS = {
   react: {
-    label: 'React',
-    componentExt: ['.tsx', '.ts', '.jsx', '.js'],
-    pkgSuffix: 'react-components',
-    bundler: 'vite',
-    peers: { react: '^18.0.0 || ^19.0.0', 'react-dom': '^18.0.0 || ^19.0.0' },
+    label: "React",
+    componentExt: [".tsx", ".ts", ".jsx", ".js"],
+    pkgSuffix: "react-components",
+    bundler: "vite",
+    peers: { react: "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" },
     devDeps: {
-      '@types/react': '^19.0.0',
-      '@types/react-dom': '^19.0.0',
-      '@vitejs/plugin-react': '^4.3.0',
-      'vite-plugin-dts': '^4.0.0',
+      "@types/react": "^19.0.0",
+      "@types/react-dom": "^19.0.0",
+      "@vitejs/plugin-react": "^4.3.0",
+      "vite-plugin-dts": "^4.0.0",
     },
   },
   vue: {
-    label: 'Vue 3',
-    componentExt: ['.vue', '.ts', '.tsx'],
-    pkgSuffix: 'vue-components',
-    bundler: 'vite',
-    peers: { vue: '^3.4.0' },
+    label: "Vue 3",
+    componentExt: [".vue", ".ts", ".tsx"],
+    pkgSuffix: "vue-components",
+    bundler: "vite",
+    peers: { vue: "^3.4.0" },
     devDeps: {
-      '@vitejs/plugin-vue': '^5.2.0',
-      'vue-tsc': '^2.2.0',
-      'vite-plugin-dts': '^4.0.0',
+      "@vitejs/plugin-vue": "^5.2.0",
+      "vue-tsc": "^2.2.0",
+      "vite-plugin-dts": "^4.0.0",
     },
   },
   svelte: {
-    label: 'Svelte 5',
-    componentExt: ['.svelte', '.ts'],
-    pkgSuffix: 'svelte-components',
-    bundler: 'vite',
-    peers: { svelte: '^5.0.0' },
+    label: "Svelte 5",
+    componentExt: [".svelte", ".ts"],
+    pkgSuffix: "svelte-components",
+    bundler: "vite",
+    peers: { svelte: "^5.0.0" },
     devDeps: {
-      '@sveltejs/package': '^2.3.0',
-      '@sveltejs/vite-plugin-svelte': '^5.0.0',
-      'svelte-check': '^4.0.0',
+      "@sveltejs/package": "^2.3.0",
+      "@sveltejs/vite-plugin-svelte": "^5.0.0",
+      "svelte-check": "^4.0.0",
     },
   },
-  'react-native': {
-    label: 'React Native',
-    componentExt: ['.tsx', '.ts'],
-    pkgSuffix: 'native-components',
-    bundler: 'tsc',
-    peers: { react: '^18.0.0', 'react-native': '>=0.74.0' },
+  "react-native": {
+    label: "React Native",
+    componentExt: [".tsx", ".ts"],
+    pkgSuffix: "native-components",
+    bundler: "tsc",
+    peers: { react: "^18.0.0", "react-native": ">=0.74.0" },
     devDeps: {
-      '@types/react': '^18.3.0',
-      typescript: '^5.7.0',
+      "@types/react": "^18.3.0",
+      typescript: "^5.7.0",
     },
   },
 };
@@ -223,36 +254,36 @@ const FRAMEWORKS = {
 // ---------- file generators ----------
 
 function tokensCss(lock) {
-  const lines = [':root {'];
+  const lines = [":root {"];
   const colors = (lock && lock.colors) || {};
-  const flat = flattenObject(colors, 'color');
+  const flat = flattenObject(colors, "color");
   for (const [k, v] of Object.entries(flat)) {
-    if (typeof v === 'string') lines.push(`  --${k}: ${v};`);
+    if (typeof v === "string") lines.push(`  --${k}: ${v};`);
   }
   const spacing = (lock && lock.spacing) || {};
   for (const [k, v] of Object.entries(spacing)) {
-    if (typeof v === 'string' || typeof v === 'number') {
-      lines.push(`  --space-${k}: ${typeof v === 'number' ? `${v}px` : v};`);
+    if (typeof v === "string" || typeof v === "number") {
+      lines.push(`  --space-${k}: ${typeof v === "number" ? `${v}px` : v};`);
     }
   }
   const radii = (lock && lock.radii) || (lock && lock.borderRadius) || {};
   for (const [k, v] of Object.entries(radii)) {
-    if (typeof v === 'string' || typeof v === 'number') {
-      lines.push(`  --radius-${k}: ${typeof v === 'number' ? `${v}px` : v};`);
+    if (typeof v === "string" || typeof v === "number") {
+      lines.push(`  --radius-${k}: ${typeof v === "number" ? `${v}px` : v};`);
     }
   }
-  lines.push('}');
-  return lines.join('\n') + '\n';
+  lines.push("}");
+  return lines.join("\n") + "\n";
 }
 
 function flattenObject(obj, prefix) {
   const out = {};
-  if (!obj || typeof obj !== 'object') return out;
+  if (!obj || typeof obj !== "object") return out;
   for (const [k, v] of Object.entries(obj)) {
     const key = prefix ? `${prefix}-${k}` : k;
-    if (v && typeof v === 'object' && !Array.isArray(v) && !('value' in v)) {
+    if (v && typeof v === "object" && !Array.isArray(v) && !("value" in v)) {
       Object.assign(out, flattenObject(v, key));
-    } else if (v && typeof v === 'object' && 'value' in v) {
+    } else if (v && typeof v === "object" && "value" in v) {
       out[key] = v.value;
     } else {
       out[key] = v;
@@ -304,43 +335,50 @@ export default preset;
 }
 
 function tokensPackageJson(scope, version) {
-  return JSON.stringify({
-    name: `${scope}/design-tokens`,
-    version,
-    description: 'Framework-agnostic design tokens (CSS variables, Tailwind preset, typed exports).',
-    type: 'module',
-    sideEffects: ['./dist/tokens.css'],
-    main: './dist/index.cjs',
-    module: './dist/index.js',
-    types: './dist/index.d.ts',
-    exports: {
-      '.': {
-        types: './dist/index.d.ts',
-        import: './dist/index.js',
-        require: './dist/index.cjs',
+  return (
+    JSON.stringify(
+      {
+        name: `${scope}/design-tokens`,
+        version,
+        description:
+          "Framework-agnostic design tokens (CSS variables, Tailwind preset, typed exports).",
+        type: "module",
+        sideEffects: ["./dist/tokens.css"],
+        main: "./dist/index.cjs",
+        module: "./dist/index.js",
+        types: "./dist/index.d.ts",
+        exports: {
+          ".": {
+            types: "./dist/index.d.ts",
+            import: "./dist/index.js",
+            require: "./dist/index.cjs",
+          },
+          "./tokens.css": "./dist/tokens.css",
+          "./tailwind-preset": {
+            types: "./dist/tailwind-preset.d.ts",
+            import: "./dist/tailwind-preset.js",
+            require: "./dist/tailwind-preset.cjs",
+          },
+          "./tokens.json": "./dist/tokens.json",
+        },
+        files: ["dist"],
+        scripts: {
+          build: "vite build && node scripts/postbuild.mjs",
+          dev: "vite build --watch",
+          "type-check": "tsc --noEmit",
+        },
+        devDependencies: {
+          typescript: "^5.7.0",
+          vite: "^6.0.0",
+          "vite-plugin-dts": "^4.0.0",
+          tailwindcss: "^4.0.0",
+        },
+        publishConfig: { access: "public" },
       },
-      './tokens.css': './dist/tokens.css',
-      './tailwind-preset': {
-        types: './dist/tailwind-preset.d.ts',
-        import: './dist/tailwind-preset.js',
-        require: './dist/tailwind-preset.cjs',
-      },
-      './tokens.json': './dist/tokens.json',
-    },
-    files: ['dist'],
-    scripts: {
-      build: 'vite build && node scripts/postbuild.mjs',
-      dev: 'vite build --watch',
-      'type-check': 'tsc --noEmit',
-    },
-    devDependencies: {
-      typescript: '^5.7.0',
-      vite: '^6.0.0',
-      'vite-plugin-dts': '^4.0.0',
-      tailwindcss: '^4.0.0',
-    },
-    publishConfig: { access: 'public' },
-  }, null, 2) + '\n';
+      null,
+      2,
+    ) + "\n"
+  );
 }
 
 function tokensViteConfig() {
@@ -376,16 +414,22 @@ cpSync('src/tokens.json', 'dist/tokens.json');
 }
 
 function tokensTsconfig() {
-  return JSON.stringify({
-    extends: '../../tsconfig.base.json',
-    compilerOptions: {
-      outDir: 'dist',
-      declaration: true,
-      declarationDir: 'dist',
-      moduleResolution: 'bundler',
-    },
-    include: ['src/**/*'],
-  }, null, 2) + '\n';
+  return (
+    JSON.stringify(
+      {
+        extends: "../../tsconfig.base.json",
+        compilerOptions: {
+          outDir: "dist",
+          declaration: true,
+          declarationDir: "dist",
+          moduleResolution: "bundler",
+        },
+        include: ["src/**/*"],
+      },
+      null,
+      2,
+    ) + "\n"
+  );
 }
 
 // ---------- components package ----------
@@ -393,79 +437,86 @@ function tokensTsconfig() {
 function componentsPackageJson(scope, version, framework, fwDesc, hasTokens) {
   const name = `${scope}/${fwDesc.pkgSuffix}`;
   const tokenDep = hasTokens ? { [`${scope}/design-tokens`]: `workspace:^${version}` } : {};
-  const isVite = fwDesc.bundler === 'vite';
+  const isVite = fwDesc.bundler === "vite";
 
   const exportsField = isVite
     ? {
-        '.': {
-          types: './dist/index.d.ts',
-          import: './dist/index.js',
-          require: './dist/index.cjs',
+        ".": {
+          types: "./dist/index.d.ts",
+          import: "./dist/index.js",
+          require: "./dist/index.cjs",
         },
-        './styles.css': './dist/styles.css',
+        "./styles.css": "./dist/styles.css",
       }
     : {
-        '.': {
-          types: './dist/index.d.ts',
-          import: './dist/index.js',
+        ".": {
+          types: "./dist/index.d.ts",
+          import: "./dist/index.js",
         },
       };
 
   const scripts = isVite
     ? {
-        build: 'vite build',
-        dev: 'vite build --watch',
-        'type-check': framework === 'vue' ? 'vue-tsc --noEmit' : 'tsc --noEmit',
+        build: "vite build",
+        dev: "vite build --watch",
+        "type-check": framework === "vue" ? "vue-tsc --noEmit" : "tsc --noEmit",
       }
     : {
-        build: 'tsc -p tsconfig.json',
-        'type-check': 'tsc --noEmit',
+        build: "tsc -p tsconfig.json",
+        "type-check": "tsc --noEmit",
       };
 
-  return JSON.stringify({
-    name,
-    version,
-    description: `${fwDesc.label} component library generated from design tokens.`,
-    type: 'module',
-    sideEffects: isVite ? ['*.css'] : false,
-    main: isVite ? './dist/index.cjs' : './dist/index.js',
-    module: './dist/index.js',
-    types: './dist/index.d.ts',
-    exports: exportsField,
-    files: ['dist'],
-    scripts,
-    peerDependencies: fwDesc.peers,
-    dependencies: tokenDep,
-    devDependencies: {
-      ...fwDesc.devDeps,
-      typescript: '^5.7.0',
-      vite: isVite ? '^6.0.0' : undefined,
-    },
-    publishConfig: { access: 'public' },
-  }, (k, v) => v === undefined ? undefined : v, 2) + '\n';
+  return (
+    JSON.stringify(
+      {
+        name,
+        version,
+        description: `${fwDesc.label} component library generated from design tokens.`,
+        type: "module",
+        sideEffects: isVite ? ["*.css"] : false,
+        main: isVite ? "./dist/index.cjs" : "./dist/index.js",
+        module: "./dist/index.js",
+        types: "./dist/index.d.ts",
+        exports: exportsField,
+        files: ["dist"],
+        scripts,
+        peerDependencies: fwDesc.peers,
+        dependencies: tokenDep,
+        devDependencies: {
+          ...fwDesc.devDeps,
+          typescript: "^5.7.0",
+          vite: isVite ? "^6.0.0" : undefined,
+        },
+        publishConfig: { access: "public" },
+      },
+      (k, v) => (v === undefined ? undefined : v),
+      2,
+    ) + "\n"
+  );
 }
 
 function componentsViteConfig(framework) {
   const plugin = {
-    react: { import: "import react from '@vitejs/plugin-react';", call: 'react()' },
-    vue: { import: "import vue from '@vitejs/plugin-vue';", call: 'vue()' },
+    react: { import: "import react from '@vitejs/plugin-react';", call: "react()" },
+    vue: { import: "import vue from '@vitejs/plugin-vue';", call: "vue()" },
     svelte: {
       import: "import { svelte } from '@sveltejs/vite-plugin-svelte';",
-      call: 'svelte()',
+      call: "svelte()",
     },
   }[framework];
 
   const externals = {
-    react: ['react', 'react-dom', 'react/jsx-runtime'],
-    vue: ['vue'],
-    svelte: ['svelte', 'svelte/internal'],
+    react: ["react", "react-dom", "react/jsx-runtime"],
+    vue: ["vue"],
+    svelte: ["svelte", "svelte/internal"],
   }[framework];
 
-  const dtsPlugin = framework === 'svelte'
-    ? '' // SvelteKit/svelte-package handles types separately; keep it simple here
-    : "import dts from 'vite-plugin-dts';\n";
+  const dtsPlugin =
+    framework === "svelte"
+      ? "" // SvelteKit/svelte-package handles types separately; keep it simple here
+      : "import dts from 'vite-plugin-dts';\n";
 
-  const dtsCall = framework === 'svelte' ? '' : ', dts({ rollupTypes: true })';
+  const dtsCall = framework === "svelte" ? "" : ", dts({ rollupTypes: true })";
 
   return `import { defineConfig } from 'vite';
 ${plugin.import}
@@ -491,37 +542,35 @@ export default defineConfig({
 
 function componentsTsconfig(framework) {
   const base = {
-    extends: '../../tsconfig.base.json',
+    extends: "../../tsconfig.base.json",
     compilerOptions: {
-      outDir: 'dist',
+      outDir: "dist",
       declaration: true,
-      declarationDir: 'dist',
-      moduleResolution: 'bundler',
-      jsx: framework === 'react' || framework === 'react-native' ? 'react-jsx' : undefined,
+      declarationDir: "dist",
+      moduleResolution: "bundler",
+      jsx: framework === "react" || framework === "react-native" ? "react-jsx" : undefined,
     },
-    include: ['src/**/*'],
+    include: ["src/**/*"],
   };
-  if (framework === 'react-native') {
-    base.compilerOptions.module = 'esnext';
-    base.compilerOptions.target = 'esnext';
-    base.compilerOptions.lib = ['esnext'];
+  if (framework === "react-native") {
+    base.compilerOptions.module = "esnext";
+    base.compilerOptions.target = "esnext";
+    base.compilerOptions.lib = ["esnext"];
   }
-  return JSON.stringify(base, (k, v) => v === undefined ? undefined : v, 2) + '\n';
+  return JSON.stringify(base, (k, v) => (v === undefined ? undefined : v), 2) + "\n";
 }
 
 function themeProvider(framework, scope, hasTokens) {
-  const tokenImport = hasTokens
-    ? `import { tokens } from '${scope}/design-tokens';\n`
-    : '';
+  const tokenImport = hasTokens ? `import { tokens } from '${scope}/design-tokens';\n` : "";
   switch (framework) {
-    case 'react':
+    case "react":
       return `import { createContext, useContext, useMemo, type ReactNode } from 'react';
 ${tokenImport}
 type Theme = 'light' | 'dark';
 
 interface ThemeContextValue {
   theme: Theme;
-  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+  tokens: ${hasTokens ? "typeof tokens" : "Record<string, unknown>"};
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -532,7 +581,7 @@ export interface ThemeProviderProps {
 }
 
 export function ThemeProvider({ theme = 'light', children }: ThemeProviderProps) {
-  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? 'tokens' : '{}'} }), [theme]);
+  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? "tokens" : "{}"} }), [theme]);
   return (
     <ThemeContext.Provider value={value}>
       <div data-theme={theme}>{children}</div>
@@ -546,14 +595,14 @@ export function useTheme() {
   return ctx;
 }
 `;
-    case 'vue':
+    case "vue":
       return `import { defineComponent, provide, inject, computed, h, type InjectionKey, type PropType } from 'vue';
 ${tokenImport}
 type Theme = 'light' | 'dark';
 
 interface ThemeContext {
   theme: Theme;
-  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+  tokens: ${hasTokens ? "typeof tokens" : "Record<string, unknown>"};
 }
 
 export const ThemeKey: InjectionKey<ThemeContext> = Symbol('theme');
@@ -564,7 +613,7 @@ export const ThemeProvider = defineComponent({
     theme: { type: String as PropType<Theme>, default: 'light' },
   },
   setup(props, { slots }) {
-    const ctx = computed<ThemeContext>(() => ({ theme: props.theme, tokens: ${hasTokens ? 'tokens' : '{}'} }));
+    const ctx = computed<ThemeContext>(() => ({ theme: props.theme, tokens: ${hasTokens ? "tokens" : "{}"} }));
     provide(ThemeKey, ctx.value);
     return () => h('div', { 'data-theme': props.theme }, slots.default?.());
   },
@@ -576,35 +625,35 @@ export function useTheme(): ThemeContext {
   return ctx;
 }
 `;
-    case 'svelte':
+    case "svelte":
       return `<script lang="ts" context="module">
 ${tokenImport.trim()}
   export type Theme = 'light' | 'dark';
   export const themeContextKey = Symbol('theme');
   export interface ThemeContext {
     theme: Theme;
-    tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+    tokens: ${hasTokens ? "typeof tokens" : "Record<string, unknown>"};
   }
 </script>
 
 <script lang="ts">
   import { setContext } from 'svelte';
   export let theme: Theme = 'light';
-  $: setContext<ThemeContext>(themeContextKey, { theme, tokens: ${hasTokens ? 'tokens' : '{}'} });
+  $: setContext<ThemeContext>(themeContextKey, { theme, tokens: ${hasTokens ? "tokens" : "{}"} });
 </script>
 
 <div data-theme={theme}>
   <slot />
 </div>
 `;
-    case 'react-native':
+    case "react-native":
       return `import { createContext, useContext, useMemo, type ReactNode } from 'react';
 ${tokenImport}
 type Theme = 'light' | 'dark';
 
 interface ThemeContextValue {
   theme: Theme;
-  tokens: ${hasTokens ? 'typeof tokens' : 'Record<string, unknown>'};
+  tokens: ${hasTokens ? "typeof tokens" : "Record<string, unknown>"};
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -615,7 +664,7 @@ export interface ThemeProviderProps {
 }
 
 export function ThemeProvider({ theme = 'light', children }: ThemeProviderProps) {
-  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? 'tokens' : '{}'} }), [theme]);
+  const value = useMemo(() => ({ theme, tokens: ${hasTokens ? "tokens" : "{}"} }), [theme]);
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
@@ -626,34 +675,42 @@ export function useTheme() {
 }
 `;
     default:
-      return '';
+      return "";
   }
 }
 
 function themeProviderFilename(framework) {
   switch (framework) {
-    case 'react': return 'ThemeProvider.tsx';
-    case 'vue': return 'ThemeProvider.ts';
-    case 'svelte': return 'ThemeProvider.svelte';
-    case 'react-native': return 'ThemeProvider.tsx';
-    default: return 'ThemeProvider.ts';
+    case "react":
+      return "ThemeProvider.tsx";
+    case "vue":
+      return "ThemeProvider.ts";
+    case "svelte":
+      return "ThemeProvider.svelte";
+    case "react-native":
+      return "ThemeProvider.tsx";
+    default:
+      return "ThemeProvider.ts";
   }
 }
 
 function buildBarrelIndex(framework, componentNames) {
-  const themeFile = themeProviderFilename(framework).replace(/\.(tsx|ts|svelte)$/, '');
-  const themeImport = framework === 'svelte'
-    ? `export { default as ThemeProvider } from './theme/${themeFile}.svelte';\n`
-    : `export { ThemeProvider, useTheme } from './theme/${themeFile}';\n` +
-      `export type { ThemeProviderProps } from './theme/${themeFile}';\n`;
+  const themeFile = themeProviderFilename(framework).replace(/\.(tsx|ts|svelte)$/, "");
+  const themeImport =
+    framework === "svelte"
+      ? `export { default as ThemeProvider } from './theme/${themeFile}.svelte';\n`
+      : `export { ThemeProvider, useTheme } from './theme/${themeFile}';\n` +
+        `export type { ThemeProviderProps } from './theme/${themeFile}';\n`;
 
   const componentExports = componentNames
-    .map(name => {
-      if (framework === 'svelte') return `export { default as ${name} } from './components/${name}.svelte';`;
-      if (framework === 'vue') return `export { default as ${name} } from './components/${name}.vue';`;
+    .map((name) => {
+      if (framework === "svelte")
+        return `export { default as ${name} } from './components/${name}.svelte';`;
+      if (framework === "vue")
+        return `export { default as ${name} } from './components/${name}.vue';`;
       return `export * from './components/${name}';`;
     })
-    .join('\n');
+    .join("\n");
 
   return `${themeImport}\n${componentExports}\n`;
 }
@@ -661,23 +718,29 @@ function buildBarrelIndex(framework, componentNames) {
 // ---------- workspace-level files ----------
 
 function workspaceRootPackageJson(scope) {
-  return JSON.stringify({
-    name: `${scope.replace(/^@/, '')}-design-system`,
-    private: true,
-    version: '0.0.0',
-    scripts: {
-      build: 'pnpm -r --filter "./packages/**" run build',
-      'type-check': 'pnpm -r --filter "./packages/**" run type-check',
-      changeset: 'changeset',
-      version: 'changeset version',
-      release: 'pnpm build && changeset publish',
-    },
-    devDependencies: {
-      '@changesets/cli': '^2.27.0',
-      typescript: '^5.7.0',
-    },
-    packageManager: 'pnpm@9.0.0',
-  }, null, 2) + '\n';
+  return (
+    JSON.stringify(
+      {
+        name: `${scope.replace(/^@/, "")}-design-system`,
+        private: true,
+        version: "0.0.0",
+        scripts: {
+          build: 'pnpm -r --filter "./packages/**" run build',
+          "type-check": 'pnpm -r --filter "./packages/**" run type-check',
+          changeset: "changeset",
+          version: "changeset version",
+          release: "pnpm build && changeset publish",
+        },
+        devDependencies: {
+          "@changesets/cli": "^2.27.0",
+          typescript: "^5.7.0",
+        },
+        packageManager: "pnpm@9.0.0",
+      },
+      null,
+      2,
+    ) + "\n"
+  );
 }
 
 function workspacePnpmYaml() {
@@ -685,41 +748,54 @@ function workspacePnpmYaml() {
 }
 
 function workspaceTsconfigBase() {
-  return JSON.stringify({
-    compilerOptions: {
-      target: 'ES2022',
-      module: 'ESNext',
-      moduleResolution: 'bundler',
-      strict: true,
-      esModuleInterop: true,
-      skipLibCheck: true,
-      isolatedModules: true,
-      resolveJsonModule: true,
-      forceConsistentCasingInFileNames: true,
-    },
-  }, null, 2) + '\n';
+  return (
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          strict: true,
+          esModuleInterop: true,
+          skipLibCheck: true,
+          isolatedModules: true,
+          resolveJsonModule: true,
+          forceConsistentCasingInFileNames: true,
+        },
+      },
+      null,
+      2,
+    ) + "\n"
+  );
 }
 
 function changesetsConfig() {
-  return JSON.stringify({
-    $schema: 'https://unpkg.com/@changesets/config@3.0.0/schema.json',
-    changelog: '@changesets/cli/changelog',
-    commit: false,
-    fixed: [],
-    linked: [],
-    access: 'public',
-    baseBranch: 'main',
-    updateInternalDependencies: 'patch',
-    ignore: [],
-  }, null, 2) + '\n';
+  return (
+    JSON.stringify(
+      {
+        $schema: "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+        changelog: "@changesets/cli/changelog",
+        commit: false,
+        fixed: [],
+        linked: [],
+        access: "public",
+        baseBranch: "main",
+        updateInternalDependencies: "patch",
+        ignore: [],
+      },
+      null,
+      2,
+    ) + "\n"
+  );
 }
 
 function workspaceReadme(ctx) {
   const { scope, framework, fwDesc, componentCount, version } = ctx;
-  const rnNote = framework === 'react-native'
-    ? `\n> **React Native note:** components build with \`tsc\` (Vite is not used for the RN runtime).\n`
-    : '';
-  return `# ${scope.replace(/^@/, '')}-design-system
+  const rnNote =
+    framework === "react-native"
+      ? `\n> **React Native note:** components build with \`tsc\` (Vite is not used for the RN runtime).\n`
+      : "";
+  return `# ${scope.replace(/^@/, "")}-design-system
 
 Generated design-system workspace from your project's tokens and components.
 ${rnNote}
@@ -783,12 +859,12 @@ pnpm add ${scope}/${fwDesc.pkgSuffix} ${scope}/design-tokens
 ## Use
 
 \`\`\`ts
-import { ThemeProvider${componentNames.length ? ', ' + componentNames.slice(0, 3).join(', ') : ''} } from '${scope}/${fwDesc.pkgSuffix}';
+import { ThemeProvider${componentNames.length ? ", " + componentNames.slice(0, 3).join(", ") : ""} } from '${scope}/${fwDesc.pkgSuffix}';
 \`\`\`
 
 ## Components
 
-${componentNames.length ? componentNames.map(n => `- \`${n}\``).join('\n') : '_No components detected._'}
+${componentNames.length ? componentNames.map((n) => `- \`${n}\``).join("\n") : "_No components detected._"}
 `;
 }
 
@@ -831,70 +907,110 @@ function main() {
   const framework = args.framework || detectFramework(buildSpec);
 
   if (!framework) {
-    die('Could not determine outputTarget. Pass --framework <react|vue|svelte|react-native> or ensure build-spec.json has outputTarget set.', 2);
+    die(
+      "Could not determine outputTarget. Pass --framework <react|vue|svelte|react-native> or ensure build-spec.json has outputTarget set.",
+      2,
+    );
   }
   const fwDesc = FRAMEWORKS[framework];
   if (!fwDesc) {
-    die(`Unsupported framework: ${framework}. Supported: ${Object.keys(FRAMEWORKS).join(', ')}.`, 3);
+    die(
+      `Unsupported framework: ${framework}. Supported: ${Object.keys(FRAMEWORKS).join(", ")}.`,
+      3,
+    );
   }
   if (!lock) {
-    die(`No design-tokens.lock.json found. Looked at: src/styles/design-tokens.lock.json, design-tokens.lock.json. Pass --lockfile <path> to override.`, 2);
+    die(
+      `No design-tokens.lock.json found. Looked at: src/styles/design-tokens.lock.json, design-tokens.lock.json. Pass --lockfile <path> to override.`,
+      2,
+    );
   }
 
   const scope = args.scope || defaultScope();
-  const componentsDir = args.componentsDir || 'src/components';
-  const version = '0.0.1';
+  const componentsDir = args.componentsDir || "src/components";
+  const version = "0.0.1";
 
   const outRoot = path.resolve(args.output);
   if (fs.existsSync(outRoot) && !args.force && !args.dryRun) {
-    die(`Output directory already exists: ${outRoot}. Pass --force to overwrite or pick a different --output.`, 1);
+    die(
+      `Output directory already exists: ${outRoot}. Pass --force to overwrite or pick a different --output.`,
+      1,
+    );
   }
   if (fs.existsSync(outRoot) && args.force && !args.dryRun) {
     fs.rmSync(outRoot, { recursive: true, force: true });
   }
 
   const opts = { dryRun: args.dryRun, _written: [], _copied: [] };
-  const tokensPkgDir = path.join(outRoot, 'packages', 'design-tokens');
-  const compPkgDir = path.join(outRoot, 'packages', fwDesc.pkgSuffix);
+  const tokensPkgDir = path.join(outRoot, "packages", "design-tokens");
+  const compPkgDir = path.join(outRoot, "packages", fwDesc.pkgSuffix);
 
   // ----- workspace root -----
-  writeFile(path.join(outRoot, 'package.json'), workspaceRootPackageJson(scope), opts);
-  writeFile(path.join(outRoot, 'pnpm-workspace.yaml'), workspacePnpmYaml(), opts);
-  writeFile(path.join(outRoot, 'tsconfig.base.json'), workspaceTsconfigBase(), opts);
-  writeFile(path.join(outRoot, '.npmrc'), 'auto-install-peers=true\nstrict-peer-dependencies=false\n', opts);
-  writeFile(path.join(outRoot, '.gitignore'), 'node_modules\ndist\n.turbo\n.changeset/.cache\n', opts);
+  writeFile(path.join(outRoot, "package.json"), workspaceRootPackageJson(scope), opts);
+  writeFile(path.join(outRoot, "pnpm-workspace.yaml"), workspacePnpmYaml(), opts);
+  writeFile(path.join(outRoot, "tsconfig.base.json"), workspaceTsconfigBase(), opts);
+  writeFile(
+    path.join(outRoot, ".npmrc"),
+    "auto-install-peers=true\nstrict-peer-dependencies=false\n",
+    opts,
+  );
+  writeFile(
+    path.join(outRoot, ".gitignore"),
+    "node_modules\ndist\n.turbo\n.changeset/.cache\n",
+    opts,
+  );
 
   if (args.changesets) {
-    writeFile(path.join(outRoot, '.changeset', 'config.json'), changesetsConfig(), opts);
-    writeFile(path.join(outRoot, '.changeset', 'README.md'),
-      '# Changesets\n\nRun `pnpm changeset` to describe a change before merging.\n', opts);
+    writeFile(path.join(outRoot, ".changeset", "config.json"), changesetsConfig(), opts);
+    writeFile(
+      path.join(outRoot, ".changeset", "README.md"),
+      "# Changesets\n\nRun `pnpm changeset` to describe a change before merging.\n",
+      opts,
+    );
   }
 
   // ----- design-tokens package -----
-  writeFile(path.join(tokensPkgDir, 'package.json'), tokensPackageJson(scope, version), opts);
-  writeFile(path.join(tokensPkgDir, 'tsconfig.json'), tokensTsconfig(), opts);
-  writeFile(path.join(tokensPkgDir, 'vite.config.ts'), tokensViteConfig(), opts);
-  writeFile(path.join(tokensPkgDir, 'README.md'), tokensReadme(scope), opts);
-  writeFile(path.join(tokensPkgDir, 'src', 'tokens.ts'), tokensTs(lock), opts);
-  writeFile(path.join(tokensPkgDir, 'src', 'tokens.css'), tokensCss(lock), opts);
-  writeFile(path.join(tokensPkgDir, 'src', 'tokens.json'), JSON.stringify(lock, null, 2) + '\n', opts);
-  writeFile(path.join(tokensPkgDir, 'src', 'tailwind-preset.ts'), tailwindPreset(lock), opts);
-  writeFile(path.join(tokensPkgDir, 'src', 'index.ts'), tokensIndexTs(), opts);
-  writeFile(path.join(tokensPkgDir, 'scripts', 'postbuild.mjs'), tokensPostbuildScript(), opts);
+  writeFile(path.join(tokensPkgDir, "package.json"), tokensPackageJson(scope, version), opts);
+  writeFile(path.join(tokensPkgDir, "tsconfig.json"), tokensTsconfig(), opts);
+  writeFile(path.join(tokensPkgDir, "vite.config.ts"), tokensViteConfig(), opts);
+  writeFile(path.join(tokensPkgDir, "README.md"), tokensReadme(scope), opts);
+  writeFile(path.join(tokensPkgDir, "src", "tokens.ts"), tokensTs(lock), opts);
+  writeFile(path.join(tokensPkgDir, "src", "tokens.css"), tokensCss(lock), opts);
+  writeFile(
+    path.join(tokensPkgDir, "src", "tokens.json"),
+    JSON.stringify(lock, null, 2) + "\n",
+    opts,
+  );
+  writeFile(path.join(tokensPkgDir, "src", "tailwind-preset.ts"), tailwindPreset(lock), opts);
+  writeFile(path.join(tokensPkgDir, "src", "index.ts"), tokensIndexTs(), opts);
+  writeFile(path.join(tokensPkgDir, "scripts", "postbuild.mjs"), tokensPostbuildScript(), opts);
 
   // ----- components package -----
   const componentNames = collectComponents(componentsDir, fwDesc.componentExt);
-  writeFile(path.join(compPkgDir, 'package.json'),
-    componentsPackageJson(scope, version, framework, fwDesc, true), opts);
-  writeFile(path.join(compPkgDir, 'tsconfig.json'), componentsTsconfig(framework), opts);
-  if (fwDesc.bundler === 'vite') {
-    writeFile(path.join(compPkgDir, 'vite.config.ts'), componentsViteConfig(framework), opts);
-  }
-  writeFile(path.join(compPkgDir, 'README.md'), componentsReadme(scope, fwDesc, componentNames), opts);
   writeFile(
-    path.join(compPkgDir, 'src', 'theme', themeProviderFilename(framework)),
-    themeProvider(framework, scope, true), opts);
-  writeFile(path.join(compPkgDir, 'src', 'index.ts'), buildBarrelIndex(framework, componentNames), opts);
+    path.join(compPkgDir, "package.json"),
+    componentsPackageJson(scope, version, framework, fwDesc, true),
+    opts,
+  );
+  writeFile(path.join(compPkgDir, "tsconfig.json"), componentsTsconfig(framework), opts);
+  if (fwDesc.bundler === "vite") {
+    writeFile(path.join(compPkgDir, "vite.config.ts"), componentsViteConfig(framework), opts);
+  }
+  writeFile(
+    path.join(compPkgDir, "README.md"),
+    componentsReadme(scope, fwDesc, componentNames),
+    opts,
+  );
+  writeFile(
+    path.join(compPkgDir, "src", "theme", themeProviderFilename(framework)),
+    themeProvider(framework, scope, true),
+    opts,
+  );
+  writeFile(
+    path.join(compPkgDir, "src", "index.ts"),
+    buildBarrelIndex(framework, componentNames),
+    opts,
+  );
 
   // Copy components
   let copiedCount = 0;
@@ -904,56 +1020,57 @@ function main() {
       if (!fwDesc.componentExt.includes(ext)) return false;
       // Skip tests, stories, type defs
       if (/\.(test|spec|stories)\.[a-z]+$/.test(filepath)) return false;
-      if (filepath.endsWith('.d.ts')) return false;
+      if (filepath.endsWith(".d.ts")) return false;
       return true;
     };
     copiedCount = copyDirRecursive(
       componentsDir,
-      path.join(compPkgDir, 'src', 'components'),
+      path.join(compPkgDir, "src", "components"),
       filter,
-      opts
+      opts,
     );
   }
 
   // ----- workspace README -----
-  writeFile(path.join(outRoot, 'README.md'), workspaceReadme({
-    scope, framework, fwDesc, componentCount: componentNames.length, version,
-  }), opts);
+  writeFile(
+    path.join(outRoot, "README.md"),
+    workspaceReadme({
+      scope,
+      framework,
+      fwDesc,
+      componentCount: componentNames.length,
+      version,
+    }),
+    opts,
+  );
 
   // ----- summary -----
   const summary = {
-    status: 'ok',
+    status: "ok",
     framework,
     scope,
     output: outRoot,
-    packages: [
-      `${scope}/design-tokens`,
-      `${scope}/${fwDesc.pkgSuffix}`,
-    ],
+    packages: [`${scope}/design-tokens`, `${scope}/${fwDesc.pkgSuffix}`],
     components: componentNames,
     componentsCopied: copiedCount,
     filesWritten: opts._written.length,
     dryRun: args.dryRun,
     bundler: fwDesc.bundler,
-    nextSteps: [
-      `cd ${path.relative(process.cwd(), outRoot) || '.'}`,
-      'pnpm install',
-      'pnpm build',
-    ],
+    nextSteps: [`cd ${path.relative(process.cwd(), outRoot) || "."}`, "pnpm install", "pnpm build"],
   };
 
   if (args.json) {
-    process.stdout.write(JSON.stringify(summary, null, 2) + '\n');
+    process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
   } else {
-    const tag = args.dryRun ? '[dry-run] ' : '';
+    const tag = args.dryRun ? "[dry-run] " : "";
     process.stdout.write(`${tag}Exported ${fwDesc.label} design system to ${outRoot}\n`);
-    process.stdout.write(`  Packages: ${summary.packages.join(', ')}\n`);
+    process.stdout.write(`  Packages: ${summary.packages.join(", ")}\n`);
     process.stdout.write(`  Components: ${componentNames.length} (${copiedCount} files copied)\n`);
     process.stdout.write(`  Files written: ${opts._written.length}\n`);
-    if (framework === 'react-native') {
+    if (framework === "react-native") {
       process.stdout.write(`  Note: react-native uses \`tsc\` (Vite is not used for RN).\n`);
     }
-    process.stdout.write(`\nNext: ${summary.nextSteps.join(' && ')}\n`);
+    process.stdout.write(`\nNext: ${summary.nextSteps.join(" && ")}\n`);
   }
 }
 
@@ -965,21 +1082,21 @@ function collectComponents(dir, exts) {
       // Look for an index file or same-named file inside
       const sub = path.join(dir, entry.name);
       const innerFiles = fs.readdirSync(sub);
-      const hasComponent = innerFiles.some(f => {
+      const hasComponent = innerFiles.some((f) => {
         const ext = path.extname(f);
         const base = path.basename(f, ext);
-        return exts.includes(ext)
-          && !/\.(test|spec|stories)$/.test(base)
-          && !f.endsWith('.d.ts');
+        return exts.includes(ext) && !/\.(test|spec|stories)$/.test(base) && !f.endsWith(".d.ts");
       });
       if (hasComponent) names.add(entry.name);
     } else if (entry.isFile()) {
       const ext = path.extname(entry.name);
       const base = path.basename(entry.name, ext);
-      if (exts.includes(ext)
-        && !/\.(test|spec|stories)$/.test(base)
-        && base !== 'index'
-        && !entry.name.endsWith('.d.ts')) {
+      if (
+        exts.includes(ext) &&
+        !/\.(test|spec|stories)$/.test(base) &&
+        base !== "index" &&
+        !entry.name.endsWith(".d.ts")
+      ) {
         names.add(base);
       }
     }

--- a/scripts/export-design-system.sh
+++ b/scripts/export-design-system.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# export-design-system.sh — thin wrapper around scripts/export-design-system.js
+# Exports generated components + tokens as a publishable pnpm workspace.
+# All flags are forwarded; see `node scripts/export-design-system.js --help`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+node "${SCRIPT_DIR}/export-design-system.js" "$@"


### PR DESCRIPTION
## Summary
- Adds a standalone `/export-design-system` slash command, an `export-design-system` skill, and a `scripts/export-design-system.{js,sh}` exporter that emits a publishable pnpm workspace from generated components and `design-tokens.lock.json`.
- Output: `@scope/design-tokens` (framework-agnostic — CSS vars, Tailwind preset, typed exports) plus `@scope/<framework>-components` (built with Vite library mode for React/Vue/Svelte; `tsc` for React Native, since Vite is incompatible with the RN runtime).
- Scoped to whatever `outputTarget` is set in `build-spec.json` (with `--framework` flag and `package.json`-based fallback). Includes Changesets versioning scaffold, `.npmrc`, per-package READMEs, and a `ThemeProvider` + `useTheme` per framework.

Closes #19.

## What's in the box
- `scripts/export-design-system.js` — main exporter (~640 LOC, ESM, no extra deps)
- `scripts/export-design-system.sh` — wrapper matching the `generate-stories.sh` pattern
- `.claude/commands/export-design-system.md` — slash command
- `.claude/skills/export-design-system/SKILL.md` — skill docs
- `CLAUDE.md` — registered new script + skill + command, count bumps (19→20 skills, 29→31 scripts)

## Test plan
- [x] `--help` renders correctly
- [x] React: auto-detects `outputTarget` from `build-spec.json`, scope from `package.json`, copies components + `index.ts`, excludes `*.test.*` / `*.stories.*` / `*.d.ts`
- [x] Vue: `.vue` components copied, `ThemeProvider.ts` uses `provide`/`inject` + `h()` render
- [x] Svelte: `.svelte` components, `ThemeProvider.svelte`, vite-plugin-svelte config
- [x] React Native: no `vite.config.ts`, `tsc -p tsconfig.json` build, peerDeps `react-native >=0.74`, RN note in stdout + README
- [x] Existing output dir: refuses without `--force` (exit 1), overwrites with `--force`
- [x] Missing inputs: clear error, exit 2
- [x] Unsupported framework (`--framework angular`): exit 3
- [x] `--dry-run`: writes nothing
- [x] `--json`: machine-readable summary
- [x] Cross-platform tokens-package build: `cp` replaced with a generated `scripts/postbuild.mjs` using `fs.cpSync` (caught during smoke testing on Windows)
- [ ] End-to-end: `pnpm install && pnpm build` against a real lockfile from a `/build-from-figma` run (not yet exercised — peer-dep ranges and Tailwind preset mapping may need tweaks for non-standard lockfile shapes)

## Caveats
- The script writes files only — it does not run `pnpm install` or `pnpm build`. First real proof-of-life will come from running the workspace against a real lockfile.
- Tailwind preset assumes lockfile keys `colors`, `spacing`, `radii`/`borderRadius`, `typography.fontFamily`. Non-standard shapes may require a hand-tweak to the generated preset.
- React Native uses `tsc` not Vite. Documented in stdout, README, and skill docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)