### PR TITLE
Add /verify-all and /ci slash commands

### DIFF
--- a/.claude/commands/ci.md
+++ b/.claude/commands/ci.md
@@ -1,0 +1,94 @@
+---
+allowed-tools: Bash, Read
+---
+
+# /ci — CI-Optimized Verification
+
+Runs the same checks as `/verify-all` but in non-interactive, machine-readable mode. Designed for CI pipelines, pre-merge gates, and automation: no prompts, JSON output, exit code reflects overall pass/fail.
+
+## Usage
+
+```
+/ci
+/ci --skip dead-code,security
+/ci --include lint-and-format,types,tests
+```
+
+The slash command wraps `./scripts/verify-all.sh --ci`. The `--ci` flag implies `--json` and sets non-interactive behavior. Pass `--skip` or `--include` to filter checks.
+
+## What runs
+
+Same eight checks as `/verify-all`, in the same order:
+
+```
+lint-and-format → types → tests → accessibility → tokens → dead-code → security → bundle-size
+```
+
+`bundle-size` is automatically skipped when no build artifact (`dist/`, `.next/`, `build/`, `out/`) is present. No other check requires a dev server, so all of them run in CI without extra setup.
+
+## Output
+
+JSON written to stdout:
+
+```json
+{
+  "ok": false,
+  "summary": { "pass": 6, "fail": 1, "skip": 1, "total": 8 },
+  "checks": [
+    { "name": "lint-and-format", "status": "pass", "exitCode": 0, "durationMs": 2618, "reason": "" },
+    { "name": "types",           "status": "fail", "exitCode": 1, "durationMs": 1843, "reason": "exit 1" },
+    { "name": "tests",           "status": "pass", "exitCode": 0, "durationMs": 4205, "reason": "" },
+    ...
+    { "name": "bundle-size",     "status": "skip", "exitCode": 0, "durationMs": 0,    "reason": "no build artifact (dist/.next/build/out)" }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | `true` only when every check passed or was skipped intentionally |
+| `summary.pass` / `fail` / `skip` / `total` | Counts across all checks |
+| `checks[].status` | `pass` \| `fail` \| `skip` |
+| `checks[].exitCode` | The exit code returned by the underlying check script |
+| `checks[].durationMs` | Wall-clock duration |
+| `checks[].reason` | Empty on pass; short reason on fail/skip |
+
+## Steps
+
+### 1. Run the orchestrator in CI mode
+
+```bash
+./scripts/verify-all.sh --ci $ARGUMENTS
+```
+
+### 2. Surface results to the user
+
+Parse the JSON and report the summary in plain text:
+
+```
+6 passed, 1 failed, 1 skipped
+Failing: types (exit 1, 1843ms)
+```
+
+When invoked from a CI pipeline, pipe the JSON straight to a downstream step or store it as a build artifact.
+
+## Exit codes
+
+- `0` — every check passed or was skipped
+- `1` — one or more checks failed
+
+The exit code is what CI runners pivot on, so do not swallow it.
+
+## Differences vs `/verify-all`
+
+| Aspect | `/verify-all` | `/ci` |
+|--------|---------------|-------|
+| Output | Human-readable summary table | JSON to stdout |
+| Interactivity | Allowed (no prompts today, but reserved) | Forbidden |
+| Use case | Local development | CI pipelines, automation, scripts |
+| Exit code on failure | 1 | 1 |
+
+## Related
+
+- `/verify-all` — human-readable version of the same checks
+- `./scripts/verify-all.sh --help` — full flag documentation

--- a/.claude/commands/verify-all.md
+++ b/.claude/commands/verify-all.md
@@ -1,0 +1,86 @@
+---
+allowed-tools: Bash, Read
+---
+
+# /verify-all — Run All Local Quality Checks
+
+Runs every local quality check in sequence and reports a pass/fail summary. Wraps `./scripts/verify-all.sh` so you do not have to remember each individual script.
+
+## Usage
+
+```
+/verify-all
+/verify-all --skip dead-code,security
+/verify-all --include lint-and-format,types,tests
+```
+
+Optional flags forward to the underlying script:
+- `--skip <a,b,c>` — skip named checks (comma-separated)
+- `--include <a,b>` — run only the named checks
+- `--list` — list available check names and exit
+
+For machine-readable output and CI-style behavior, use `/ci` instead.
+
+## What runs
+
+The orchestrator runs these checks in order. Each is independent — a failure in one does not stop the others.
+
+| # | Check | Backing script | What it does |
+|---|-------|----------------|--------------|
+| 1 | `lint-and-format` | `lint-and-format.sh --check` | ESLint + Prettier (no auto-fix) |
+| 2 | `types` | `check-types.sh` | `tsc --noEmit` |
+| 3 | `tests` | `run-tests.sh` | Vitest with coverage |
+| 4 | `accessibility` | `check-accessibility.sh` | ESLint with `jsx-a11y` rules |
+| 5 | `tokens` | `verify-tokens.sh` | Hardcoded-value scan vs lockfile |
+| 6 | `dead-code` | `check-dead-code.sh` | Knip: unused exports/files/deps |
+| 7 | `security` | `check-security.sh` | Dependency audit + anti-pattern scan |
+| 8 | `bundle-size` | `check-bundle-size.sh` | Bundle analysis (skipped if no build artifact) |
+
+## Steps
+
+### 1. Run the orchestrator
+
+```bash
+./scripts/verify-all.sh $ARGUMENTS
+```
+
+The script prints per-check progress and a summary table at the end:
+
+```
+=== Summary ===
+Check              Status Duration   Reason
+-----              ------ --------   ------
+lint-and-format    pass   2618ms
+types              pass   1843ms
+tests              pass   4205ms
+accessibility      pass   1102ms
+tokens             pass   320ms
+dead-code          pass   2980ms
+security           pass   4111ms
+bundle-size        skip   0ms        no build artifact (dist/.next/build/out)
+
+Totals: 7 passed, 0 failed, 1 skipped
+
+✓ All checks passed.
+```
+
+### 2. If any check fails
+
+The summary lists the exact command to reproduce each failure with full output. Re-run that one script to see the underlying errors:
+
+```bash
+./scripts/lint-and-format.sh --check
+```
+
+Once the failing check is fixed, re-run `/verify-all` to confirm.
+
+## Exit codes
+
+- `0` — every check passed (or was skipped intentionally)
+- `1` — one or more checks failed
+
+## Related
+
+- `/ci` — same checks, JSON output, non-interactive (for automation / CI)
+- `/lint` — lint and format only
+- `/test` — tests only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,12 @@ Claude: [Uses test-writer-fixer agent]
 /export-design-system [flags] # Export components + tokens as publishable pnpm workspace
 ```
 
+**Quality Verification:**
+```bash
+/verify-all                   # Run every local quality check, human-readable summary
+/ci                           # Same checks, JSON output, non-zero exit on failure
+```
+
 **Git Workflows (via commit-commands):**
 ```bash
 /commit                       # Structured commit
@@ -540,6 +546,8 @@ gh issue create               # Create issue
 ./scripts/regression-test.sh            # Visual regression testing
 ./scripts/export-design-system.sh       # Export components + tokens as pnpm workspace
 ./scripts/validate-pipeline-config.sh   # Validate pipeline.config.json against schema
+./scripts/verify-all.sh                 # Run all quality checks with summary
+./scripts/verify-all.sh --ci            # CI mode: JSON output, exit 1 on any failure
 ```
 
 **Build Performance & Caching:**
@@ -557,6 +565,6 @@ node scripts/metrics-dashboard.js summary  # Quick metrics summary
 ---
 
 **Last Updated:** 2026-05-21
-**Architecture:** 53 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 32 scripts, 8 hooks
+**Architecture:** 53 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 33 scripts, 8 hooks
 
 > **Keeping counts in sync:** When adding or removing agents, skills, scripts, or hooks, update all count references across the project. Search for the old count number in `*.md` files to find all references: `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/onboarding/`, `docs/react-development/`, and `.claude/AGENT-NAMING-GUIDE.md`.

--- a/scripts/__tests__/verify-all.test.js
+++ b/scripts/__tests__/verify-all.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync } from "child_process";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync, chmodSync } from "fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+const SCRIPT = join(repoRoot, "scripts", "verify-all.sh");
+
+/**
+ * Tests for scripts/verify-all.sh
+ *
+ * Strategy: build a temp project that contains stub scripts at the paths the
+ * orchestrator expects, then invoke verify-all.sh from that project root.
+ * Each stub exits with a known code so we can assert the orchestrator threads
+ * everything through correctly without depending on the real (slow) checks.
+ */
+
+let counter = 0;
+
+const ALL_CHECKS = [
+  ["lint-and-format", "lint-and-format.sh"],
+  ["types", "check-types.sh"],
+  ["tests", "run-tests.sh"],
+  ["accessibility", "check-accessibility.sh"],
+  ["tokens", "verify-tokens.sh"],
+  ["dead-code", "check-dead-code.sh"],
+  ["security", "check-security.sh"],
+  ["bundle-size", "check-bundle-size.sh"],
+];
+
+function tmpProject({ failing = [], hasBuild = false } = {}) {
+  counter++;
+  const dir = join(__dirname, "fixtures", `verify-all-${counter}-${Date.now()}`);
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+
+  for (const [name, file] of ALL_CHECKS) {
+    const exit = failing.includes(name) ? 1 : 0;
+    const path = join(dir, "scripts", file);
+    writeFileSync(path, `#!/usr/bin/env bash\necho "$0 ran"\nexit ${exit}\n`);
+    chmodSync(path, 0o755);
+  }
+
+  if (hasBuild) {
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "dist", "index.js"), "x");
+  }
+
+  return dir;
+}
+
+function run(cwd, args = []) {
+  try {
+    const stdout = execFileSync("bash", [SCRIPT, ...args], {
+      encoding: "utf-8",
+      timeout: 30000,
+      cwd,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      exitCode: err.status,
+    };
+  }
+}
+
+afterAll(() => {
+  const fixtures = join(__dirname, "fixtures");
+  if (existsSync(fixtures)) {
+    try {
+      for (const e of readdirSync(fixtures)) {
+        if (e.startsWith("verify-all-")) {
+          rmSync(join(fixtures, e), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // best-effort cleanup
+    }
+  }
+});
+
+describe("--list", () => {
+  it("prints all check names and exits 0", () => {
+    const r = run(tmpProject(), ["--list"]);
+    expect(r.exitCode).toBe(0);
+    for (const [name] of ALL_CHECKS) {
+      expect(r.stdout).toContain(name);
+    }
+  });
+});
+
+describe("all checks pass", () => {
+  it("exits 0 and reports each check in human mode", () => {
+    const r = run(tmpProject({ hasBuild: true }));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/All checks passed/);
+    for (const [name] of ALL_CHECKS) {
+      expect(r.stdout).toContain(name);
+    }
+  });
+
+  it("exits 0 in --ci JSON mode with ok=true", () => {
+    const r = run(tmpProject({ hasBuild: true }), ["--ci"]);
+    expect(r.exitCode).toBe(0);
+    const json = JSON.parse(r.stdout);
+    expect(json.ok).toBe(true);
+    expect(json.summary.fail).toBe(0);
+    expect(json.summary.total).toBe(8);
+    expect(json.checks).toHaveLength(8);
+    for (const check of json.checks) {
+      expect(["pass", "skip"]).toContain(check.status);
+    }
+  });
+});
+
+describe("failing checks", () => {
+  it("exits 1 when any check fails", () => {
+    const r = run(tmpProject({ failing: ["types"], hasBuild: true }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("Some checks failed");
+    expect(r.stdout).toContain("check-types.sh");
+  });
+
+  it("--ci returns ok=false and lists each failure", () => {
+    const r = run(tmpProject({ failing: ["lint-and-format", "tests"], hasBuild: true }), ["--ci"]);
+    expect(r.exitCode).toBe(1);
+    const json = JSON.parse(r.stdout);
+    expect(json.ok).toBe(false);
+    expect(json.summary.fail).toBe(2);
+    const failedNames = json.checks
+      .filter((c) => c.status === "fail")
+      .map((c) => c.name)
+      .sort();
+    expect(failedNames).toEqual(["lint-and-format", "tests"]);
+  });
+});
+
+describe("--skip and --include", () => {
+  it("--skip marks excluded checks as skip with the filter reason", () => {
+    const r = run(tmpProject({ hasBuild: true }), ["--ci", "--skip", "tests,security"]);
+    const json = JSON.parse(r.stdout);
+    const skipped = json.checks.filter((c) => c.status === "skip").map((c) => c.name);
+    expect(skipped).toEqual(expect.arrayContaining(["tests", "security"]));
+    const tests = json.checks.find((c) => c.name === "tests");
+    expect(tests.reason).toContain("filtered");
+  });
+
+  it("--include runs only the named checks", () => {
+    const r = run(tmpProject({ hasBuild: true }), ["--ci", "--include", "tokens,types"]);
+    const json = JSON.parse(r.stdout);
+    const passed = json.checks.filter((c) => c.status === "pass").map((c) => c.name);
+    expect(passed.sort()).toEqual(["tokens", "types"]);
+    // The other six should all be skipped.
+    expect(json.summary.pass).toBe(2);
+    expect(json.summary.skip).toBe(6);
+  });
+
+  it("failure inside --include still triggers exit 1", () => {
+    const r = run(tmpProject({ failing: ["tokens"], hasBuild: true }), [
+      "--ci",
+      "--include",
+      "tokens",
+    ]);
+    expect(r.exitCode).toBe(1);
+    const json = JSON.parse(r.stdout);
+    expect(json.ok).toBe(false);
+  });
+});
+
+describe("bundle-size conditional", () => {
+  it("skips bundle-size when no build artifact exists", () => {
+    const r = run(tmpProject({ hasBuild: false }), ["--ci"]);
+    const json = JSON.parse(r.stdout);
+    const bundle = json.checks.find((c) => c.name === "bundle-size");
+    expect(bundle.status).toBe("skip");
+    expect(bundle.reason).toContain("no build artifact");
+  });
+
+  it("runs bundle-size when a build artifact exists", () => {
+    const r = run(tmpProject({ hasBuild: true }), ["--ci"]);
+    const json = JSON.parse(r.stdout);
+    const bundle = json.checks.find((c) => c.name === "bundle-size");
+    expect(bundle.status).toBe("pass");
+  });
+});
+
+describe("missing check script", () => {
+  it("marks the check as skip with a 'script not found' reason", () => {
+    const dir = tmpProject({ hasBuild: true });
+    rmSync(join(dir, "scripts", "check-types.sh"), { force: true });
+    const r = run(dir, ["--ci"]);
+    const json = JSON.parse(r.stdout);
+    const types = json.checks.find((c) => c.name === "types");
+    expect(types.status).toBe("skip");
+    expect(types.reason).toContain("script not found");
+    // Skips alone should not flip ok to false.
+    expect(json.ok).toBe(true);
+  });
+});
+
+describe("unknown flag", () => {
+  it("exits 2 with a helpful error", () => {
+    const r = run(tmpProject(), ["--nope"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr ?? "").toContain("Unknown argument");
+  });
+});
+
+describe("JSON schema", () => {
+  it("emits valid JSON with the expected shape", () => {
+    const r = run(tmpProject({ hasBuild: true }), ["--json"]);
+    const json = JSON.parse(r.stdout);
+    expect(json).toHaveProperty("ok");
+    expect(json).toHaveProperty("summary.pass");
+    expect(json).toHaveProperty("summary.fail");
+    expect(json).toHaveProperty("summary.skip");
+    expect(json).toHaveProperty("summary.total");
+    expect(Array.isArray(json.checks)).toBe(true);
+    for (const check of json.checks) {
+      expect(check).toHaveProperty("name");
+      expect(check).toHaveProperty("status");
+      expect(check).toHaveProperty("exitCode");
+      expect(check).toHaveProperty("durationMs");
+      expect(check).toHaveProperty("reason");
+    }
+  });
+});

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# verify-all.sh — Run every local quality check in sequence and report a summary.
+#
+# Backs both /verify-all (interactive) and /ci (machine-readable, non-interactive)
+# slash commands. Each check is a separate script under scripts/ and is treated
+# as opaque: we capture its exit code and its trailing output for the report.
+#
+# Usage:
+#   ./scripts/verify-all.sh                   # Human-readable summary
+#   ./scripts/verify-all.sh --json            # Machine-readable JSON summary
+#   ./scripts/verify-all.sh --ci              # Implies --json + non-interactive
+#   ./scripts/verify-all.sh --skip <a,b,c>    # Skip named checks
+#   ./scripts/verify-all.sh --include <a,b>   # Run only the named checks
+#   ./scripts/verify-all.sh --list            # Print check names and exit
+#
+# Check names:
+#   lint-and-format, types, tests, accessibility, tokens, dead-code, security,
+#   bundle-size
+#
+# Exit codes:
+#   0 — every check passed (or was skipped intentionally)
+#   1 — one or more checks failed
+
+set -uo pipefail
+
+# Run relative to the caller's cwd (expected to be the repo root). This lets
+# tests run against fixture directories without forcing themselves into the
+# real project tree, and matches how the individual check scripts behave.
+
+JSON_OUTPUT=false
+CI_MODE=false
+SKIP_LIST=""
+INCLUDE_LIST=""
+LIST_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON_OUTPUT=true ;;
+    --ci) CI_MODE=true; JSON_OUTPUT=true ;;
+    --skip) SKIP_LIST="${2:-}"; shift ;;
+    --include) INCLUDE_LIST="${2:-}"; shift ;;
+    --list) LIST_ONLY=true ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# Each check: name | script path | extra args (space-separated)
+# `bundle-size` is conditional — it runs only when a build artifact exists.
+ALL_CHECKS=(
+  "lint-and-format|./scripts/lint-and-format.sh|--check"
+  "types|./scripts/check-types.sh|"
+  "tests|./scripts/run-tests.sh|"
+  "accessibility|./scripts/check-accessibility.sh|"
+  "tokens|./scripts/verify-tokens.sh|"
+  "dead-code|./scripts/check-dead-code.sh|"
+  "security|./scripts/check-security.sh|"
+  "bundle-size|./scripts/check-bundle-size.sh|"
+)
+
+if [[ "$LIST_ONLY" == "true" ]]; then
+  for entry in "${ALL_CHECKS[@]}"; do
+    echo "${entry%%|*}"
+  done
+  exit 0
+fi
+
+# --- Filtering ---
+csv_contains() {
+  local csv="$1"
+  local needle="$2"
+  [[ -z "$csv" ]] && return 1
+  IFS=',' read -ra parts <<< "$csv"
+  for p in "${parts[@]}"; do
+    [[ "$(echo "$p" | tr -d ' ')" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+should_run() {
+  local name="$1"
+  if [[ -n "$INCLUDE_LIST" ]]; then
+    csv_contains "$INCLUDE_LIST" "$name" && return 0
+    return 1
+  fi
+  if [[ -n "$SKIP_LIST" ]]; then
+    csv_contains "$SKIP_LIST" "$name" && return 1
+  fi
+  return 0
+}
+
+# --- Conditional gates ---
+build_artifact_exists() {
+  for d in dist .next build out; do
+    if [[ -d "$d" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- Runner ---
+RESULTS_NAME=()
+RESULTS_STATUS=()
+RESULTS_EXIT=()
+RESULTS_MS=()
+RESULTS_REASON=()
+
+now_ms() {
+  # GNU date supports %N; macOS date does not. Fall back to Python or seconds*1000.
+  if date +%s%3N >/dev/null 2>&1; then
+    date +%s%3N
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import time; print(int(time.time()*1000))'
+  else
+    echo "$(( $(date +%s) * 1000 ))"
+  fi
+}
+
+emit_progress() {
+  $JSON_OUTPUT && return 0
+  echo "$@"
+}
+
+run_check() {
+  local name="$1"
+  local script="$2"
+  local args="$3"
+
+  if ! should_run "$name"; then
+    RESULTS_NAME+=("$name")
+    RESULTS_STATUS+=("skip")
+    RESULTS_EXIT+=("0")
+    RESULTS_MS+=("0")
+    RESULTS_REASON+=("filtered by --skip/--include")
+    return 0
+  fi
+
+  if [[ "$name" == "bundle-size" ]] && ! build_artifact_exists; then
+    RESULTS_NAME+=("$name")
+    RESULTS_STATUS+=("skip")
+    RESULTS_EXIT+=("0")
+    RESULTS_MS+=("0")
+    RESULTS_REASON+=("no build artifact (dist/.next/build/out)")
+    emit_progress "▸ $name … skipped (no build artifact)"
+    return 0
+  fi
+
+  if [[ ! -x "$script" ]] && [[ ! -f "$script" ]]; then
+    RESULTS_NAME+=("$name")
+    RESULTS_STATUS+=("skip")
+    RESULTS_EXIT+=("0")
+    RESULTS_MS+=("0")
+    RESULTS_REASON+=("script not found: $script")
+    emit_progress "▸ $name … skipped (script not found)"
+    return 0
+  fi
+
+  emit_progress "▸ $name …"
+  local start
+  start="$(now_ms)"
+  local exit_code=0
+  if [[ -n "$args" ]]; then
+    bash "$script" $args >/dev/null 2>&1 || exit_code=$?
+  else
+    bash "$script" >/dev/null 2>&1 || exit_code=$?
+  fi
+  local end
+  end="$(now_ms)"
+  local duration_ms=$((end - start))
+
+  RESULTS_NAME+=("$name")
+  RESULTS_EXIT+=("$exit_code")
+  RESULTS_MS+=("$duration_ms")
+  if [[ "$exit_code" -eq 0 ]]; then
+    RESULTS_STATUS+=("pass")
+    RESULTS_REASON+=("")
+    emit_progress "  ✓ pass (${duration_ms}ms)"
+  else
+    RESULTS_STATUS+=("fail")
+    RESULTS_REASON+=("exit $exit_code")
+    emit_progress "  ✗ fail (exit $exit_code, ${duration_ms}ms)"
+  fi
+}
+
+# --- Run all ---
+$JSON_OUTPUT || echo "=== verify-all ==="
+$JSON_OUTPUT || echo ""
+
+for entry in "${ALL_CHECKS[@]}"; do
+  name="${entry%%|*}"
+  rest="${entry#*|}"
+  script="${rest%%|*}"
+  args="${rest#*|}"
+  run_check "$name" "$script" "$args"
+done
+
+# --- Summary ---
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+for status in "${RESULTS_STATUS[@]}"; do
+  case "$status" in
+    pass) PASS_COUNT=$((PASS_COUNT + 1)) ;;
+    fail) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+    skip) SKIP_COUNT=$((SKIP_COUNT + 1)) ;;
+  esac
+done
+
+if $JSON_OUTPUT; then
+  printf '{\n'
+  if [[ "$FAIL_COUNT" -eq 0 ]]; then
+    printf '  "ok": true,\n'
+  else
+    printf '  "ok": false,\n'
+  fi
+  printf '  "summary": { "pass": %d, "fail": %d, "skip": %d, "total": %d },\n' \
+    "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "${#RESULTS_NAME[@]}"
+  printf '  "checks": [\n'
+  for i in "${!RESULTS_NAME[@]}"; do
+    sep=","
+    [[ "$i" -eq $(( ${#RESULTS_NAME[@]} - 1 )) ]] && sep=""
+    reason_escaped="${RESULTS_REASON[$i]//\\/\\\\}"
+    reason_escaped="${reason_escaped//\"/\\\"}"
+    printf '    { "name": "%s", "status": "%s", "exitCode": %s, "durationMs": %s, "reason": "%s" }%s\n' \
+      "${RESULTS_NAME[$i]}" "${RESULTS_STATUS[$i]}" "${RESULTS_EXIT[$i]}" "${RESULTS_MS[$i]}" \
+      "$reason_escaped" "$sep"
+  done
+  printf '  ]\n'
+  printf '}\n'
+else
+  echo ""
+  echo "=== Summary ==="
+  printf '%-18s %-6s %-10s %s\n' "Check" "Status" "Duration" "Reason"
+  printf '%-18s %-6s %-10s %s\n' "-----" "------" "--------" "------"
+  for i in "${!RESULTS_NAME[@]}"; do
+    printf '%-18s %-6s %-10s %s\n' \
+      "${RESULTS_NAME[$i]}" "${RESULTS_STATUS[$i]}" "${RESULTS_MS[$i]}ms" "${RESULTS_REASON[$i]}"
+  done
+  echo ""
+  echo "Totals: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped"
+  if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "✗ Some checks failed. Run each failing check individually for full output:"
+    for i in "${!RESULTS_NAME[@]}"; do
+      if [[ "${RESULTS_STATUS[$i]}" == "fail" ]]; then
+        # Look up the original script for the failing check
+        for entry in "${ALL_CHECKS[@]}"; do
+          if [[ "${entry%%|*}" == "${RESULTS_NAME[$i]}" ]]; then
+            rest="${entry#*|}"
+            failing_script="${rest%%|*}"
+            failing_args="${rest#*|}"
+            if [[ -n "$failing_args" ]]; then
+              echo "  $failing_script $failing_args"
+            else
+              echo "  $failing_script"
+            fi
+            break
+          fi
+        done
+      fi
+    done
+  else
+    echo ""
+    echo "✓ All checks passed."
+  fi
+fi
+
+# --- Exit code ---
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #50

## Summary
- Adds \`scripts/verify-all.sh\` — a single orchestrator that runs all 8 local quality checks (lint-and-format, types, tests, accessibility, tokens, dead-code, security, bundle-size) and reports a unified pass/fail summary
- Adds two slash commands: \`/verify-all\` (interactive, human-readable) and \`/ci\` (JSON output, non-zero exit on failure)
- bundle-size auto-skips when no build artifact (\`dist\` / \`.next\` / \`build\` / \`out\`) is present, matching the issue's "if build output exists" requirement
- 13 vitest cases verify the orchestrator end-to-end using stub check scripts in a fixture directory

## Acceptance criteria
- [x] \`/verify-all\` command created in \`.claude/commands/\`
- [x] \`/ci\` command created in \`.claude/commands/\`
- [x] Both commands report summary with pass/fail per check
- [x] \`/ci\` returns non-zero exit on any failure

## Sample output

Interactive (\`/verify-all\`):
\`\`\`
=== Summary ===
Check              Status Duration   Reason
-----              ------ --------   ------
lint-and-format    pass   2618ms
types              pass   1843ms
tests              pass   4205ms
accessibility      pass   1102ms
tokens             pass   320ms
dead-code          pass   2980ms
security           pass   4111ms
bundle-size        skip   0ms        no build artifact (dist/.next/build/out)

Totals: 7 passed, 0 failed, 1 skipped

✓ All checks passed.
\`\`\`

CI (\`/ci\`):
\`\`\`json
{
  "ok": false,
  "summary": { "pass": 6, "fail": 1, "skip": 1, "total": 8 },
  "checks": [
    { "name": "types", "status": "fail", "exitCode": 1, "durationMs": 1843, "reason": "exit 1" },
    ...
  ]
}
\`\`\`

## Test plan
- [x] \`pnpm vitest run scripts/__tests__/verify-all.test.js --config scripts/__tests__/vitest.config.js\` → 13 passed
- [x] \`bash scripts/verify-all.sh --include tokens\` from repo root → exits 0, reports pass
- [x] \`bash scripts/verify-all.sh --ci --include lint-and-format,tokens\` with one failure → exits 1, JSON \`ok: false\`
- [x] \`bash scripts/verify-all.sh --list\` → prints all 8 check names
- [ ] Invoke \`/verify-all\` from inside Claude Code in a real project and confirm the agent surfaces the summary
- [ ] Invoke \`/ci\` in a CI workflow and confirm the JSON / exit code parse correctly downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)