### PR TITLE
Extract inline hooks to dedicated files with tests and docs

### DIFF
--- a/.claude/hooks/bundle-size-guard.sh
+++ b/.claude/hooks/bundle-size-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# bundle-size-guard.sh — PostToolUse hook
+# Warns when the existing build artifacts exceed bundleSize.maxSizeKb from
+# pipeline.config.json. Fires when the agent runs `git commit` so the warning
+# arrives at the natural review point.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT (unused)
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+trap 'exit 0' ERR
+
+if ! echo "$TOOL_INPUT" | grep -q "git commit"; then
+  exit 0
+fi
+
+# Pick the first build directory that exists.
+BUILD_DIR=""
+for d in .next dist build out; do
+  if [ -d "$d" ]; then
+    BUILD_DIR="$d"
+    break
+  fi
+done
+if [ -z "$BUILD_DIR" ]; then
+  exit 0
+fi
+
+if ! command -v du >/dev/null 2>&1; then
+  exit 0
+fi
+SIZE_KB="$(du -sk "$BUILD_DIR" 2>/dev/null | cut -f1)"
+if [ -z "$SIZE_KB" ]; then
+  exit 0
+fi
+
+# Default max = 200 KB. Overridden by pipeline.config.json -> bundleSize.maxSizeKb.
+MAX_KB=200
+if [ -f .claude/pipeline.config.json ] && command -v node >/dev/null 2>&1; then
+  PARSED="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.bundleSize?.maxSizeKb ?? 200);' 2>/dev/null)" || PARSED=""
+  if [ -n "$PARSED" ]; then
+    MAX_KB="$PARSED"
+  fi
+fi
+
+if [ "$SIZE_KB" -gt "$MAX_KB" ]; then
+  echo "[bundle-guard] $BUILD_DIR is ${SIZE_KB}KB, above the ${MAX_KB}KB limit. Run: ./scripts/check-bundle-size.sh"
+fi
+
+exit 0

--- a/.claude/hooks/coverage-check.sh
+++ b/.claude/hooks/coverage-check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# coverage-check.sh — PostToolUse hook
+# Reminds the agent to check the configured coverage threshold after running
+# `vitest` with coverage output.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+if echo "$TOOL_INPUT" | grep -q "vitest" \
+   && echo "$TOOL_OUTPUT" | grep -qE "[Cc]overage"; then
+  THRESHOLD=80
+  if [ -f .claude/pipeline.config.json ] && command -v node >/dev/null 2>&1; then
+    PARSED="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.tdd?.coverageThreshold ?? 80);' 2>/dev/null)" || PARSED=""
+    if [ -n "$PARSED" ]; then
+      THRESHOLD="$PARSED"
+    fi
+  fi
+  echo "[coverage-check] Review coverage output above. Ensure it meets the ${THRESHOLD}% threshold from pipeline.config.json."
+fi
+
+exit 0

--- a/.claude/hooks/dark-mode-reminder.sh
+++ b/.claude/hooks/dark-mode-reminder.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# dark-mode-reminder.sh — PostToolUse hook
+# Suggests running dark-mode verification after a visual-diff run reports PASS.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+if echo "$TOOL_INPUT" | grep -q "visual-diff.js" \
+   && echo "$TOOL_OUTPUT" | grep -q "PASS"; then
+  echo "[dark-mode-reminder] Visual diff passed. Consider running dark mode verification: ./scripts/check-dark-mode.sh"
+fi
+
+exit 0

--- a/.claude/hooks/lighthouse-ci.sh
+++ b/.claude/hooks/lighthouse-ci.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# lighthouse-ci.sh — PostToolUse hook
+# Suggests a Lighthouse audit after a successful pnpm build, including the
+# performance and accessibility thresholds from pipeline.config.json.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+if ! echo "$TOOL_INPUT" | grep -q "pnpm build"; then
+  exit 0
+fi
+if ! echo "$TOOL_OUTPUT" | grep -q "built in"; then
+  exit 0
+fi
+
+CONFIG=".claude/pipeline.config.json"
+PERF=80
+A11Y=90
+
+if [ -f "$CONFIG" ] && command -v node >/dev/null 2>&1; then
+  P="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.qualityGate?.lighthouseThresholds?.performance ?? 80);' 2>/dev/null)" || P=""
+  A="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.qualityGate?.lighthouseThresholds?.accessibility ?? 90);' 2>/dev/null)" || A=""
+  [ -n "$P" ] && PERF="$P"
+  [ -n "$A" ] && A11Y="$A"
+fi
+
+echo "[lighthouse-ci] Build done. Run Lighthouse audit — thresholds: performance=${PERF}, accessibility=${A11Y}. Use: npx lighthouse <url> --output=json"
+
+exit 0

--- a/.claude/hooks/mutation-test-reminder.sh
+++ b/.claude/hooks/mutation-test-reminder.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# mutation-test-reminder.sh — PostToolUse hook
+# Suggests running Stryker mutation tests after a fully-passing vitest run,
+# but only when pipeline.config.json -> mutationTesting.reminder is true.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+if ! echo "$TOOL_INPUT" | grep -q "vitest"; then
+  exit 0
+fi
+if ! echo "$TOOL_OUTPUT" | grep -qE "Tests\s+[0-9]+ passed"; then
+  exit 0
+fi
+
+if [ ! -f .claude/pipeline.config.json ] || ! command -v node >/dev/null 2>&1; then
+  exit 0
+fi
+
+REMINDER="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.mutationTesting?.reminder ?? false);' 2>/dev/null)" || REMINDER="false"
+
+if [ "$REMINDER" = "true" ]; then
+  echo "[mutation-test] All tests passed. Consider running mutation tests to validate test quality: npx stryker run"
+fi
+
+exit 0

--- a/.claude/hooks/post-build-qa.sh
+++ b/.claude/hooks/post-build-qa.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# post-build-qa.sh — PostToolUse hook
+# Reminds the agent to run the quality gate after a successful pnpm build.
+#
+# Args:
+#   $1  TOOL_INPUT   The Bash command Claude just ran.
+#   $2  TOOL_OUTPUT  The stdout/stderr returned by that command.
+#
+# Exit: always 0. Hook output goes to stdout; absence of output means no reminder.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+
+# Tolerate any unexpected runtime error — hooks must never break the parent call.
+trap 'exit 0' ERR
+
+if echo "$TOOL_INPUT" | grep -q "pnpm build" \
+   && echo "$TOOL_OUTPUT" | grep -q "built in"; then
+  echo "[post-build-qa] Build succeeded. Run quality gate: pnpm vitest run && pnpm tsc --noEmit && ./scripts/verify-tokens.sh"
+fi
+
+exit 0

--- a/.claude/hooks/pre-commit-token-guard.sh
+++ b/.claude/hooks/pre-commit-token-guard.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# pre-commit-token-guard.sh — PostToolUse hook
+# When the agent runs `git commit`, runs verify-tokens.sh and surfaces any
+# token-violation summary so the agent can fix them before the commit is
+# considered done. Does not block the commit — Claude's tool call has already
+# completed by the time this fires.
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT (unused; the commit's own output isn't relevant here)
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+trap 'exit 0' ERR
+
+if ! echo "$TOOL_INPUT" | grep -q "git commit"; then
+  exit 0
+fi
+
+if [ ! -f src/styles/design-tokens.lock.json ] || [ ! -d src ]; then
+  exit 0
+fi
+
+if [ ! -x ./scripts/verify-tokens.sh ]; then
+  exit 0
+fi
+
+RESULT="$(./scripts/verify-tokens.sh 2>&1)" || EXIT=$?
+EXIT="${EXIT:-0}"
+
+if [ "$EXIT" -ne 0 ]; then
+  echo "[pre-commit-guard] Token violations found. Fix before committing:"
+  echo "$RESULT" | tail -5
+fi
+
+exit 0

--- a/.claude/hooks/regression-reminder.sh
+++ b/.claude/hooks/regression-reminder.sh
@@ -1,12 +1,35 @@
 #!/usr/bin/env bash
-# regression-reminder.sh — PostToolUse hook: remind about regression tests
-TOOL_INPUT="$1"
-TOOL_OUTPUT="$2"
+# regression-reminder.sh — PostToolUse hook
+# Suggests running visual regression tests after a successful build, but only
+# when baseline screenshots already exist (otherwise there's nothing to diff).
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
 
-# Only trigger on pnpm build success
-if echo "$TOOL_INPUT" | grep -q "pnpm build" && echo "$TOOL_OUTPUT" | grep -q "Build\|build.*complete\|Successfully compiled"; then
-  BASELINE_COUNT=$(find .claude/visual-qa/baselines -name "*.png" 2>/dev/null | wc -l)
-  if [ "$BASELINE_COUNT" -gt 0 ]; then
-    echo "REGRESSION: $BASELINE_COUNT baselines exist. Run ./scripts/regression-test.sh to check for visual regressions."
-  fi
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+if ! echo "$TOOL_INPUT" | grep -q "pnpm build"; then
+  exit 0
 fi
+if ! echo "$TOOL_OUTPUT" | grep -qE "Build|build.*complete|Successfully compiled|built in"; then
+  exit 0
+fi
+
+if [ ! -d .claude/visual-qa/baselines ]; then
+  exit 0
+fi
+
+BASELINE_COUNT="$(find .claude/visual-qa/baselines -name "*.png" 2>/dev/null | wc -l | tr -d ' ')"
+if [ -z "$BASELINE_COUNT" ] || [ "$BASELINE_COUNT" = "0" ]; then
+  exit 0
+fi
+
+echo "[regression-reminder] $BASELINE_COUNT baselines exist. Run ./scripts/regression-test.sh to check for visual regressions."
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,43 +6,43 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"pnpm build\" && echo \"$TOOL_OUTPUT\" | grep -q \"built in\"; then echo \"[post-build-qa] Build succeeded. Run quality gate: pnpm vitest run && pnpm tsc --noEmit && ./scripts/verify-tokens.sh\"; fi'",
+            "command": "bash .claude/hooks/post-build-qa.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Remind to run quality gate after successful builds during the pipeline"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"git commit\"; then if [ -f src/styles/design-tokens.lock.json ] && [ -d src ]; then RESULT=$(./scripts/verify-tokens.sh 2>&1); EXIT=$?; if [ $EXIT -ne 0 ]; then echo \"[pre-commit-guard] Token violations found. Fix before committing:\"; echo \"$RESULT\" | tail -5; fi; fi; fi'",
+            "command": "bash .claude/hooks/pre-commit-token-guard.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Check for token violations before git commits"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"visual-diff.js\" && echo \"$TOOL_OUTPUT\" | grep -q \"PASS\"; then echo \"[dark-mode-reminder] Visual diff passed. Consider running dark mode verification: ./scripts/check-dark-mode.sh\"; fi'",
+            "command": "bash .claude/hooks/dark-mode-reminder.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Remind to run dark mode verification after visual diff passes"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"vitest\" && echo \"$TOOL_OUTPUT\" | grep -qE \"[Cc]overage\"; then echo \"[coverage-check] Review coverage output above. Ensure it meets the 80% threshold in pipeline.config.json.\"; fi'",
+            "command": "bash .claude/hooks/coverage-check.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Remind to check coverage threshold after test runs with coverage"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"pnpm build\" && echo \"$TOOL_OUTPUT\" | grep -q \"built in\"; then CONFIG=\".claude/pipeline.config.json\"; if [ -f \"$CONFIG\" ]; then PERF=$(node -e \"const c=require(\\\"./\\\" + process.argv[1]); console.log(c.qualityGate?.lighthouseThresholds?.performance ?? 80)\" \"$CONFIG\" 2>/dev/null || echo 80); A11Y=$(node -e \"const c=require(\\\"./\\\" + process.argv[1]); console.log(c.qualityGate?.lighthouseThresholds?.accessibility ?? 90)\" \"$CONFIG\" 2>/dev/null || echo 90); echo \"[lighthouse-ci] Build done. Run Lighthouse audit — thresholds: performance=$PERF, accessibility=$A11Y. Use: npx lighthouse <url> --output=json\"; fi; fi'",
+            "command": "bash .claude/hooks/lighthouse-ci.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Suggest Lighthouse audit after successful builds with threshold targets"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"git commit\"; then if [ -d \".next\" ] || [ -d \"dist\" ]; then BUILD_DIR=$( [ -d \".next\" ] && echo \".next\" || echo \"dist\" ); SIZE_KB=$(du -sk \"$BUILD_DIR\" 2>/dev/null | cut -f1); CONFIG=\".claude/pipeline.config.json\"; MAX=$(node -e \"const c=require(\\\"./\\\" + process.argv[1]); console.log((c.bundleSize?.maxSizeKb ?? 200) * 1024)\" \"$CONFIG\" 2>/dev/null || echo 204800); if [ \"$SIZE_KB\" -gt \"$MAX\" ]; then echo \"[bundle-guard] Bundle size ${SIZE_KB}KB exceeds limit. Run: ./scripts/check-bundle-size.sh\"; fi; fi; fi'",
+            "command": "bash .claude/hooks/bundle-size-guard.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Warn if bundle size exceeds configured limit before commits"
           },
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"vitest\" && echo \"$TOOL_OUTPUT\" | grep -qE \"Tests\\s+[0-9]+ passed\"; then CONFIG=\".claude/pipeline.config.json\"; REMINDER=$(node -e \"const c=require(\\\"./\\\" + process.argv[1]); console.log(c.mutationTesting?.reminder ?? false)\" \"$CONFIG\" 2>/dev/null || echo false); if [ \"$REMINDER\" = \"true\" ]; then echo \"[mutation-test] All tests passed. Consider running mutation tests to validate test quality: npx stryker run\"; fi; fi'",
+            "command": "bash .claude/hooks/mutation-test-reminder.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
             "description": "Suggest mutation testing after all tests pass"
           },
           {
             "type": "command",
             "command": "bash .claude/hooks/regression-reminder.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
-            "description": "Reminds to run visual regression tests after successful builds"
+            "description": "Remind to run visual regression tests after successful builds"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,18 +389,18 @@ Quality gate subtasks (coverage, typecheck, build, token-verify, lighthouse) als
 
 ### Automated Hooks (8 Total)
 
-Configured in `.claude/settings.json` as `PostToolUse` hooks on the `Bash` matcher:
+Each hook is a standalone script under `.claude/hooks/`, registered in `.claude/settings.json` as a `PostToolUse` hook on the `Bash` matcher. Hooks receive `$TOOL_INPUT` and `$TOOL_OUTPUT` as positional args, follow a defensive skeleton (`set -u`, `trap 'exit 0' ERR`, always `exit 0`), and are testable in isolation. See [docs/guides/hooks.md](docs/guides/hooks.md) for the full guide.
 
-| Hook | Trigger | Action |
-|------|---------|--------|
-| Post-build QA reminder | `pnpm build` succeeds | Reminds to run quality gate (vitest, tsc, verify-tokens) |
-| Pre-commit token guard | `git commit` detected | Runs `verify-tokens.sh`, warns if violations found |
-| Dark mode reminder | `visual-diff.js` passes | Suggests running `check-dark-mode.sh` |
-| Coverage enforcement | `vitest` with coverage output | Reminds to check 80% threshold from pipeline config |
-| Lighthouse CI | `pnpm build` succeeds | Suggests Lighthouse audit with threshold targets from config |
-| Bundle size guard | `git commit` detected | Warns if build output exceeds maxSizeKb from config |
-| Mutation testing reminder | `vitest` all tests pass | Suggests running Stryker for test quality validation |
-| Regression reminder | `pnpm build` succeeds | Suggests running `./scripts/regression-test.sh` if baselines exist |
+| Script | Trigger | Action |
+|--------|---------|--------|
+| `post-build-qa.sh` | `pnpm build` succeeds | Reminds to run quality gate (vitest, tsc, verify-tokens) |
+| `pre-commit-token-guard.sh` | `git commit` detected | Runs `verify-tokens.sh`, warns if violations found |
+| `dark-mode-reminder.sh` | `visual-diff.js` passes | Suggests running `check-dark-mode.sh` |
+| `coverage-check.sh` | `vitest` with coverage output | Reminds to check threshold from pipeline config |
+| `lighthouse-ci.sh` | `pnpm build` succeeds | Suggests Lighthouse audit with threshold targets from config |
+| `bundle-size-guard.sh` | `git commit` detected | Warns if build output exceeds maxSizeKb from config |
+| `mutation-test-reminder.sh` | `vitest` all tests pass | Suggests running Stryker for test quality validation |
+| `regression-reminder.sh` | `pnpm build` succeeds | Suggests running `./scripts/regression-test.sh` if baselines exist |
 
 ---
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -1,21 +1,21 @@
 # Hook System
 
-Hooks are shell commands that run automatically after Claude Code tool-use events. They provide automated reminders, guards, and quality checks without requiring manual intervention. All hooks are configured in `.claude/settings.json`.
+Hooks are shell scripts that run automatically after Claude Code tool-use events. They provide automated reminders, guards, and quality checks without requiring manual intervention. Each hook lives in its own file under `.claude/hooks/` and is wired into `.claude/settings.json`.
 
 ## How Hooks Fire
 
-The `PostToolUse` event fires every time the Bash tool completes inside Claude Code. When this happens, the runtime iterates through all hooks with `"matcher": "Bash"` and executes each one. Two environment variables are available to every hook command:
+The `PostToolUse` event fires every time the Bash tool completes inside Claude Code. The runtime iterates through every hook with `"matcher": "Bash"` and executes each one with two positional arguments:
 
-| Variable | Contents |
+| Argument | Contents |
 |----------|----------|
-| `$TOOL_INPUT` | The command that was run (e.g. `pnpm build`, `git commit -m "feat: add hero"`) |
-| `$TOOL_OUTPUT` | The stdout/stderr returned by the command |
+| `$1` (`TOOL_INPUT`) | The command that was run, e.g. `pnpm build` or `git commit -m "feat: add hero"` |
+| `$2` (`TOOL_OUTPUT`) | The stdout/stderr returned by that command |
 
-Each hook uses `grep` or other pattern-matching against these variables to decide whether to print a message. If the hook produces output, the message is shown to the user. If it produces no output, the hook passes silently.
+Each hook pattern-matches these inputs to decide whether to print a reminder. Output on stdout is shown to the user; no output means the hook stayed silent.
 
 ## Hook Configuration Format
 
-Hooks live in the `hooks` object inside `.claude/settings.json`:
+Hooks live in `hooks.PostToolUse[].hooks[]` in `.claude/settings.json`:
 
 ```json
 {
@@ -26,8 +26,8 @@ Hooks live in the `hooks` object inside `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"pattern\"; then echo \"[hook-name] message\"; fi'",
-            "description": "Human-readable description"
+            "command": "bash .claude/hooks/<hook-name>.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
+            "description": "Human-readable summary"
           }
         ]
       }
@@ -36,118 +36,195 @@ Hooks live in the `hooks` object inside `.claude/settings.json`:
 }
 ```
 
-Each hook entry has three fields:
-
 | Field | Purpose |
 |-------|---------|
 | `type` | Always `"command"` |
-| `command` | The shell command to execute. Receives `$TOOL_INPUT` and `$TOOL_OUTPUT` |
-| `description` | Shown to users in Claude Code. Describe what the hook does |
+| `command` | Invokes the hook script, passing the two tool variables as positional args |
+| `description` | Shown to users in Claude Code; describe what the hook does in plain English |
+
+Old inline shell snippets (`bash -c '...'`) are no longer used. Every hook is a file under `.claude/hooks/` so it can be edited, reviewed, and tested in isolation.
 
 ## Execution Order
 
-All hooks in the array run sequentially after the Bash tool completes. Execution follows array position in `settings.json` -- the first entry runs first, the second runs second, and so on. Each hook is independent; one hook's output does not affect another.
+Hooks run **sequentially** in the order they appear in the `hooks` array. The first entry runs first, the second runs second, and so on. The current order is:
 
-A hook that prints text shows a visible message. A hook that prints nothing passes silently. Both outcomes are normal.
+1. `post-build-qa.sh`
+2. `pre-commit-token-guard.sh`
+3. `dark-mode-reminder.sh`
+4. `coverage-check.sh`
+5. `lighthouse-ci.sh`
+6. `bundle-size-guard.sh`
+7. `mutation-test-reminder.sh`
+8. `regression-reminder.sh`
+
+Each hook is independent — one hook's output does not influence the next. Reordering the array changes only the visual order of reminders in the terminal.
+
+Hooks must complete quickly (target: under 2 seconds each). They run after every matching Bash tool use, so a slow hook becomes a tax on the whole session.
 
 ## Built-In Hooks
 
-The framework ships with 8 hooks covering build quality, commit safety, and testing reminders:
+| Hook script | Triggers when | Action |
+|-------------|---------------|--------|
+| `post-build-qa.sh` | `pnpm build` succeeds (`built in` in output) | Reminds to run quality gate (vitest, tsc, verify-tokens) |
+| `pre-commit-token-guard.sh` | `git commit` detected in input | Runs `verify-tokens.sh`, surfaces violations |
+| `dark-mode-reminder.sh` | `visual-diff.js` + `PASS` in output | Suggests `check-dark-mode.sh` |
+| `coverage-check.sh` | `vitest` + `Coverage` in output | Reminds to verify against `tdd.coverageThreshold` |
+| `lighthouse-ci.sh` | `pnpm build` succeeds | Suggests Lighthouse audit using thresholds from config |
+| `bundle-size-guard.sh` | `git commit` and a build dir exists | Warns if build dir exceeds `bundleSize.maxSizeKb` |
+| `mutation-test-reminder.sh` | `vitest` + passing-tests line | Suggests Stryker when `mutationTesting.reminder` is `true` |
+| `regression-reminder.sh` | `pnpm build` succeeds | Suggests regression test if baselines exist |
 
-| Hook | Trigger | Action |
-|------|---------|--------|
-| Post-build QA | `pnpm build` succeeds (`built in` in output) | Reminds to run quality gate: vitest, tsc, verify-tokens |
-| Pre-commit token guard | `git commit` detected in input | Runs `verify-tokens.sh`, warns if violations found |
-| Dark mode reminder | `visual-diff.js` in input + `PASS` in output | Suggests running `check-dark-mode.sh` |
-| Coverage enforcement | `vitest` in input + `Coverage` in output | Reminds to check 80% threshold from pipeline.config.json |
-| Lighthouse CI | `pnpm build` succeeds | Suggests Lighthouse audit with thresholds from config (perf=80, a11y=90) |
-| Bundle size guard | `git commit` + build dir exists | Checks dir size against `maxSizeKb` from config, warns if exceeded |
-| Mutation testing reminder | `vitest` + `Tests N passed` in output | Suggests Stryker if `mutationTesting.reminder` is true in config |
-| Regression reminder | `pnpm build` succeeds | Calls `regression-reminder.sh` to suggest regression tests if baselines exist |
+Most hooks match on **both** `$TOOL_INPUT` (what command ran) and `$TOOL_OUTPUT` (what it returned) to keep false triggers down.
 
-Notice the pattern: most hooks match on both `$TOOL_INPUT` (what command ran) and `$TOOL_OUTPUT` (what it returned). Matching on both reduces false triggers.
+## Hook Script Anatomy
+
+Every hook follows the same skeleton:
+
+```bash
+#!/usr/bin/env bash
+# my-hook.sh — short description of what this hook does
+#
+# Args:
+#   $1  TOOL_INPUT
+#   $2  TOOL_OUTPUT
+#
+# Exit: always 0.
+
+set -u
+TOOL_INPUT="${1:-}"
+TOOL_OUTPUT="${2:-}"
+trap 'exit 0' ERR
+
+# Decide whether to fire.
+if echo "$TOOL_INPUT" | grep -q "<trigger>"; then
+  echo "[my-hook] reminder text"
+fi
+
+exit 0
+```
+
+The defensive bits matter:
+
+| Pattern | Why |
+|---------|-----|
+| `set -u` | Catches typos / unset variables early, preventing silent skips |
+| `${1:-}` defaults | Tolerates being called with no args (e.g. from a test) |
+| `trap 'exit 0' ERR` | Any unexpected runtime error exits silently rather than crashing |
+| Final `exit 0` | Hooks are informational and must never block the workflow |
+| `[hook-name]` prefix | Makes it easy to identify which hook produced a message in the terminal |
+
+Reading thresholds from `pipeline.config.json` follows the same defensive pattern: try Node, fall back to a hard-coded default if `node` is unavailable or the field is missing.
+
+```bash
+THRESHOLD=80
+if [ -f .claude/pipeline.config.json ] && command -v node >/dev/null 2>&1; then
+  PARSED="$(node -e 'const c=require("./.claude/pipeline.config.json"); console.log(c.tdd?.coverageThreshold ?? 80);' 2>/dev/null)" || PARSED=""
+  [ -n "$PARSED" ] && THRESHOLD="$PARSED"
+fi
+```
 
 ## Creating a Custom Hook
 
-### Step by step
+### 1. Write the script
 
-1. Open `.claude/settings.json`
-2. Find the `hooks.PostToolUse[0].hooks` array
-3. Add a new object with `type`, `command`, and `description`
-4. Write a bash command that pattern-matches `$TOOL_INPUT` and/or `$TOOL_OUTPUT`
-5. Test by running the triggering command in Claude Code
+Create `.claude/hooks/my-hook.sh`. Use the skeleton above and `chmod +x` it:
 
-### Example: Changelog reminder after git tag
+```bash
+chmod +x .claude/hooks/my-hook.sh
+```
+
+### 2. Register it in settings.json
+
+Append a new entry to `hooks.PostToolUse[0].hooks`:
 
 ```json
 {
   "type": "command",
-  "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"git tag\"; then echo \"[changelog] New tag created. Remember to update CHANGELOG.md\"; fi'",
+  "command": "bash .claude/hooks/my-hook.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
+  "description": "What the hook does (shown to users)"
+}
+```
+
+### 3. Test in isolation
+
+Hooks accept tool input and output as plain args, so you can run them directly:
+
+```bash
+# Trigger case
+bash .claude/hooks/my-hook.sh "pnpm test" "Tests  42 passed"
+# → expected: prints reminder, exit 0
+
+# No-trigger case
+bash .claude/hooks/my-hook.sh "ls" "file.txt"
+# → expected: prints nothing, exit 0
+
+# Robustness
+bash .claude/hooks/my-hook.sh
+# → expected: prints nothing, exit 0 (no crash on missing args)
+```
+
+For automated coverage, add a vitest spec under `scripts/__tests__/hooks.test.js`. The existing file is a good template — it spins up a temp project, invokes each hook with controlled inputs, and asserts on stdout + exit code.
+
+### Example — changelog reminder after git tag
+
+`.claude/hooks/changelog-reminder.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -u
+TOOL_INPUT="${1:-}"
+trap 'exit 0' ERR
+
+if echo "$TOOL_INPUT" | grep -q "git tag"; then
+  echo "[changelog-reminder] New tag created. Update CHANGELOG.md if you haven't."
+fi
+exit 0
+```
+
+`.claude/settings.json` addition:
+
+```json
+{
+  "type": "command",
+  "command": "bash .claude/hooks/changelog-reminder.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
   "description": "Remind to update changelog after creating git tags"
 }
 ```
 
-### Example: Warn when installing a new dependency
-
-```json
-{
-  "type": "command",
-  "command": "bash -c 'if echo \"$TOOL_INPUT\" | grep -q \"pnpm add\"; then echo \"[dep-check] New dependency added. Run ./scripts/check-security.sh to audit.\"; fi'",
-  "description": "Suggest security audit after adding dependencies"
-}
-```
-
-## Hook Scripts Directory
-
-When a hook grows too complex for a single inline bash command, extract the logic to a script file in `.claude/hooks/` and call it from settings.json.
-
-The regression reminder hook demonstrates this pattern. Instead of cramming file-counting logic into a JSON string, it delegates to a script:
-
-```json
-{
-  "type": "command",
-  "command": "bash .claude/hooks/regression-reminder.sh \"$TOOL_INPUT\" \"$TOOL_OUTPUT\"",
-  "description": "Reminds to run visual regression tests after successful builds"
-}
-```
-
-The script at `.claude/hooks/regression-reminder.sh` receives the two arguments, does its grep checks and baseline counting, and echoes a message only when appropriate.
-
-When writing hook scripts:
-- Accept `$1` (tool input) and `$2` (tool output) as positional arguments
-- Echo a message when the hook should fire; print nothing otherwise
-- Exit with code 0 in all cases
-
 ## Best Practices
 
-- **Keep hooks fast.** They run after every matching Bash tool use. Aim for under 2 seconds.
-- **Exit 0 for reminders.** Hooks are informational. Use exit code 0 so they never block the workflow.
-- **Match carefully.** Pattern-match on both `$TOOL_INPUT` and `$TOOL_OUTPUT` when possible to avoid false triggers.
-- **Prefix output with `[hook-name]`.** This makes it easy to identify which hook produced a message.
-- **Extract complex logic.** If your command exceeds one or two conditions, move it to a script in `.claude/hooks/`.
-- **Read thresholds from config.** When a hook checks a limit (bundle size, coverage), read it from `pipeline.config.json` rather than hardcoding.
+- **Keep hooks fast** — under 2 seconds each. They run on every matching Bash tool use.
+- **Always `exit 0`** — hooks are informational, never blocking. A non-zero exit may interrupt Claude Code's flow.
+- **Match on both input and output** when possible — single-side matching causes false triggers.
+- **Prefix output with `[hook-name]`** — makes terminal messages skimmable.
+- **Read thresholds from config** — never hard-code. Fall back to a default if the config or `node` is unavailable.
+- **Use `set -u` and `trap 'exit 0' ERR`** — catches typos and absorbs unexpected errors.
+- **Tolerate missing tooling** — guard each external command with `command -v` and `[ -f ... ]` checks.
 
 ## Troubleshooting
 
 **Hook not firing**
-Check that your `grep` pattern matches the actual command string. Test it manually:
+Test the trigger pattern manually:
 ```bash
 echo "pnpm build --production" | grep -q "pnpm build" && echo "match"
 ```
-If the pattern uses special characters, make sure they are properly escaped inside the JSON string.
+If the script is the issue, run it directly with sample inputs (`bash .claude/hooks/foo.sh "..." "..."`).
 
 **Hook firing too often**
-Tighten the pattern. Match on both input and output instead of just one:
+Tighten the pattern — match on both input and output instead of one:
 ```bash
-# Too broad -- fires on any vitest run
+# Too broad — fires on any vitest run
 if echo "$TOOL_INPUT" | grep -q "vitest"; then ...
 
-# Better -- only fires when coverage output is present
+# Better — only fires when coverage output is present
 if echo "$TOOL_INPUT" | grep -q "vitest" && echo "$TOOL_OUTPUT" | grep -q "Coverage"; then ...
 ```
 
 **Hook blocking workflow**
-Make sure the hook script always exits with code 0. A non-zero exit code may interrupt Claude Code's execution flow.
+Confirm the script ends with `exit 0` and uses `trap 'exit 0' ERR`. Avoid `set -e` — it makes the hook exit non-zero on any failed command.
 
 **Hook output not visible**
-The hook must echo to stdout. Check for quoting issues in the JSON command string -- mismatched quotes are the most common cause of silent failures. Test the command directly in a terminal first.
+The hook must echo to stdout, not stderr. Run the script directly in a terminal to confirm it produces output. Also double-check the settings.json command quoting — escaped quotes around `$TOOL_INPUT` are required so the shell expands the variable but treats it as one argument.
+
+**Hook script not executable**
+Run `chmod +x .claude/hooks/<name>.sh`. The `bash <path>` invocation in settings.json also works without the executable bit, but committing the bit avoids confusion when running the script directly.

--- a/docs/onboarding/architecture.md
+++ b/docs/onboarding/architecture.md
@@ -342,18 +342,18 @@ GitHub integration is via the `gh` CLI (not a plugin): `gh pr create`, `gh issue
 
 ## Hooks (8 Automated)
 
-Configured in `.claude/settings.json` as `PostToolUse` hooks on the `Bash` matcher. These run automatically after specific commands.
+Configured in `.claude/settings.json` as `PostToolUse` hooks on the `Bash` matcher. Each hook is a stand-alone script under `.claude/hooks/` that receives `$TOOL_INPUT` and `$TOOL_OUTPUT` as positional args and decides whether to print a reminder. See the [Hook System guide](../guides/hooks.md) for the full anatomy, execution order, error-handling pattern, and how to add custom hooks.
 
-| Hook | Triggers On | Action |
-|------|-------------|--------|
-| Post-build QA reminder | `pnpm build` succeeds | Suggests running quality gate checks |
-| Pre-commit token guard | `git commit` detected | Runs `verify-tokens.sh`, warns on violations |
-| Dark mode reminder | `visual-diff.js` passes | Suggests running dark mode verification |
-| Coverage enforcement | `vitest` with coverage output | Reminds to check 80% threshold |
-| Lighthouse CI | `pnpm build` succeeds | Suggests Lighthouse audit with config thresholds |
-| Bundle size guard | `git commit` detected | Warns if build exceeds `maxSizeKb` |
-| Mutation testing reminder | All vitest tests pass | Suggests running Stryker for test quality |
-| Regression reminder | `pnpm build` succeeds | Suggests regression test if baselines exist |
+| Script | Triggers On | Action |
+|--------|-------------|--------|
+| `post-build-qa.sh` | `pnpm build` succeeds | Suggests running quality gate checks |
+| `pre-commit-token-guard.sh` | `git commit` detected | Runs `verify-tokens.sh`, warns on violations |
+| `dark-mode-reminder.sh` | `visual-diff.js` passes | Suggests running dark mode verification |
+| `coverage-check.sh` | `vitest` with coverage output | Reminds to check coverage threshold |
+| `lighthouse-ci.sh` | `pnpm build` succeeds | Suggests Lighthouse audit with config thresholds |
+| `bundle-size-guard.sh` | `git commit` detected | Warns if build exceeds `maxSizeKb` |
+| `mutation-test-reminder.sh` | All vitest tests pass | Suggests running Stryker for test quality |
+| `regression-reminder.sh` | `pnpm build` succeeds | Suggests regression test if baselines exist |
 
 ---
 

--- a/scripts/__tests__/hooks.test.js
+++ b/scripts/__tests__/hooks.test.js
@@ -40,11 +40,11 @@ function tmpProject() {
 
 function runHook(name, cwd, toolInput = "", toolOutput = "") {
   try {
-    const stdout = execFileSync(
-      "bash",
-      [join(HOOKS_DIR, name), toolInput, toolOutput],
-      { encoding: "utf-8", timeout: 15000, cwd },
-    );
+    const stdout = execFileSync("bash", [join(HOOKS_DIR, name), toolInput, toolOutput], {
+      encoding: "utf-8",
+      timeout: 15000,
+      cwd,
+    });
     return { stdout, exitCode: 0 };
   } catch (err) {
     return {
@@ -92,12 +92,7 @@ describe("post-build-qa.sh", () => {
 
 describe("dark-mode-reminder.sh", () => {
   it("emits reminder after visual-diff PASS", () => {
-    const r = runHook(
-      "dark-mode-reminder.sh",
-      tmpProject(),
-      "node scripts/visual-diff.js",
-      "PASS",
-    );
+    const r = runHook("dark-mode-reminder.sh", tmpProject(), "node scripts/visual-diff.js", "PASS");
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain("[dark-mode-reminder]");
   });
@@ -205,12 +200,7 @@ describe("mutation-test-reminder.sh", () => {
       join(dir, ".claude", "pipeline.config.json"),
       JSON.stringify({ mutationTesting: { reminder: false } }),
     );
-    const r = runHook(
-      "mutation-test-reminder.sh",
-      dir,
-      "pnpm vitest run",
-      "Tests  10 passed (10)",
-    );
+    const r = runHook("mutation-test-reminder.sh", dir, "pnpm vitest run", "Tests  10 passed (10)");
     expect(r.stdout).toBe("");
   });
 });
@@ -223,12 +213,7 @@ describe("pre-commit-token-guard.sh", () => {
   });
 
   it("stays silent when no lockfile exists", () => {
-    const r = runHook(
-      "pre-commit-token-guard.sh",
-      tmpProject(),
-      "git commit -m feat",
-      "",
-    );
+    const r = runHook("pre-commit-token-guard.sh", tmpProject(), "git commit -m feat", "");
     expect(r.stdout).toBe("");
   });
 });
@@ -243,10 +228,7 @@ describe("regression-reminder.sh", () => {
   it("emits reminder when baselines exist", () => {
     const dir = tmpProject();
     mkdirSync(join(dir, ".claude", "visual-qa", "baselines"), { recursive: true });
-    writeFileSync(
-      join(dir, ".claude", "visual-qa", "baselines", "home.png"),
-      "fake",
-    );
+    writeFileSync(join(dir, ".claude", "visual-qa", "baselines", "home.png"), "fake");
     const r = runHook("regression-reminder.sh", dir, "pnpm build", "built in 1.0s");
     expect(r.stdout).toContain("[regression-reminder]");
     expect(r.stdout).toContain("1 baselines");

--- a/scripts/__tests__/hooks.test.js
+++ b/scripts/__tests__/hooks.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync } from "child_process";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from "fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+const HOOKS_DIR = join(repoRoot, ".claude", "hooks");
+
+/**
+ * Tests for the PostToolUse hooks in .claude/hooks/.
+ *
+ * Each hook is invoked as `bash <hook>.sh <TOOL_INPUT> <TOOL_OUTPUT>`
+ * and exits 0 even when emitting a reminder. Stdout carries the reminder text
+ * (empty if the hook decided not to fire).
+ */
+
+let counter = 0;
+
+function tmpProject() {
+  counter++;
+  const dir = join(__dirname, "fixtures", `hooks-${counter}-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  // Drop a minimal pipeline config so the config-reading hooks have data.
+  mkdirSync(join(dir, ".claude"), { recursive: true });
+  writeFileSync(
+    join(dir, ".claude", "pipeline.config.json"),
+    JSON.stringify({
+      tdd: { coverageThreshold: 85 },
+      qualityGate: {
+        lighthouseThresholds: { performance: 90, accessibility: 95 },
+      },
+      bundleSize: { maxSizeKb: 50 },
+      mutationTesting: { reminder: true },
+    }),
+  );
+  return dir;
+}
+
+function runHook(name, cwd, toolInput = "", toolOutput = "") {
+  try {
+    const stdout = execFileSync(
+      "bash",
+      [join(HOOKS_DIR, name), toolInput, toolOutput],
+      { encoding: "utf-8", timeout: 15000, cwd },
+    );
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      exitCode: err.status,
+    };
+  }
+}
+
+afterAll(() => {
+  const fixtures = join(__dirname, "fixtures");
+  if (existsSync(fixtures)) {
+    try {
+      for (const e of readdirSync(fixtures)) {
+        if (e.startsWith("hooks-")) {
+          rmSync(join(fixtures, e), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe("post-build-qa.sh", () => {
+  it("emits reminder after a successful pnpm build", () => {
+    const r = runHook("post-build-qa.sh", tmpProject(), "pnpm build", "built in 1.2s");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("[post-build-qa]");
+    expect(r.stdout).toContain("pnpm vitest run");
+  });
+
+  it("stays silent for unrelated commands", () => {
+    const r = runHook("post-build-qa.sh", tmpProject(), "pnpm dev", "ready");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("exits 0 with no args", () => {
+    const r = runHook("post-build-qa.sh", tmpProject());
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe("dark-mode-reminder.sh", () => {
+  it("emits reminder after visual-diff PASS", () => {
+    const r = runHook(
+      "dark-mode-reminder.sh",
+      tmpProject(),
+      "node scripts/visual-diff.js",
+      "PASS",
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("[dark-mode-reminder]");
+  });
+
+  it("stays silent on FAIL output", () => {
+    const r = runHook(
+      "dark-mode-reminder.sh",
+      tmpProject(),
+      "node scripts/visual-diff.js",
+      "FAIL: 5% mismatch",
+    );
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("coverage-check.sh", () => {
+  it("uses tdd.coverageThreshold from config", () => {
+    const r = runHook(
+      "coverage-check.sh",
+      tmpProject(),
+      "pnpm vitest run --coverage",
+      "Coverage report: ...",
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("[coverage-check]");
+    expect(r.stdout).toContain("85% threshold");
+  });
+
+  it("falls back to 80% when config missing", () => {
+    const dir = join(__dirname, "fixtures", `hooks-bare-${counter++}-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const r = runHook(
+      "coverage-check.sh",
+      dir,
+      "pnpm vitest run --coverage",
+      "Coverage report: ...",
+    );
+    expect(r.stdout).toContain("80% threshold");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("lighthouse-ci.sh", () => {
+  it("emits config thresholds after build", () => {
+    const r = runHook("lighthouse-ci.sh", tmpProject(), "pnpm build", "built in 2.4s");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("performance=90");
+    expect(r.stdout).toContain("accessibility=95");
+  });
+
+  it("stays silent if build did not finish", () => {
+    const r = runHook("lighthouse-ci.sh", tmpProject(), "pnpm build", "compiling...");
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("bundle-size-guard.sh", () => {
+  it("warns when dist exceeds the configured limit", () => {
+    const dir = tmpProject();
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    // Write a file larger than the 50 KB limit set in tmpProject().
+    writeFileSync(join(dir, "dist", "big.js"), "x".repeat(60 * 1024));
+    const r = runHook("bundle-size-guard.sh", dir, "git commit -m feat", "");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("[bundle-guard]");
+    expect(r.stdout).toMatch(/above the 50KB limit/);
+  });
+
+  it("stays silent when no build dir exists", () => {
+    const r = runHook("bundle-size-guard.sh", tmpProject(), "git commit -m feat", "");
+    expect(r.stdout).toBe("");
+  });
+
+  it("stays silent for non-commit commands", () => {
+    const r = runHook("bundle-size-guard.sh", tmpProject(), "pnpm test", "");
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("mutation-test-reminder.sh", () => {
+  it("emits reminder when config reminder=true and tests pass", () => {
+    const r = runHook(
+      "mutation-test-reminder.sh",
+      tmpProject(),
+      "pnpm vitest run",
+      "Tests  42 passed (42)",
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("[mutation-test]");
+  });
+
+  it("stays silent when no passing-tests line", () => {
+    const r = runHook(
+      "mutation-test-reminder.sh",
+      tmpProject(),
+      "pnpm vitest run",
+      "Tests  3 failed",
+    );
+    expect(r.stdout).toBe("");
+  });
+
+  it("stays silent when reminder=false", () => {
+    const dir = tmpProject();
+    writeFileSync(
+      join(dir, ".claude", "pipeline.config.json"),
+      JSON.stringify({ mutationTesting: { reminder: false } }),
+    );
+    const r = runHook(
+      "mutation-test-reminder.sh",
+      dir,
+      "pnpm vitest run",
+      "Tests  10 passed (10)",
+    );
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("pre-commit-token-guard.sh", () => {
+  it("stays silent for non-commit commands", () => {
+    const r = runHook("pre-commit-token-guard.sh", tmpProject(), "ls", "");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("stays silent when no lockfile exists", () => {
+    const r = runHook(
+      "pre-commit-token-guard.sh",
+      tmpProject(),
+      "git commit -m feat",
+      "",
+    );
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("regression-reminder.sh", () => {
+  it("stays silent when no baselines exist", () => {
+    const r = runHook("regression-reminder.sh", tmpProject(), "pnpm build", "built in 1.0s");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("emits reminder when baselines exist", () => {
+    const dir = tmpProject();
+    mkdirSync(join(dir, ".claude", "visual-qa", "baselines"), { recursive: true });
+    writeFileSync(
+      join(dir, ".claude", "visual-qa", "baselines", "home.png"),
+      "fake",
+    );
+    const r = runHook("regression-reminder.sh", dir, "pnpm build", "built in 1.0s");
+    expect(r.stdout).toContain("[regression-reminder]");
+    expect(r.stdout).toContain("1 baselines");
+  });
+
+  it("stays silent for non-build commands", () => {
+    const r = runHook("regression-reminder.sh", tmpProject(), "ls", "");
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("hook robustness", () => {
+  const hooks = [
+    "post-build-qa.sh",
+    "pre-commit-token-guard.sh",
+    "dark-mode-reminder.sh",
+    "coverage-check.sh",
+    "lighthouse-ci.sh",
+    "bundle-size-guard.sh",
+    "mutation-test-reminder.sh",
+    "regression-reminder.sh",
+  ];
+
+  for (const hook of hooks) {
+    it(`${hook} exits 0 with no args`, () => {
+      const r = runHook(hook, tmpProject());
+      expect(r.exitCode).toBe(0);
+    });
+
+    it(`${hook} exits 0 with empty strings`, () => {
+      const r = runHook(hook, tmpProject(), "", "");
+      expect(r.exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
Closes #46

## Summary
- Extracts 7 inline shell snippets from \`.claude/settings.json\` into standalone scripts under \`.claude/hooks/\`. Every hook is now a file, matching the original \`regression-reminder.sh\` pattern.
- Hardens all 8 hooks with the same defensive skeleton: \`set -u\`, \`trap 'exit 0' ERR\`, default args via \`\${1:-}\`, and a final \`exit 0\` so hooks never block the parent tool call.
- Config-reading hooks (coverage threshold, Lighthouse thresholds, bundle-size limit, mutation reminder flag) gracefully fall back to defaults when \`node\` is missing or the field is absent.
- Adds \`scripts/__tests__/hooks.test.js\` — **36 vitest cases** covering trigger behavior, silence on non-matching input, no-arg robustness, and fixture-based scenarios for bundle-size and regression hooks.
- Rewrites \`docs/guides/hooks.md\` to document the file-based architecture, execution order, defensive skeleton, custom-hook authoring, isolation testing, and troubleshooting.
- Updates \`CLAUDE.md\` and \`docs/onboarding/architecture.md\` hook tables to use filename identifiers and link to the guide.

## Acceptance criteria
- [x] Each hook extracted to its own file in \`.claude/hooks/\`
- [x] \`settings.json\` updated to reference external files
- [x] Each hook file has error handling (\`set -u\`, \`trap 'exit 0' ERR\`, \`exit 0\` on all paths)
- [x] Documentation page explaining hook system, execution order, and how to create custom hooks (\`docs/guides/hooks.md\`)
- [x] Hooks are testable in isolation (\`scripts/__tests__/hooks.test.js\`, 36/36 passing)

## Test plan
- [x] \`pnpm vitest run scripts/__tests__/hooks.test.js\` → 36 passed
- [x] \`pnpm eslint scripts/__tests__/hooks.test.js\` → no errors
- [x] \`node -e \"JSON.parse(...settings.json)\"\` → valid JSON
- [x] Each hook smoke-tested by hand with trigger and non-trigger inputs
- [ ] Trigger a real \`pnpm build\` in a project to confirm the post-build-qa, lighthouse-ci, and regression-reminder hooks fire end-to-end through Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)