### PR TITLE
docs(readme): add Related Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ Details: `.claude/PLUGINS-REFERENCE.md`
 | Pipeline config | `.claude/pipeline.config.json` | Thresholds, app types, quality gates |
 | Agent naming guide | `.claude/AGENT-NAMING-GUIDE.md` | Conventions for creating new agents |
 
+## Related Projects
+
+| Project | Description |
+|---------|-------------|
+| [AI SEO Copilot (Chrome)](https://github.com/die-Manufaktur/AISEOC-Chrome-Extension) | Free, open-source Chrome extension for AI-powered SEO analysis. Built with React 19, TypeScript, and Vite. The Chrome extension pipeline in Aurelius was battle-tested against this project. [Install from Chrome Web Store](https://chromewebstore.google.com/detail/ai-seo-copilot/anhpobnkbmgjhcgbohkddjjpcbbdllhl) |
+| [AI SEO Copilot (Webflow)](https://github.com/die-Manufaktur/AI-SEO-Copilot-for-Webflow) | The original Webflow app with ~20,000 installs |
+| [Flavian](https://github.com/PMDevSolutions/Flavian) | Claude Code-integrated WordPress development framework with FSE block theme tools and Figma-to-WordPress pipelines |
+| [Nerva](https://github.com/PMDevSolutions/Nerva) | Claude Code-integrated API and backend development framework with Hono, Cloudflare Workers, and Drizzle ORM |
+| [Claudius](https://github.com/PMDevSolutions/Claudius) | Embeddable AI chat widget powered by Claude. React + TypeScript + Cloudflare Workers |
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a **Related Projects** section to the README, immediately above the License section, cross-linking related PMDevSolutions repositories to improve discoverability.

Highlights the **AI SEO Copilot Chrome extension** (now live on the Chrome Web Store, built with React 19 + TypeScript + Vite) — Aurelius's Chrome extension pipeline (app-type detection, Playwright E2E fixtures, manifest.json handling) was battle-tested against it. Also links the AI SEO Copilot Webflow app and the Flavian, Nerva, and Claudius frameworks.

## Changes

- README.md: new `## Related Projects` table inserted before `## License`

## Testing

- `pnpm prettier --check README.md` ✅
- Pre-commit doc-count guard passed (53 agents, 20 skills in sync)

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)