### PR TITLE
Complete screenshot-intake skill (stub → self-contained)

### DIFF
--- a/.claude/skills/screenshot-intake/SKILL.md
+++ b/.claude/skills/screenshot-intake/SKILL.md
@@ -1,152 +1,424 @@
 ---
 name: screenshot-intake
-description: Structured discovery from screenshots or live URLs. Uses Chrome DevTools or Playwright to capture pages, Claude vision to analyze structure and components, and targeted user questions to produce a build-spec.json. Entry point for /build-from-screenshot pipeline. Keywords: screenshot intake, URL capture, build spec, screenshot discovery, website clone, screenshot interview, image to code
+description: Use when a user provides a URL or screenshot files and wants to build an app from them, or when starting /build-from-screenshot. Captures pages via Chrome DevTools or Playwright MCP, analyzes structure with Claude vision, and produces build-spec.json. Keywords: screenshot intake, URL capture, build spec, screenshot discovery, website clone, screenshot interview, image to code, URL to code
 ---
 
 # Screenshot Intake — Structured Discovery
 
 ## Purpose
 
-Gather everything needed to build a React/Vue/Svelte/RN app from screenshots or a live URL. Captures pages, analyzes with Claude vision, asks targeted questions, and outputs a build-spec.json that downstream skills consume.
+Gather everything needed to build a React/Vue/Svelte/React Native app from screenshots or a live URL in a single structured pass. Captures pages, analyzes them with Claude vision, asks the user only what cannot be derived, and writes `.claude/plans/build-spec.json` that downstream phases consume without re-asking questions.
 
 ## When to Use
 
-- First phase of `/build-from-screenshot` pipeline
-- When user provides a URL and says "build something like this"
-- When user provides screenshot images and wants to build from them
-- When no design tool (Figma/Canva) is available
+- First phase of the `/build-from-screenshot` pipeline
+- A user provides a URL and says "build something like this" or "clone this site"
+- A user provides screenshot image paths and wants to build from them
+- No Figma or Canva source is available, only screenshots or live pages
 
 ## Inputs
 
 - **One of:**
-  - URL (e.g., `https://example.com`) — will be captured via browser
-  - Image file paths (e.g., `./designs/homepage.png`)
+  - URL (`http://` or `https://`) — captured via browser MCP
+  - One or more image file paths (`.png`, `.jpg`, `.webp`)
 - **Optional:** Existing project directory to integrate into
+- **Reads:** `.claude/pipeline.config.json` for screenshot settings under `screenshot`
 
 ## Process
 
-### Step 1: Capture or Validate Screenshots
+### Step 1: Determine Source Mode and Capture
 
-**If URL provided:**
+```dot
+digraph capture_flow {
+    "Input received" [shape=diamond];
+    "URL mode" [shape=box];
+    "File mode" [shape=box];
+    "Chrome DevTools MCP available?" [shape=diamond];
+    "Use Chrome DevTools MCP" [shape=box];
+    "Playwright MCP available?" [shape=diamond];
+    "Use Playwright MCP" [shape=box];
+    "Ask user to provide screenshots" [shape=box];
+    "Validate image files" [shape=box];
+    "Save to source dir" [shape=box];
 
-Use Chrome DevTools MCP or Playwright MCP to capture:
+    "Input received" -> "URL mode" [label="starts with http"];
+    "Input received" -> "File mode" [label="otherwise"];
+    "URL mode" -> "Chrome DevTools MCP available?";
+    "Chrome DevTools MCP available?" -> "Use Chrome DevTools MCP" [label="yes"];
+    "Chrome DevTools MCP available?" -> "Playwright MCP available?" [label="no"];
+    "Playwright MCP available?" -> "Use Playwright MCP" [label="yes"];
+    "Playwright MCP available?" -> "Ask user to provide screenshots" [label="no"];
+    "File mode" -> "Validate image files";
+    "Use Chrome DevTools MCP" -> "Save to source dir";
+    "Use Playwright MCP" -> "Save to source dir";
+    "Validate image files" -> "Save to source dir";
+}
+```
+
+#### Option A: URL capture mode
+
+**Tool selection:**
+
+| Tool | When to use |
+|------|-------------|
+| Chrome DevTools MCP (`mcp__chrome-devtools__*`) | **Default.** Lighter weight, faster startup, integrated with Lighthouse audits. |
+| Playwright MCP (`mcp__playwright__*`) | Site requires WebKit/Firefox-specific behavior, needs persistent context, or Chrome DevTools is unavailable. |
+| Manual fallback | Both MCPs unavailable, URL behind auth, CORS blocked, or rate limiting blocks capture. |
+
+**Capture steps (Chrome DevTools MCP):**
 
 ```
-1. Navigate to URL
-2. Wait for network idle + 1s settle
-3. Capture full-page screenshot at desktop viewport (1440x900)
-4. Capture full-page screenshot at mobile viewport (375x812)
-5. If URL has navigation links:
-   → Detect nav links via DOM query
-   → Offer to capture each linked page
-6. Save screenshots to .claude/visual-qa/screenshots/source/
+1. mcp__chrome-devtools__new_page (or select existing)
+2. mcp__chrome-devtools__navigate_page → URL
+3. Wait for network idle + screenshot.capture.waitAfterLoadMs (default 1000ms)
+4. For each viewport in pipeline.config.json > screenshot.urlCapture.viewports:
+   a. mcp__chrome-devtools__resize_page → width, height
+   b. mcp__chrome-devtools__take_screenshot → fullPage: true, format: png
+   c. Save as .claude/visual-qa/screenshots/source/page-1-{viewportName}.png
+5. mcp__chrome-devtools__evaluate_script → extract nav links:
+   Array.from(document.querySelectorAll('a[href]'))
+     .map(a => ({ href: a.href, text: a.textContent.trim() }))
+     .filter(a => a.href.startsWith(location.origin) && a.href !== location.href)
+     .slice(0, 20)
+6. If links found: ask user which to capture (see Step 1.1 multi-page handling)
 ```
 
-**If image files provided:**
+**Capture steps (Playwright MCP fallback):**
 
 ```
-1. Verify files exist and are valid images (PNG, JPG, WebP)
-2. Copy to .claude/visual-qa/screenshots/source/
-3. Note original dimensions
+1. mcp__playwright__browser_navigate → URL
+2. mcp__playwright__browser_wait_for → networkidle (or 1000ms)
+3. For each viewport:
+   a. mcp__playwright__browser_resize → width, height
+   b. mcp__playwright__browser_take_screenshot → fullPage: true
+   c. Save as .claude/visual-qa/screenshots/source/page-1-{viewportName}.png
+4. mcp__playwright__browser_evaluate → extract nav links (same query as above)
+```
+
+**Manual fallback:**
+
+```
+If both MCPs fail or are unavailable:
+1. Inform user: "I can't capture this URL automatically. Possible reasons: site behind auth, CORS blocked, MCP unavailable, or rate limiting."
+2. Ask the user to capture screenshots manually (browser → Save Page As, or use a screenshot tool).
+3. Request file paths and switch to File mode (Option B).
+4. Record fallback in build-spec.json: "screenshot.captureMode": "manual"
+```
+
+#### Option B: File mode
+
+```
+1. Glob/validate each provided path:
+   - Exists and is readable
+   - Is a supported image format (.png, .jpg, .jpeg, .webp)
+   - Dimensions >= 1024px wide (warn if smaller — affects vision accuracy)
+2. Copy (do not move) each file to .claude/visual-qa/screenshots/source/
+   Preserve original filenames where unambiguous; otherwise rename:
+   page-1-desktop.png, page-2-desktop.png, ...
+3. Record original paths and dimensions in build-spec.json
+```
+
+### Step 1.1: Multi-Page Handling
+
+A "page" here means a distinct screen/route in the target app, not a viewport variant of the same page.
+
+**URL mode with detected nav links:**
+
+```
+1. List up to 20 same-origin links with their visible text.
+2. Ask user (single question):
+   "I detected these N internal pages. Which should I capture?
+    [Numbered list]
+    a) All (default)
+    b) Selection (provide numbers)
+    c) Homepage only"
+3. For each selected link: repeat Step 1 capture flow at all viewports.
+4. Store each captured page in .claude/visual-qa/screenshots/source/
+   with naming: page-{index}-{viewportName}.png
+```
+
+**File mode with multiple files:**
+
+```
+1. Group files by likely page (heuristic: filename contains "home"/"about"/"pricing"
+   OR sequential numbering OR identical aspect ratio).
+2. Confirm grouping with user if ambiguous:
+   "I see N files. Are these all the same page at different viewports,
+    or do they represent N separate pages?"
+3. Update naming: page-{N}-{viewport}.png
+```
+
+**Single page (default):**
+
+```
+1. If only one URL/file and no nav links detected, treat as a single-page app.
+2. Set pages: [{ name: "Home", route: "/", screenshotPath: "..." }] in build-spec.
+3. Do not ask multi-page questions.
 ```
 
 ### Step 2: Vision Analysis
 
-Feed each screenshot to Claude for structural analysis (identical to canva-intake Step 1 vision analysis):
+For each captured screenshot (use desktop viewport as primary, mobile as supplementary), prompt Claude to extract:
 
 ```
-1. Page structure: sections, layout patterns, responsive hints
-2. Component candidates: buttons, cards, inputs, navbars, etc.
-3. Visual hierarchy: heading levels, primary/secondary actions
-4. Text content: all visible text strings
-5. Color palette: dominant colors, backgrounds, text colors
-6. Typography: font size hierarchy, weight patterns
+1. Page structure
+   - Distinct sections (hero, nav, features, pricing, footer, sidebar, etc.)
+   - Layout pattern (grid, flex, sidebar+main, stacked, dashboard)
+   - Responsive hints (column counts at each viewport)
+
+2. Component candidates
+   - Buttons (variants: primary, secondary, ghost, link)
+   - Inputs, cards, modals, navbars, footers, tabs, accordions
+   - Repeated patterns suggesting reusable components
+
+3. Visual hierarchy
+   - Heading levels (H1-H4) inferred from size/weight
+   - Primary vs secondary actions
+   - Content grouping and spacing patterns
+
+4. Text content
+   - All visible text (headings, body, labels, CTAs, placeholders)
+   - Distinguish placeholder/lorem from real content if possible
+
+5. Confidence
+   - For each component: high/medium/low
+   - Note any region with low contrast, occlusion, or compression artifacts
 ```
+
+Store extracted data in working memory for Step 4 (questions) and Step 5 (build-spec output).
 
 ### Step 3: Local Project Scan
 
-Identical to figma-intake/canva-intake:
-
 ```
-1. Detect framework (Next.js, Vite, Remix, Nuxt, SvelteKit, Expo, or none)
-2. Detect app type (web-app, chrome-extension, pwa)
-3. Scan existing components
-4. Check package.json for UI libraries
-5. Check for existing design tokens
-6. Load pipeline config
+1. Detect framework (in order):
+   - next.config.* → Next.js          (outputTarget: "react")
+   - remix.config.* → Remix           (outputTarget: "react")
+   - nuxt.config.* → Nuxt             (outputTarget: "vue")
+   - svelte.config.* → SvelteKit      (outputTarget: "svelte")
+   - app.json with "expo" → Expo      (outputTarget: "react-native")
+   - vite.config.* + vue in deps → Vite+Vue       (outputTarget: "vue")
+   - vite.config.* + svelte in deps → Vite+Svelte (outputTarget: "svelte")
+   - vite.config.* → Vite+React        (outputTarget: "react")
+   - None → ask user (Q3 below)
+
+2. Detect app type:
+   - manifest.json with "manifest_version" → chrome-extension
+   - manifest.json with "start_url" or "display" → pwa
+   - Otherwise → web-app
+
+3. Inventory existing components:
+   Glob: src/components/**/*.{tsx,vue,svelte}, app/components/**
+   Record name, props interface (if detectable), file path.
+
+4. Check package.json for libraries:
+   UI: @shadcn/ui, @radix-ui/*, @headlessui/*, naive-ui, vuetify, skeletonlabs
+   Style: tailwindcss, @emotion/*, styled-components, unocss
+   State: zustand, jotai, pinia, @tanstack/*-query
+
+5. Check for existing tokens:
+   tailwind.config.* (theme.extend), src/styles/tokens.css,
+   design-tokens.lock.json (from prior run).
+
+6. Load pipeline config:
+   Read .claude/pipeline.config.json (screenshot, appTypes sections).
 ```
 
 ### Step 4: Ask Targeted Questions (Max 6)
 
-**Question 1 — Scope:**
-> Which pages/screens should I build? [Show list from captures]
+Only ask what cannot be derived from captures or local scan. Use `AskUserQuestion` tool with multiple questions in one prompt where possible.
 
-**Question 2 — Component Confirmation:**
+**Q1 — Scope (always):**
+> Which pages should I build?
+> a) All N detected pages (default)
+> b) Specific selection (provide numbers)
+> c) Homepage only
+
+**Q2 — Component confirmation (always):**
 > I detected these components from the screenshots. Confirm or correct:
-> [Table with confidence levels]
+> [Table: name | confidence | suggested action]
+>
+> Since detection is vision-based, low-confidence rows are worth a second look.
 
-**Question 3 — Output Target:**
+**Q3 — Output target (only if no framework detected):**
 > What framework should I build this in?
 > a) React (Next.js / Vite / Remix)
 > b) Vue 3 (Nuxt / Vite)
 > c) Svelte (SvelteKit / Vite)
 > d) React Native (Expo)
-> (Default: React + Vite if no project detected)
+> Default: React + Vite for new projects.
 
-**Question 4 — Component Reuse:**
-> [Only if existing project detected]
+**Q4 — Component reuse (only if existing components detected):**
+> I found N existing components that match detected components.
+> a) Reuse and only generate missing ones (recommended)
+> b) Regenerate all from screenshots (replaces existing)
+> c) Generate alongside with new names (no overwrites)
 
-**Question 5 — Business Logic:**
-> Are there interactions beyond what's visible?
+**Q5 — Business logic (always):**
+> Are there interactions beyond what's visible (form validation rules, API calls, auth requirements, state machines)?
+> Default: pure presentational.
 
-**Question 6 — Integration:**
-> Standalone app or integrate into existing project?
+**Q6 — Integration (only if existing project detected):**
+> a) Standalone app (new project scaffold)
+> b) Integrate into the existing project at [detected path]
 
 ### Step 5: Generate build-spec.json
 
-Write `.claude/plans/build-spec.json` with:
+Write `.claude/plans/build-spec.json`. The schema is consumed by `canva-token-inference` (Phase 2), `tdd-from-figma` (Phase 3), and the framework-specific converter agents (Phase 4).
+
+**Concrete example (single-page React from URL):**
 
 ```jsonc
 {
   "version": "1.0.0",
   "source": "screenshot",
-  "createdAt": "...",
+  "outputTarget": "react",
+  "createdAt": "2026-05-21T14:30:00Z",
   "screenshot": {
-    "inputType": "url",           // "url" | "files"
-    "sourceUrl": "https://...",   // null if files
+    "inputType": "url",
+    "sourceUrl": "https://example.com",
+    "captureMode": "chrome-devtools-mcp",
     "capturedScreenshots": [
       ".claude/visual-qa/screenshots/source/page-1-desktop.png",
       ".claude/visual-qa/screenshots/source/page-1-mobile.png"
+    ],
+    "viewports": [
+      { "name": "desktop", "width": 1440, "height": 900 },
+      { "name": "mobile", "width": 375, "height": 812 }
     ]
   },
-  "outputTarget": "react",       // "react" | "vue" | "svelte" | "react-native"
   "appType": "web-app",
   "framework": {
-    "type": "vite",               // varies by outputTarget
+    "type": "vite",
     "version": "6.0.0",
     "outputDir": "src"
   },
-  // ... rest identical to figma/canva build-spec
+  "styling": {
+    "approach": "tailwind",
+    "uiLibrary": "shadcn",
+    "existingTokens": false
+  },
+  "pages": [
+    {
+      "name": "Home",
+      "route": "/",
+      "screenshotPath": ".claude/visual-qa/screenshots/source/page-1-desktop.png",
+      "sections": ["nav", "hero", "features", "pricing", "footer"]
+    }
+  ],
+  "components": [
+    {
+      "detectedName": "Primary Button",
+      "confidence": "high",
+      "reactName": "Button",
+      "category": "ui",
+      "action": "generate",
+      "existingPath": null,
+      "variants": ["primary", "secondary", "outline"],
+      "props": ["variant", "size", "disabled", "children"]
+    },
+    {
+      "detectedName": "Pricing Card",
+      "confidence": "medium",
+      "reactName": "PricingCard",
+      "category": "composite",
+      "action": "generate",
+      "existingPath": null,
+      "props": ["title", "price", "features", "ctaText", "highlighted"]
+    }
+  ],
+  "textContent": {
+    "hero-heading": "Build faster with AI",
+    "hero-subheading": "Ship production apps in days, not months",
+    "cta-primary": "Get Started"
+  },
+  "businessLogic": {
+    "forms": [],
+    "apiCalls": [],
+    "auth": null,
+    "stateManagement": null
+  },
+  "e2e": {
+    "strategy": "navigate-interact-verify",
+    "flows": [
+      {
+        "name": "homepage-render",
+        "description": "Load homepage and verify all sections render",
+        "steps": [
+          "navigate to /",
+          "verify nav visible",
+          "verify hero heading text",
+          "verify CTA button clickable"
+        ]
+      }
+    ]
+  },
+  "testStrategy": {
+    "unit": true,
+    "e2e": true,
+    "visual": true,
+    "crossBrowser": false,
+    "coverageThreshold": 80
+  },
+  "options": {
+    "componentReuse": "reuse",
+    "integration": "standalone"
+  }
 }
 ```
 
+**Multi-page variant:** include one entry per page in `pages[]`, with distinct `screenshotPath` and `route`. Add a `page-navigation` flow to `e2e.flows` enumerating route transitions.
+
+**File-mode variant:** set `screenshot.inputType` to `"files"`, `sourceUrl` to `null`, and `captureMode` to `"file"`. Record original paths in a `screenshot.originalPaths` array.
+
+**Manual-fallback variant:** set `captureMode` to `"manual"`.
+
 ### Step 6: Confirm and Proceed
 
-Present summary, wait for confirmation.
+Present a build plan summary and wait for confirmation:
+
+```
+## Build Plan Summary
+- Source: Screenshot (URL: https://example.com)
+- Capture mode: Chrome DevTools MCP
+- Pages: 3 (Home, Pricing, Dashboard)
+- Components: 12 to generate (8 high, 3 medium, 1 low confidence)
+- Existing to reuse: 4
+- Output target: React + Vite (tailwind + shadcn)
+- App type: web-app
+- Token inference: AI-powered (will need your confirmation in Phase 2)
+
+Proceed with token inference?
+```
+
+Do not continue until the user confirms.
 
 ## Output
 
-**Primary:** `.claude/plans/build-spec.json`
-**Secondary:** Captured screenshots in `.claude/visual-qa/screenshots/source/`
+| Artifact | Path |
+|----------|------|
+| Build spec | `.claude/plans/build-spec.json` |
+| Captured screenshots | `.claude/visual-qa/screenshots/source/page-{n}-{viewport}.png` |
+| Build plan summary | Displayed to user (not written to disk) |
 
 ## Error Handling
 
-- **URL unreachable:** Offer to retry or accept manual screenshots
-- **Screenshots too small/blurry:** Warn about quality, suggest higher resolution
-- **CORS/auth blocking capture:** Ask user to provide screenshots manually
-- **Multi-page site:** Capture homepage, ask which subpages to include
+| Failure | Recovery |
+|---------|----------|
+| **URL unreachable** (network error, DNS failure) | Retry once. If still failing, ask user to verify URL, then fall back to file mode. |
+| **URL behind auth** (401/403, login wall) | Cannot bypass. Ask user to log in and provide screenshots manually (file mode). |
+| **CORS or bot detection** (page captures blank or 403) | Try Playwright MCP fallback (often less detectable). If still blocked, request manual screenshots. |
+| **Rate limiting** (429) | Wait 60s, retry once. If persistent, ask user to wait and re-invoke later. |
+| **Both MCPs unavailable** | Inform user. Ask them to install at least one MCP, or provide screenshots manually. |
+| **Image file missing/unreadable** | List affected paths. Ask user to verify paths or re-provide. |
+| **Image resolution too low** (<1024px wide) | Warn that vision accuracy will degrade. Ask whether to proceed or provide higher-res images. |
+| **Image corrupted** (decode failure) | List affected files. Ask user to re-export or provide alternatives. |
+| **Vision analysis low confidence on most components** | Warn user. Offer to: (a) proceed with low-confidence flags marked in build-spec, (b) capture additional zoomed-in screenshots of key sections, (c) provide manual component list. |
+| **Multi-page nav detection returns 0 links on a known multi-page site** | Treat as single-page. Mention to user that no internal links were detected — ask if they want to provide additional URLs. |
+| **User selects a viewport not in config** | Add the requested viewport to the build-spec but warn that some downstream phases (visual-diff, responsive) may not test it by default. |
+| **Existing build-spec.json present from prior run** | Ask: "Reuse existing build-spec, regenerate, or merge?" — default to reuse if `source` matches. |
 
 ## Integration
 
-- **Consumed by:** `canva-token-inference` (reused for vision-based token extraction), `/build-from-screenshot`
-- **Uses:** Chrome DevTools MCP, Playwright MCP, Claude vision, Glob, Read
+- **Consumed by:** `canva-token-inference` (Phase 2 of `/build-from-screenshot`), `tdd-from-figma` (Phase 3), framework converter agents (Phase 4), `/build-from-screenshot` orchestrator
+- **Uses:** Chrome DevTools MCP (preferred), Playwright MCP (fallback), Claude vision, `AskUserQuestion`, `Glob`, `Read`, `Write`
+- **Config keys read:** `pipeline.config.json` → `screenshot.*`, `appTypes.*`, `screenshotCapture.*`


### PR DESCRIPTION
Closes #43

## Summary
- Rewrites `.claude/skills/screenshot-intake/SKILL.md` from a stub into a self-contained Phase 1 spec for `/build-from-screenshot`
- Removes "identical to canva-intake/figma-intake" cross-references that left the process underspecified
- Adds MCP tool-selection logic (Chrome DevTools default, Playwright fallback, manual fallback) with concrete capture sequences for each path
- Documents multi-page handling for both URL and file modes, plus single-page default
- Includes a concrete `build-spec.json` example with url/file/manual variants
- Expands error handling to 12 failure modes (auth walls, CORS, rate limits, low-res images, missing nav links, viewport mismatches, etc.)

## Acceptance criteria
- [x] Skill has complete, actionable process steps (not references to other skills)
- [x] URL capture workflow documented with MCP tool selection (Chrome DevTools vs Playwright)
- [x] Fallback strategy when MCP tools are unavailable
- [x] Example build-spec.json output for screenshot source
- [x] Multi-page vs single-page handling documented
- [x] Error handling for common failures (URL unreachable, screenshot too low-res, etc.)

## Test plan
- [ ] Run `/build-from-screenshot https://example.com` and verify Phase 1 produces a valid `build-spec.json`
- [ ] Run `/build-from-screenshot ./designs/home.png` and verify file-mode path produces a valid `build-spec.json`
- [ ] Simulate Chrome DevTools MCP unavailable — verify Playwright fallback kicks in
- [ ] Simulate both MCPs unavailable — verify manual fallback prompts the user
- [ ] Provide a multi-page URL with detectable nav links — verify Q1 lists pages and user can select
- [ ] Verify `canva-token-inference` (Phase 2) accepts the generated build-spec without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)