### PR TITLE
Add JSON Schema validation for pipeline.config.json

### DIFF
--- a/.claude/pipeline.config.json
+++ b/.claude/pipeline.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "./pipeline.config.schema.json",
   "description": "Configuration for the Figma-to-React autonomous build pipeline",
   "version": "1.0.0",
   "visualDiff": {
@@ -504,7 +504,7 @@
     "enabled": true,
     "strategy": "content-hash",
     "directory": ".claude/pipeline-cache",
-    "maxAgedays": 7,
+    "maxAgeDays": 7,
     "inputCategories": {
       "source": ["src/**/*.{ts,tsx,js,jsx}", "components/**/*.{ts,tsx}"],
       "styles": ["src/**/*.css", "styles/**/*.css", "tailwind.config.*"],

--- a/.claude/pipeline.config.schema.json
+++ b/.claude/pipeline.config.schema.json
@@ -1,0 +1,697 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/PMDevSolutions/Aurelius/blob/main/.claude/pipeline.config.schema.json",
+  "title": "Aurelius Pipeline Configuration",
+  "description": "Schema for .claude/pipeline.config.json — controls thresholds, iteration limits, app-type definitions, and orchestration for the autonomous build pipeline.",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema URI for IDE validation and autocompletion."
+    },
+    "description": { "type": "string" },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semantic version of the config schema in use."
+    },
+
+    "visualDiff": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Pixel-diff thresholds and analysis options for the visual QA loop.",
+      "properties": {
+        "threshold": { "$ref": "#/$defs/percentageRatio", "description": "Max acceptable mismatch ratio (0-1). 0.02 = 2%." },
+        "antialiasing": { "type": "boolean", "description": "Ignore antialiasing differences when comparing." },
+        "diffColorRgb": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0, "maximum": 255 },
+          "minItems": 3,
+          "maxItems": 3,
+          "description": "RGB color used to highlight differences in the diff image."
+        },
+        "alphaBlending": { "type": "number", "minimum": 0, "maximum": 1, "description": "Opacity of the diff overlay (0-1)." },
+        "breakpoints": { "$ref": "#/$defs/breakpointMap" },
+        "requiredBreakpoints": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Subset of breakpoint names that must pass for a build to be considered successful."
+        },
+        "outputDir": { "type": "string", "description": "Where diff images are written." },
+        "subPixelClassification": { "type": "boolean", "description": "Enable sub-pixel cluster analysis to distinguish rendering noise from real diffs." },
+        "subPixelMaxClusterSize": { "type": "integer", "minimum": 1, "description": "Max cluster size (px) to be considered sub-pixel noise rather than a real difference." },
+        "typographyAnalysis": { "type": "boolean", "description": "Detect font-weight and font-fallback differences." },
+        "fontWeightThreshold": { "type": "number", "minimum": 0, "description": "Sensitivity for font-weight mismatch detection (higher = more permissive)." },
+        "fontFallbackDensityThreshold": { "type": "number", "minimum": 0, "maximum": 1, "description": "Density of pixel differences that signal a font fallback (0-1)." },
+        "layoutDriftAnalysis": { "type": "boolean", "description": "Detect horizontal/vertical layout shifts vs pixel-level color differences." },
+        "layoutShiftThresholdPx": { "type": "number", "minimum": 0, "description": "Px shift above which a region is flagged as a layout drift." }
+      }
+    },
+
+    "iterationLoop": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Controls the auto-fix loop that runs after each visual diff failure.",
+      "properties": {
+        "maxVisualIterations": { "type": "integer", "minimum": 1, "description": "Max times the build/diff/fix loop runs before giving up." },
+        "maxFixAttemptsPerCheck": { "type": "integer", "minimum": 1, "description": "Max fix attempts the agent makes per iteration before re-running the diff." },
+        "diffPassThreshold": { "$ref": "#/$defs/percentageRatio" },
+        "diffWarnThreshold": { "$ref": "#/$defs/percentageRatio" },
+        "regionAnalysis": { "type": "boolean", "description": "Split each diff into a grid of regions to localize fixes." },
+        "regionGridSize": { "type": "integer", "minimum": 1, "description": "Grid dimension (e.g. 4 = 4x4 = 16 regions) for region-based diff analysis." },
+        "stopOnFirstPassingIteration": { "type": "boolean", "description": "Exit the loop as soon as one iteration passes the threshold." }
+      }
+    },
+
+    "tdd": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Test-driven development enforcement for the build pipeline.",
+      "properties": {
+        "enforced": { "type": "boolean", "description": "Hard gate Phase 4 (build) on Phase 3 (tests) completion." },
+        "redPhaseRequired": { "type": "boolean" },
+        "greenPhaseRequired": { "type": "boolean" },
+        "refactorPhaseOptional": { "type": "boolean" },
+        "testExistenceGate": { "type": "boolean", "description": "Block the build until every component has a corresponding test file." },
+        "coverageThreshold": { "$ref": "#/$defs/percentageInt" },
+        "componentTestRequired": { "type": "boolean" },
+        "lockfileAssertionsRequired": { "type": "boolean", "description": "Require tests to assert against design-tokens.lock.json values." }
+      }
+    },
+
+    "e2e": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "End-to-end Playwright test configuration.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "conditionalOnAppType": { "type": "boolean", "description": "Skip E2E for app types whose appTypes.<type>.devServer is false (e.g. react-native)." },
+        "browsers": { "$ref": "#/$defs/browserList" },
+        "crossBrowserBrowsers": { "$ref": "#/$defs/browserList" },
+        "crossBrowserRequired": { "type": "boolean" },
+        "timeoutMs": { "type": "integer", "minimum": 0 },
+        "retries": { "type": "integer", "minimum": 0 },
+        "mobileBrowsers": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["mobile-chrome", "mobile-safari"] }
+        },
+        "crossBrowserDiffThreshold": { "$ref": "#/$defs/percentageRatio" }
+      }
+    },
+
+    "qualityGate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Gate criteria that must pass before Phase 9 (report) runs.",
+      "properties": {
+        "testsRequired": { "type": "boolean" },
+        "typescriptRequired": { "type": "boolean" },
+        "buildRequired": { "type": "boolean" },
+        "tokenVerificationRequired": { "type": "boolean" },
+        "lighthouseRequired": { "type": "boolean" },
+        "lighthouseThresholds": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Minimum Lighthouse category scores (0-100).",
+          "properties": {
+            "performance": { "$ref": "#/$defs/percentageInt" },
+            "accessibility": { "$ref": "#/$defs/percentageInt" },
+            "bestPractices": { "$ref": "#/$defs/percentageInt" },
+            "seo": { "$ref": "#/$defs/percentageInt" }
+          }
+        },
+        "e2eRequired": { "type": "boolean" },
+        "crossBrowserScreenshotsRequired": { "type": "boolean" },
+        "testCoverageEnforced": { "type": "boolean" },
+        "mutationScore": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "threshold": { "$ref": "#/$defs/percentageInt" },
+            "tool": { "type": "string", "enum": ["stryker"] },
+            "blocking": { "type": "boolean", "description": "If false, mutation score is reported but does not fail the gate." }
+          }
+        }
+      }
+    },
+
+    "appTypes": {
+      "type": "object",
+      "description": "Definitions for supported app types. Keys are referenced by build-spec.json.appType.",
+      "additionalProperties": false,
+      "properties": {
+        "web-app": { "$ref": "#/$defs/appType" },
+        "chrome-extension": { "$ref": "#/$defs/appType" },
+        "pwa": { "$ref": "#/$defs/appType" },
+        "react-native": { "$ref": "#/$defs/appType" }
+      }
+    },
+
+    "screenshotCapture": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Default screenshot capture settings used by visual-diff and intake phases.",
+      "properties": {
+        "fullPage": { "type": "boolean" },
+        "format": { "type": "string", "enum": ["png", "jpeg", "webp"] },
+        "quality": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "waitForNetworkIdle": { "type": "boolean" },
+        "waitAfterLoadMs": { "type": "integer", "minimum": 0 },
+        "outputDir": { "type": "string" }
+      }
+    },
+
+    "darkMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "diffThreshold": { "$ref": "#/$defs/percentageRatio" },
+        "emulateMediaFeature": { "type": "string", "description": "Chrome DevTools / Playwright media-feature emulation string, e.g. 'prefers-color-scheme: dark'." },
+        "compareAgainst": { "type": "string", "enum": ["light", "design"], "description": "Whether to diff dark mode against the light-mode capture or against a separate design reference." },
+        "screenshotDir": { "type": "string" }
+      }
+    },
+
+    "storybook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "autoGenerate": { "type": "boolean" },
+        "includeResponsiveViewports": { "type": "boolean" },
+        "viewports": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Names of breakpoints (from visualDiff.breakpoints) to include as Storybook viewports."
+        },
+        "skipPatterns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Glob patterns to exclude from story generation."
+        },
+        "generateMdx": { "type": "boolean" },
+        "maxVariantsPerProp": { "type": "integer", "minimum": 1, "description": "Cap on the number of variants generated per discriminated prop to keep stories navigable." }
+      }
+    },
+
+    "tokenSync": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "autoCheck": { "type": "boolean" },
+        "warnOnDrift": { "type": "boolean" },
+        "autoUpdate": { "type": "boolean", "description": "When true, sync-tokens.sh rewrites the lockfile in place when drift is detected." }
+      }
+    },
+
+    "reporting": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "outputDir": { "type": "string" },
+        "buildReportFile": { "type": "string" },
+        "diffReportFile": { "type": "string" },
+        "e2eReportFile": { "type": "string" },
+        "accessibilityReportFile": { "type": "string" },
+        "includeScreenshots": { "type": "boolean" },
+        "includeDiffImages": { "type": "boolean" }
+      }
+    },
+
+    "security": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "auditLevel": { "type": "string", "enum": ["low", "moderate", "high", "critical"] },
+        "failOnVulnerability": { "type": "boolean" },
+        "checkLockfile": { "type": "boolean" },
+        "snyk": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "severityThreshold": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+            "failOnIssues": { "type": "boolean" }
+          }
+        },
+        "csp": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Content Security Policy options applied to deploy previews.",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "reportOnly": { "type": "boolean" },
+            "reportUri": { "type": "string" }
+          }
+        },
+        "inputSanitization": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "blockPrivateUrls": { "type": "boolean", "description": "Reject URLs in private IP ranges to prevent SSRF in URL-capture mode." },
+            "allowLocalhostInDev": { "type": "boolean" }
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hsts": { "type": "boolean" },
+            "noSniff": { "type": "boolean" },
+            "frameOptions": { "type": "string", "enum": ["DENY", "SAMEORIGIN"] },
+            "xssProtection": { "type": "boolean" },
+            "referrerPolicy": {
+              "type": "string",
+              "enum": [
+                "no-referrer",
+                "no-referrer-when-downgrade",
+                "origin",
+                "origin-when-cross-origin",
+                "same-origin",
+                "strict-origin",
+                "strict-origin-when-cross-origin",
+                "unsafe-url"
+              ]
+            }
+          }
+        }
+      }
+    },
+
+    "bundleSize": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxSizeKb": { "type": "integer", "minimum": 1 },
+        "warnSizeKb": { "type": "integer", "minimum": 1 }
+      }
+    },
+
+    "mutationTesting": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Stryker mutation testing reminder/runner config (also see qualityGate.mutationScore for gate behavior).",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tool": { "type": "string", "enum": ["stryker"] },
+        "scoreThreshold": { "$ref": "#/$defs/percentageInt" },
+        "reminder": { "type": "boolean" }
+      }
+    },
+
+    "errorMonitoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": { "type": "string", "enum": ["sentry"] },
+        "dsn": { "type": "string" },
+        "environment": { "type": "string" },
+        "sampleRate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "tracesSampleRate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "enableInDev": { "type": "boolean" },
+        "sourceMapUpload": { "type": "boolean" }
+      }
+    },
+
+    "deployPreview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "provider": { "type": "string", "enum": ["vercel", "netlify", "cloudflare"] },
+        "autoDeployOnPR": { "type": "boolean" },
+        "runVisualQAOnPreview": { "type": "boolean" },
+        "runLighthouseOnPreview": { "type": "boolean" }
+      }
+    },
+
+    "responsiveVerification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "breakpoints": { "$ref": "#/$defs/breakpointMap" },
+        "diffThreshold": { "$ref": "#/$defs/percentageRatio" },
+        "blocking": { "type": "boolean" }
+      }
+    },
+
+    "regressionTesting": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "baselineDir": { "type": "string" },
+        "screenshotDir": { "type": "string" },
+        "diffDir": { "type": "string" },
+        "threshold": { "$ref": "#/$defs/percentageRatio" },
+        "failOnMissingBaseline": { "type": "boolean" },
+        "updateBaselinesOnPass": { "type": "boolean" },
+        "breakpoints": { "$ref": "#/$defs/breakpointMap" },
+        "waitAfterLoadMs": { "type": "integer", "minimum": 0 },
+        "fullPage": { "type": "boolean" },
+        "routes": { "type": "array", "items": { "type": "string" } },
+        "browsers": { "$ref": "#/$defs/browserList" },
+        "reportFile": { "type": "string" }
+      }
+    },
+
+    "deadCode": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tool": { "type": "string", "enum": ["knip", "ts-prune"] },
+        "ignorePatterns": { "type": "array", "items": { "type": "string" } },
+        "reportUnusedExports": { "type": "boolean" },
+        "reportUnusedDependencies": { "type": "boolean" },
+        "reportUnusedFiles": { "type": "boolean" }
+      }
+    },
+
+    "canva": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tokenInference": { "$ref": "#/$defs/tokenInferenceOptions" },
+        "export": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "format": { "type": "string", "enum": ["png", "jpeg", "webp"] },
+            "scale": { "type": "number", "minimum": 1, "description": "PNG export scale factor (1 = 1x, 2 = 2x retina, 3 = 3x)." },
+            "quality": { "type": "integer", "minimum": 1, "maximum": 100 }
+          }
+        },
+        "mcpServer": { "type": "string" },
+        "restApiFallback": { "type": "boolean" },
+        "retry": { "$ref": "#/$defs/retryOptions" }
+      }
+    },
+
+    "screenshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "tokenInference": { "$ref": "#/$defs/tokenInferenceOptions" },
+        "capture": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "format": { "type": "string", "enum": ["png", "jpeg", "webp"] },
+            "scale": { "type": "number", "minimum": 1 },
+            "quality": { "type": "integer", "minimum": 1, "maximum": 100 },
+            "fullPage": { "type": "boolean" },
+            "waitForNetworkIdle": { "type": "boolean" },
+            "waitAfterLoadMs": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "urlCapture": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "viewports": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "width", "height"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "width": { "type": "integer", "minimum": 1 },
+                  "height": { "type": "integer", "minimum": 1 }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+
+    "orchestration": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Parallel phase execution graph. Phase keys are arbitrary; depends[] entries must reference other keys in the same map.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxConcurrent": { "type": "integer", "minimum": 1, "description": "Max phases that may run simultaneously across the orchestration graph." },
+        "phases": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/$defs/orchestrationPhase" }
+        },
+        "qualityGateSubtasks": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "resources": { "$ref": "#/$defs/resourceList" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "reporting": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "showStreamingResults": { "type": "boolean" },
+            "showBatchSummary": { "type": "boolean" },
+            "showSpeedupEstimate": { "type": "boolean" },
+            "includeTimeline": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
+    "caching": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Content-hash caching of phase outputs to skip unchanged work on rebuild.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "strategy": { "type": "string", "enum": ["content-hash", "mtime"] },
+        "directory": { "type": "string" },
+        "maxAgeDays": { "type": "integer", "minimum": 1, "description": "Cache entries older than this many days are evicted by the cleanup pass." },
+        "inputCategories": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "description": "Named glob groups (e.g. 'source', 'styles') referenced by phaseInputs."
+        },
+        "phaseInputs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "description": "Map phase name → list of inputCategories keys whose changes invalidate that phase."
+        },
+        "invalidateOnConfigChange": { "type": "boolean" }
+      }
+    },
+
+    "profiling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "metricsDirectory": { "type": "string" },
+        "historyLimit": { "type": "integer", "minimum": 1, "description": "Number of build runs to retain in profiling history." },
+        "slowStageThresholdMs": { "type": "integer", "minimum": 0 },
+        "alerts": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "slowStageWarning": { "type": "boolean" },
+            "memoryThresholdMb": { "type": "integer", "minimum": 1 },
+            "trendDegradationPercent": { "type": "number", "minimum": 0, "description": "Percent slowdown vs. historical median that triggers a degradation alert." }
+          }
+        },
+        "reporting": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "generateOnComplete": { "type": "boolean" },
+            "formats": {
+              "type": "array",
+              "items": { "type": "string", "enum": ["md", "json", "html"] }
+            },
+            "includeMemoryMetrics": { "type": "boolean" },
+            "includeTimeline": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
+    "incrementalBuild": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parallelPhases": { "type": "boolean" },
+        "skipCachedPhases": { "type": "boolean" },
+        "forceRebuildOn": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Files whose modification forces a full rebuild regardless of cache state."
+        },
+        "maxParallelPhases": { "type": "integer", "minimum": 1 }
+      }
+    },
+
+    "dashboard": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "outputDirectory": { "type": "string" },
+        "formats": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["html", "md"] }
+        },
+        "autoGenerateAfterBuild": { "type": "boolean" },
+        "includeCharts": { "type": "boolean" },
+        "retentionDays": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+
+  "$defs": {
+    "percentageRatio": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Ratio between 0 and 1 (e.g. 0.02 = 2%)."
+    },
+    "percentageInt": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Whole-number percentage between 0 and 100."
+    },
+    "breakpointMap": {
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 1 },
+      "description": "Map of viewport-name → pixel width."
+    },
+    "browserList": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["chromium", "firefox", "webkit"] }
+    },
+    "appType": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "e2eStrategy", "defaultE2eFlows", "testHarness"],
+      "properties": {
+        "description": { "type": "string" },
+        "e2eStrategy": { "type": "string", "description": "Identifier consumed by e2e-test-generator to choose a test template." },
+        "defaultE2eFlows": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Named flows to generate by default for this app type."
+        },
+        "testHarness": {
+          "type": "string",
+          "enum": ["playwright", "playwright-chromium-persistent", "maestro"],
+          "description": "Which test runner the converter agent should target for this app type."
+        },
+        "devServer": { "type": "boolean", "description": "Whether the pipeline starts pnpm dev before screenshots/E2E for this app type." },
+        "browsers": { "$ref": "#/$defs/browserList" },
+        "firefoxWebExtSupport": { "type": "boolean" },
+        "mobileBrowsers": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["mobile-chrome", "mobile-safari"] }
+        },
+        "browserContextOptions": {
+          "type": "object",
+          "description": "Pass-through options forwarded to Playwright's browserContext. May contain string-interpolated tokens like ${extensionPath}.",
+          "additionalProperties": true
+        },
+        "buildCommand": { "type": "string" },
+        "extensionPathDefault": { "type": "string" },
+        "platforms": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["ios", "android"] }
+        }
+      }
+    },
+    "tokenInferenceOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "confirmWithUser": { "type": "boolean", "description": "Block before writing the lockfile until the user confirms or corrects inferred tokens." },
+        "confidenceThreshold": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "description": "Min confidence level below which a token must be confirmed by the user even if confirmWithUser is false."
+        },
+        "maxInferenceRetries": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "retryOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Exponential-backoff retry config for external API calls.",
+      "properties": {
+        "maxAttempts": { "type": "integer", "minimum": 1 },
+        "initialDelayMs": { "type": "integer", "minimum": 0 },
+        "backoffMultiplier": { "type": "number", "minimum": 1 },
+        "maxDelayMs": { "type": "integer", "minimum": 0 },
+        "retryableErrors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Error codes/keywords that trigger a retry. Other errors fail immediately."
+        }
+      }
+    },
+    "resourceList": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Resource identifier in 'category:name' form (e.g. 'filesystem:tokens', 'port:dev-server'). Two phases declaring the same exclusive resource cannot run concurrently."
+          },
+          {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "mode": { "type": "string", "enum": ["exclusive", "shared"], "description": "Shared = multiple phases may hold this resource simultaneously (e.g. read-only dev server)." }
+            }
+          }
+        ]
+      }
+    },
+    "orchestrationPhase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["depends", "description"],
+      "properties": {
+        "depends": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Phase keys that must complete before this phase starts."
+        },
+        "resources": { "$ref": "#/$defs/resourceList" },
+        "blocking": { "type": "boolean", "description": "When true, failure of this phase fails the whole pipeline. When false, failure is reported but the pipeline continues." },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.claude/*.md
 !.claude/settings.json
 !.claude/pipeline.config.json
+!.claude/pipeline.config.schema.json
 !.claude/test-fixtures/
 
 # Claude Code temporary/user-specific files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,11 @@ node scripts/visual-diff.js --batch <actual-dir> <expected-dir> [--output-dir di
 # Run visual regression tests against baselines
 ./scripts/regression-test.sh [url] [--update-baselines] [--json]
 
+# Validate pipeline.config.json against its JSON Schema
+./scripts/validate-pipeline-config.sh                # Validate live config
+./scripts/validate-pipeline-config.sh --json         # Machine-readable output
+node scripts/validate-pipeline-config.js --config <path> --schema <path>
+
 # Export generated components as a publishable design-system workspace
 ./scripts/export-design-system.sh [--scope @org] [--output dir] [--framework <react|vue|svelte|react-native>] [--dry-run] [--json]
 
@@ -534,6 +539,7 @@ gh issue create               # Create issue
 ./scripts/capture-baselines.sh          # Capture regression baselines
 ./scripts/regression-test.sh            # Visual regression testing
 ./scripts/export-design-system.sh       # Export components + tokens as pnpm workspace
+./scripts/validate-pipeline-config.sh   # Validate pipeline.config.json against schema
 ```
 
 **Build Performance & Caching:**
@@ -550,7 +556,7 @@ node scripts/metrics-dashboard.js summary  # Quick metrics summary
 
 ---
 
-**Last Updated:** 2026-04-14
-**Architecture:** 53 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 31 scripts, 8 hooks
+**Last Updated:** 2026-05-21
+**Architecture:** 53 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 32 scripts, 8 hooks
 
 > **Keeping counts in sync:** When adding or removing agents, skills, scripts, or hooks, update all count references across the project. Search for the old count number in `*.md` files to find all references: `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/onboarding/`, `docs/react-development/`, and `.claude/AGENT-NAMING-GUIDE.md`.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/typescript-checker": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
+    "ajv": "^8.20.0",
     "commit-and-tag-version": "^12.7.1",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.5.0))(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.0(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)))
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       commit-and-tag-version:
         specifier: ^12.7.1
         version: 12.7.1
@@ -742,6 +745,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   angular-html-parser@10.4.0:
     resolution: {integrity: sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==}
@@ -2527,7 +2533,7 @@ snapshots:
   '@commitlint/config-validator@20.5.0':
     dependencies:
       '@commitlint/types': 20.5.0
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   '@commitlint/ensure@20.5.0':
     dependencies:
@@ -3071,6 +3077,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0

--- a/scripts/validate-pipeline-config.js
+++ b/scripts/validate-pipeline-config.js
@@ -63,7 +63,7 @@ function loadJson(path, label) {
   try {
     return JSON.parse(readFileSync(path, "utf-8"));
   } catch (e) {
-    throw new Error(`Failed to parse ${label} (${path}): ${e.message}`);
+    throw new Error(`Failed to parse ${label} (${path}): ${e.message}`, { cause: e });
   }
 }
 

--- a/scripts/validate-pipeline-config.js
+++ b/scripts/validate-pipeline-config.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * validate-pipeline-config.js — Validate .claude/pipeline.config.json against
+ * the project's JSON Schema, plus structural checks the schema cannot express
+ * (orchestration dependency graph, qualityGateSubtasks references, etc.).
+ *
+ * Usage:
+ *   node scripts/validate-pipeline-config.js
+ *   node scripts/validate-pipeline-config.js --config <path>
+ *   node scripts/validate-pipeline-config.js --schema <path>
+ *   node scripts/validate-pipeline-config.js --json
+ *
+ * Exit codes:
+ *   0 — config is valid
+ *   1 — config has schema or structural errors
+ *   2 — usage/IO error (file missing, parse failure, etc.)
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join, dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+const DEFAULT_CONFIG = join(repoRoot, ".claude", "pipeline.config.json");
+const DEFAULT_SCHEMA = join(repoRoot, ".claude", "pipeline.config.schema.json");
+
+function parseArgs(argv) {
+  const out = { config: DEFAULT_CONFIG, schema: DEFAULT_SCHEMA, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--config") out.config = resolve(argv[++i]);
+    else if (a === "--schema") out.schema = resolve(argv[++i]);
+    else if (a === "--json") out.json = true;
+    else if (a === "-h" || a === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${a}`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/validate-pipeline-config.js [options]
+
+Options:
+  --config <path>   Path to config (default: .claude/pipeline.config.json)
+  --schema <path>   Path to schema (default: .claude/pipeline.config.schema.json)
+  --json            Emit machine-readable JSON output
+  -h, --help        Show this message`);
+}
+
+function loadJson(path, label) {
+  if (!existsSync(path)) {
+    throw new Error(`${label} not found at ${path}`);
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch (e) {
+    throw new Error(`Failed to parse ${label} (${path}): ${e.message}`);
+  }
+}
+
+/**
+ * Walk a schema-validation error from ajv and convert to a flat record
+ * with a JSON Pointer-style path for easy reading.
+ */
+function formatSchemaError(err) {
+  const path = err.instancePath || "(root)";
+  const detail = err.message ?? "validation failed";
+  const extras = [];
+  if (err.params?.additionalProperty) {
+    extras.push(`unexpected key "${err.params.additionalProperty}"`);
+  }
+  if (err.params?.allowedValues) {
+    extras.push(`allowed: ${JSON.stringify(err.params.allowedValues)}`);
+  }
+  if (err.params?.missingProperty) {
+    extras.push(`missing "${err.params.missingProperty}"`);
+  }
+  return { path, message: detail, extras };
+}
+
+/**
+ * Structural checks the JSON Schema cannot express:
+ *   - orchestration.phases[*].depends references existing phase keys
+ *   - orchestration graph has no cycles
+ *   - caching.phaseInputs keys reference real inputCategories
+ *   - storybook.viewports reference real visualDiff.breakpoints
+ *   - e2e.requiredBreakpoints reference real visualDiff.breakpoints
+ */
+function structuralChecks(config) {
+  const issues = [];
+
+  // 1. Orchestration dependency graph
+  const phases = config.orchestration?.phases;
+  if (phases && typeof phases === "object") {
+    const names = new Set(Object.keys(phases));
+    for (const [name, def] of Object.entries(phases)) {
+      for (const dep of def.depends ?? []) {
+        if (!names.has(dep)) {
+          issues.push({
+            path: `/orchestration/phases/${name}/depends`,
+            message: `references unknown phase "${dep}"`,
+          });
+        }
+      }
+    }
+    // Cycle detection (Kahn's algorithm). Only count edges to existing phases so
+    // a missing-dep error doesn't masquerade as a cycle.
+    const incoming = Object.fromEntries(Object.keys(phases).map((n) => [n, 0]));
+    for (const [name, def] of Object.entries(phases)) {
+      for (const dep of def.depends ?? []) {
+        if (names.has(dep)) incoming[name]++;
+      }
+    }
+    const queue = Object.keys(incoming).filter((n) => incoming[n] === 0);
+    const visited = new Set();
+    while (queue.length) {
+      const n = queue.shift();
+      visited.add(n);
+      for (const [m, def] of Object.entries(phases)) {
+        if ((def.depends ?? []).includes(n)) {
+          incoming[m]--;
+          if (incoming[m] === 0) queue.push(m);
+        }
+      }
+    }
+    if (visited.size !== Object.keys(phases).length) {
+      const cyclic = Object.keys(phases).filter((n) => !visited.has(n));
+      issues.push({
+        path: "/orchestration/phases",
+        message: `dependency cycle detected involving: ${cyclic.join(", ")}`,
+      });
+    }
+  }
+
+  // 2. caching.phaseInputs → inputCategories
+  const caching = config.caching;
+  if (caching?.phaseInputs && caching?.inputCategories) {
+    const categories = new Set(Object.keys(caching.inputCategories));
+    for (const [phase, inputs] of Object.entries(caching.phaseInputs)) {
+      for (const cat of inputs ?? []) {
+        if (!categories.has(cat)) {
+          issues.push({
+            path: `/caching/phaseInputs/${phase}`,
+            message: `references unknown inputCategory "${cat}"`,
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Breakpoint name references
+  const breakpoints = config.visualDiff?.breakpoints;
+  if (breakpoints) {
+    const known = new Set(Object.keys(breakpoints));
+    for (const name of config.visualDiff?.requiredBreakpoints ?? []) {
+      if (!known.has(name)) {
+        issues.push({
+          path: "/visualDiff/requiredBreakpoints",
+          message: `"${name}" not defined in /visualDiff/breakpoints`,
+        });
+      }
+    }
+    for (const name of config.storybook?.viewports ?? []) {
+      if (!known.has(name)) {
+        issues.push({
+          path: "/storybook/viewports",
+          message: `"${name}" not defined in /visualDiff/breakpoints`,
+        });
+      }
+    }
+  }
+
+  // 4. qualityGate.mutationScore.threshold vs mutationTesting.scoreThreshold drift
+  const gateThreshold = config.qualityGate?.mutationScore?.threshold;
+  const runnerThreshold = config.mutationTesting?.scoreThreshold;
+  if (
+    gateThreshold !== undefined &&
+    runnerThreshold !== undefined &&
+    gateThreshold !== runnerThreshold
+  ) {
+    issues.push({
+      path: "/qualityGate/mutationScore/threshold",
+      message: `disagrees with /mutationTesting/scoreThreshold (${gateThreshold} vs ${runnerThreshold}) — gate and runner may behave inconsistently`,
+    });
+  }
+
+  return issues;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  let config;
+  let schema;
+  try {
+    config = loadJson(args.config, "Config");
+    schema = loadJson(args.schema, "Schema");
+  } catch (e) {
+    if (args.json) console.log(JSON.stringify({ ok: false, error: e.message }));
+    else console.error(`✗ ${e.message}`);
+    process.exit(2);
+  }
+
+  // Dynamically import ajv. If missing, give a clear remediation hint.
+  let Ajv2020;
+  try {
+    ({ default: Ajv2020 } = await import("ajv/dist/2020.js"));
+  } catch {
+    const msg = "ajv is not installed. Run `pnpm install` (or `pnpm add -D ajv`) and retry.";
+    if (args.json) console.log(JSON.stringify({ ok: false, error: msg }));
+    else console.error(`✗ ${msg}`);
+    process.exit(2);
+  }
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema);
+  const ok = validate(config);
+
+  const schemaErrors = (validate.errors ?? []).map(formatSchemaError);
+  const structural = structuralChecks(config);
+
+  const totalIssues = schemaErrors.length + structural.length;
+  const pass = ok && structural.length === 0;
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: pass,
+          configPath: args.config,
+          schemaPath: args.schema,
+          schemaErrors,
+          structuralIssues: structural,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`Validating ${args.config}`);
+    console.log(`Against     ${args.schema}\n`);
+
+    if (pass) {
+      console.log(`✓ Config is valid (${Object.keys(config).length} top-level sections)`);
+    } else {
+      if (schemaErrors.length) {
+        console.log(`✗ Schema errors (${schemaErrors.length}):`);
+        for (const err of schemaErrors) {
+          const extras = err.extras.length ? ` — ${err.extras.join("; ")}` : "";
+          console.log(`  ${err.path}: ${err.message}${extras}`);
+        }
+      }
+      if (structural.length) {
+        console.log(`✗ Structural issues (${structural.length}):`);
+        for (const err of structural) {
+          console.log(`  ${err.path}: ${err.message}`);
+        }
+      }
+      console.log(`\nFix ${totalIssues} issue(s) and re-run.`);
+    }
+  }
+
+  process.exit(pass ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error(`✗ Unhandled error: ${e.stack ?? e.message}`);
+  process.exit(2);
+});

--- a/scripts/validate-pipeline-config.sh
+++ b/scripts/validate-pipeline-config.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# validate-pipeline-config.sh — Validate .claude/pipeline.config.json against
+# its JSON Schema. Thin wrapper around validate-pipeline-config.js so the
+# scripts/ directory exposes both .sh and .js entrypoints (consistent with the
+# project's other tools).
+#
+# Usage:
+#   ./scripts/validate-pipeline-config.sh
+#   ./scripts/validate-pipeline-config.sh --json
+#   ./scripts/validate-pipeline-config.sh --config <path> --schema <path>
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/validate-pipeline-config.js" "$@"


### PR DESCRIPTION
Closes #45

## Summary
- Adds `.claude/pipeline.config.schema.json` (JSON Schema 2020-12) covering all 29 top-level sections of `pipeline.config.json`, with `additionalProperties: false` everywhere to catch typos
- Adds `scripts/validate-pipeline-config.{js,sh}` — an ajv-backed validator that reports schema errors plus structural issues the schema can't express (orchestration dependency graph, `caching.phaseInputs` cross-refs, breakpoint name lookups, mutation-score threshold drift)
- Wires `\$schema` in `pipeline.config.json` to the new file so VS Code / JetBrains get autocompletion and hover docs
- Fixes the live `maxAgedays` → `maxAgeDays` typo and confirms the runtime in `pipeline-cache.js` already uses the correct camelCase
- Allowlists the schema file in `.gitignore` (which globs `.claude/*`)

## Acceptance criteria
- [x] JSON Schema file (`pipeline.config.schema.json`) covering all config sections
- [x] Schema includes descriptions for non-obvious fields (`regionGridSize`, `maxConcurrent`, `subPixelMaxClusterSize`, `slowStageThresholdMs`, etc.)
- [x] Validation script or integration that checks config against schema
- [x] Schema referenced in `pipeline.config.json` via `\$schema` field for IDE support

## Validator output

Live config:
\`\`\`
✓ Config is valid (29 top-level sections)
\`\`\`

Synthetic bad config (typo + out-of-range + missing phase ref):
\`\`\`
✗ Schema errors (2):
  /qualityGate/lighthouseThresholds/performance: must be <= 100
  /caching: must NOT have additional properties — unexpected key \"maxAgedays\"
✗ Structural issues (1):
  /orchestration/phases/report/depends: references unknown phase \"phantom-phase\"
\`\`\`

Real dependency cycle:
\`\`\`
✗ Structural issues (1):
  /orchestration/phases: dependency cycle detected involving: intake, token-lock, ...
\`\`\`

## Test plan
- [x] \`node scripts/validate-pipeline-config.js\` exits 0 on the live config
- [x] Validator exits 1 on schema errors, missing phase refs, and real cycles
- [x] Validator exits 2 on IO/parse failures (config or schema missing)
- [x] Validator distinguishes a missing-dep from a cycle (no false-positive cycle when a dep is just typo'd)
- [ ] Open \`pipeline.config.json\` in VS Code with the schema reference and confirm hover docs / autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)