### PR TITLE
feat: add /build-from-conversation — conversational app creation via Figma generation

### DIFF
--- a/.claude/AGENT-NAMING-GUIDE.md
+++ b/.claude/AGENT-NAMING-GUIDE.md
@@ -1,10 +1,10 @@
 # Agent Naming Guide
 
-**Last Updated:** 2026-04-02
+**Last Updated:** 2026-06-11
 
 ## Naming Convention
 
-All 54 agents use unique, hyphenated names (e.g., `frontend-developer`, `figma-react-converter`). There are no naming conflicts in the current agent set.
+All 55 agents use unique, hyphenated names (e.g., `frontend-developer`, `figma-react-converter`). There are no naming conflicts in the current agent set.
 
 Agent files live in `.claude/agents/` as `<agent-name>.md`.
 

--- a/.claude/CUSTOM-AGENTS-GUIDE.md
+++ b/.claude/CUSTOM-AGENTS-GUIDE.md
@@ -1,7 +1,7 @@
 # Custom Agents Guide
 
-**Last Updated:** 2026-03-25
-**Total Agents:** 54
+**Last Updated:** 2026-06-11
+**Total Agents:** 55
 **Location:** `.claude/agents/`
 
 Agents are auto-selected by Claude Code based on task context, or you can request one explicitly.
@@ -42,6 +42,7 @@ Agents are auto-selected by Claude Code based on task context, or you can reques
 | figma-react-converter | Figma-to-React conversion pipeline orchestration | Converting Figma designs into React components with Tailwind CSS |
 | canva-react-converter | Canva-to-React conversion from screenshots | Converting Canva designs into React components with Tailwind CSS |
 | astro-converter | Design-to-Astro hybrid conversion (zero-JS .astro statics + React islands) | Building Astro apps where most components are static and a few are interactive React islands |
+| conversation-designer | Natural-language descriptions → concrete design decisions, design briefs, and HTML mockups for Figma generation | Powering /build-from-conversation: authoring design-brief.json and the mockups captured into Figma |
 | asset-cataloger | Image/asset semantic mapping and validation | Mapping hash-named exports to meaningful names, validating asset usage |
 
 ## Testing & QA
@@ -140,7 +141,7 @@ User: "Use the accessibility-auditor agent to check this page"
 
 ## Agent + Skill Integration
 
-Agents work alongside the 20 custom skills in `.claude/skills/`:
+Agents work alongside the 22 custom skills in `.claude/skills/`:
 
 | Agent | Complementary Skill |
 |-------|-------------------|
@@ -156,6 +157,7 @@ Agents work alongside the 20 custom skills in `.claude/skills/`:
 | animation-optimizer | animation-motion |
 | bundle-analyzer | react-performance-optimization |
 | canva-react-converter | canva-token-inference |
+| conversation-designer | conversation-intake, design-brief-to-figma |
 
 **Skills Documentation:** `.claude/skills/README.md`
 
@@ -181,4 +183,5 @@ Agents work alongside the 20 custom skills in `.claude/skills/`:
 | Upgrade React/Next.js | migration-specialist |
 | Add internationalization | i18n-engineer |
 | Convert Canva to React | canva-react-converter |
+| Build an app from a description | conversation-designer (via /build-from-conversation) |
 | Ship a release | project-shipper |

--- a/.claude/agents/conversation-designer.md
+++ b/.claude/agents/conversation-designer.md
@@ -1,0 +1,113 @@
+---
+name: conversation-designer
+description: Use this agent when translating natural-language app descriptions into concrete design decisions. Interprets a user's described intent ("a clean dashboard for my SaaS"), makes specific visual choices (layout grid, palette, typography, component anatomy), authors the design-brief.json artifact, and generates the high-fidelity HTML mockups that design-brief-to-figma captures into a real Figma file. Used by the conversation-intake and design-brief-to-figma skills inside /build-from-conversation.
+color: cyan
+tools: Write, Read, MultiEdit, Grep, Glob, WebSearch, WebFetch
+---
+
+You are a senior product designer who works without a canvas. Users describe what they want in plain language; you turn those words into specific, defensible design decisions and into pixel-precise HTML mockups that become the project's actual Figma design. You never answer with "it depends" — you choose, and you record why.
+
+You operate inside the `/build-from-conversation` pipeline. Two skills dispatch you:
+
+1. **conversation-intake** — after the interview, you expand the user's answers into `design-brief.json`
+2. **design-brief-to-figma** — you render that brief as one self-contained HTML mockup per page; the skill captures each mockup into Figma via `generate_figma_design`
+
+Your mockups are not throwaway sketches. The captured Figma frames become the reference that Phase 5 (pixel-diff visual QA) compares the built app against. Every value you put in a mockup is a value the final app will be measured by — so be exact, not approximate.
+
+## Primary Responsibilities
+
+### 1. Interpret Descriptions into Decisions
+
+Vague input, concrete output. For every fuzzy phrase, commit to a specific decision and note the reasoning in the brief:
+
+| User says | You decide |
+|-----------|-----------|
+| "a clean dashboard" | 240px fixed sidebar + 12-column content grid, 24px gutters, stat cards in a 4-up row, table below |
+| "make it pop" | bold style direction: oversized display headings, saturated primary, high-contrast section breaks |
+| "professional, for banks" | corporate: navy/slate palette, conservative type scale, dense data tables, no decorative motion |
+| "like a startup landing page" | hero + social proof + 3-up features + pricing + footer, generous vertical rhythm (96px sections) |
+
+Never ask the user to make a design decision the interview already gave you enough signal to make. Decide, record the rationale, and let the review gate catch disagreements.
+
+### 2. Author design-brief.json
+
+You own this artifact. Write it to `.claude/plans/design-brief.json`:
+
+```jsonc
+{
+  "version": "1.0.0",
+  "source": "conversation",
+  "createdAt": "2026-06-11T09:05:00Z",        // ISO-8601
+  "appName": "Pulse Analytics",                // used as the Figma file name
+  "styleDirection": "minimal",                 // minimal | bold | playful | corporate | dark | custom
+  "colorPreferences": {
+    "primary": "#2563EB",                      // hex or null (you derive one)
+    "style": "cool-neutral",                   // cool-neutral | warm-neutral | vibrant | monochrome | custom
+    "userProvided": true,                      // false when you derived the palette
+    "notes": "reasoning for the color choice"
+  },
+  "typography": {
+    "style": "modern-sans",                    // modern-sans | classic-serif | geometric | humanist | monospace
+    "headingStyle": "bold-clean",              // bold-clean | elegant | casual | technical
+    "notes": "reasoning"
+  },
+  "layoutStyle": {
+    "density": "comfortable",                  // compact | comfortable | spacious
+    "maxWidth": "1280px",
+    "sidebar": true,
+    "notes": "reasoning"
+  },
+  "componentDescriptions": {
+    "ComponentName": "Natural-language description of appearance, anatomy, states, and responsive behavior"
+  },
+  "darkMode": true,
+  "animations": "subtle",                      // none | subtle | expressive
+  "specialRequirements": []                    // e.g. ["auth", "dark-mode", "i18n"]
+}
+```
+
+Every `componentDescriptions` entry must be specific enough that a developer who never saw the mockup could sketch the component: anatomy, alignment, states, and what changes at mobile widths.
+
+### 3. Apply Style-Direction Defaults
+
+When the user gives no explicit preference, derive concrete values from the style direction. These are your defaults — deviate only with a reason recorded in `notes`:
+
+| Direction | Palette | Typography | Shape & depth | Spacing |
+|-----------|---------|------------|---------------|---------|
+| minimal | cool-neutral surfaces (#FAFAFA/#FFFFFF), one restrained accent | Inter / modern-sans, 1.250 scale | 8px radius, hairline borders, shadows barely-there | 8px grid, generous whitespace |
+| bold | vibrant primary + near-black ink, high contrast | Display weight 700-800 headings, tight tracking | 12-16px radius, hard color blocks over shadows | large section padding (96px+) |
+| playful | saturated multi-hue palette, tinted pastel surfaces | geometric/humanist sans, rounded feel | 16-24px radius, soft colored shadows | airy, irregular rhythm allowed |
+| corporate | navy/slate + restrained blue accent, warm greys | classic-serif or sober sans, 1.2 scale | 4-6px radius, 1px borders, minimal elevation | compact-to-comfortable, dense tables |
+| dark | #0B0F19-range surfaces, desaturated accent that passes contrast | modern-sans, slightly looser leading | 8px radius, elevation via lighter surface steps | comfortable; avoid pure-black/pure-white |
+
+All palettes must hold WCAG 2.1 AA contrast (4.5:1 body text). If a user-provided brand color fails contrast on your chosen surface, keep the brand hex for accents, derive an accessible text/surface pairing, and say so in `notes`.
+
+### 4. Generate HTML Mockups
+
+When design-brief-to-figma dispatches you, write one **self-contained** HTML file per page from `build-spec.json` into the configured mockup directory (default `.claude/design-mockups/`, one file per page route, e.g. `dashboard.html`). These files are captured into Figma exactly as rendered, so:
+
+- **Deterministic rendering.** No JavaScript, no animations, no network calls except Google Fonts `<link>` tags. Static HTML + a single inline `<style>` block.
+- **Fixed desktop frame.** Design for a 1440px-wide viewport (`body { width: 1440px; margin: 0 auto; }` is acceptable); the downstream pipeline handles responsive variants from the build spec, not from the mockup.
+- **Exact values only.** Every color, font-size, spacing, radius, and shadow comes from the design brief. No `lightblue`, no `1.2rem`-because-it-felt-right. These values become the design tokens the whole pipeline locks against.
+- **Real text content.** Use the strings from `build-spec.json > textContent` — never lorem ipsum. The TDD phase writes assertions against these exact strings.
+- **Semantic structure.** One landmark per build-spec section, in order, each tagged `data-section="<section-name>"` so captured frames map cleanly back to the spec.
+- **Placeholder imagery.** Solid blocks or inline SVG shapes in palette colors. No external images, no base64 photos.
+- **Every described component appears** at least once, in every state worth designing (e.g. a StatsCard with positive and negative delta).
+
+### 5. Revise on Feedback
+
+When the review gate returns user feedback ("make the sidebar darker", "less whitespace"), make targeted edits to the brief and only the affected mockups. Do not redesign unaffected pages — unchanged pages keep their existing Figma captures.
+
+## Decision Heuristics
+
+- **No color given:** derive from domain (finance → corporate navy, health → calm teal, dev tools → dark + electric accent) and record `"userProvided": false`.
+- **Conflicting asks** ("minimal but also really colorful"): satisfy the structural ask (minimal layout) and scope the conflicting one (color confined to data visualization and CTAs); explain in `notes`.
+- **Unfamiliar product space:** spend one WebSearch on current conventions for that app category before deciding layouts; conventions beat invention for v1.
+- **When genuinely ambiguous** (two defensible directions with different page structures), surface the choice through the dispatching skill's question budget rather than guessing.
+
+## Integration
+
+- **Dispatched by:** `conversation-intake` (Step 3 — brief authoring), `design-brief-to-figma` (Step 2 — mockup generation)
+- **Reads:** interview answers, `build-spec.json`, `.claude/pipeline.config.json > conversation`
+- **Writes:** `.claude/plans/design-brief.json`, `<mockupDir>/*.html`
+- **Consumed by:** `/build-from-conversation`, `generate_figma_design` capture, and ultimately the Phase 5 pixel-diff loop

--- a/.claude/commands/build-from-conversation.md
+++ b/.claude/commands/build-from-conversation.md
@@ -1,0 +1,114 @@
+---
+allowed-tools: Skill, Agent, Bash, Read, Write, Edit, Glob, Grep, TodoWrite, AskUserQuestion, mcp__figma__whoami, mcp__figma__create_new_file, mcp__figma__generate_figma_design, mcp__figma__get_metadata, mcp__figma__get_screenshot, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__new_page, mcp__chrome-devtools__take_screenshot, mcp__playwright__browser_navigate
+---
+
+# /build-from-conversation — Conversational App Creation via Figma Generation
+
+You are the master orchestrator for building a working, tested app from nothing but a conversation. The user describes what they want; you interview them, generate a real Figma design from the resulting brief, and then hand off to the existing `/build-from-figma` pipeline, which runs unchanged from there. "Talk to build" — no pre-existing design file required.
+
+```
+Conversation ──► [C0] conversation-intake ──► build-spec.json + design-brief.json
+                          │
+                          ▼
+                 [C1] design-brief-to-figma ──► real Figma file (URL + node IDs)
+                          │
+                          ▼
+                 /build-from-figma <generated URL> ──► phases 0-9, unchanged
+```
+
+**Key enforcement rules:**
+- **The interview is bounded** — at most `conversation.interview.maxQuestions` (default 7) questions. Auto-discover everything else.
+- **The brief is confirmed** — when `conversation.interview.confirmBriefWithUser` is `true`, the user approves the build plan before any Figma file is created.
+- **The generated design is reviewed** — when `conversation.designGeneration.reviewBeforeHandoff` is `true`, the user sees the Figma file before the build pipeline starts.
+- **Downstream is untouched** — everything after the handoff is the standard `/build-from-figma` pipeline; this command adds phases in front of it, never modifies it.
+
+## Input
+
+The user provides: `$ARGUMENTS` (optional — a brief initial description of the app, e.g. "a minimal analytics dashboard with auth and dark mode")
+
+If `$ARGUMENTS` is non-empty, pass it to the `conversation-intake` skill as seed answers; the skill skips any interview question the description already answers. If empty, the interview starts from Question 1.
+
+## Configuration
+
+Load `.claude/pipeline.config.json` at the start. This command reads the `conversation` section:
+- `conversation.interview` — question cap, brief confirmation gate
+- `conversation.designGeneration` — mockup directory and server port, capture polling, review gate, regeneration attempts
+- `conversation.retry` — exponential backoff for Figma MCP capture failures
+
+All downstream settings (visual diff thresholds, TDD enforcement, quality gates) are read by `/build-from-figma` as usual.
+
+## Progress Tracking
+
+Use `TodoWrite` to create a master checklist. The handoff phases are tracked by `/build-from-figma` itself.
+
+```
+[ ] Phase C0: Conversation Intake — conversation-intake skill → build-spec.json + design-brief.json
+[ ] Phase C1: Figma Design Generation — design-brief-to-figma skill → Figma URL + node IDs
+[ ] Handoff: /build-from-figma <generated URL> → phases 0-9
+```
+
+## Phase C0: Conversation Intake
+
+Invoke the `conversation-intake` skill.
+
+**Input:** `$ARGUMENTS` (optional seed description)
+**Output:** `.claude/plans/build-spec.json` with `"source": "conversation"` and `figma: null`, plus `.claude/plans/design-brief.json`
+
+This phase:
+1. Auto-discovers local project context (renderer registry, app type, existing components, UI libraries)
+2. Interviews the user — maximum of 7 questions, skipping anything derivable
+3. Dispatches the `conversation-designer` agent to expand answers into concrete design decisions
+4. Writes both artifacts and presents the build plan for confirmation
+
+**Resume check:** If `.claude/plans/build-spec.json` already exists with `"source": "conversation"`:
+- `figma` is `null` → offer to reuse it and resume at Phase C1, or re-run the interview
+- `figma` is populated → offer to skip straight to the handoff with the recorded URL
+
+## Phase C1: Figma Design Generation
+
+Invoke the `design-brief-to-figma` skill.
+
+**Input:** `design-brief.json` + `build-spec.json`
+**Output:** A real Figma file URL; `build-spec.json` updated in place (`figma` block populated, `pages[].figmaNodeId` and `pages[].mockupPath` filled in)
+
+This phase:
+1. Verifies Figma MCP auth (`whoami`) and resolves the `planKey`
+2. Dispatches `conversation-designer` to render one self-contained HTML mockup per page
+3. Serves the mockups locally and creates a new Figma file (`create_new_file`)
+4. Captures each mockup into the file via `generate_figma_design` (one single-use capture per page, polled until complete)
+5. Maps the generated node IDs into the build spec (`get_metadata`)
+6. Shows the generated design to the user when `conversation.designGeneration.reviewBeforeHandoff` is `true`; on rejection, regenerates the affected pages (max `conversation.designGeneration.maxRegenerationAttempts` loops)
+
+**Resume check:** If `build-spec.json` already has a populated `figma` block with `"generated": true`, confirm the file still exists (`get_metadata`) and skip to the handoff.
+
+## Handoff: /build-from-figma
+
+Invoke the `build-from-figma` command with the generated Figma URL as its arguments — exactly as if the user had run:
+
+```
+/build-from-figma https://figma.com/design/<fileKey>/<appName>
+```
+
+The standard pipeline runs unchanged. What to expect on a conversation-sourced run:
+
+- **Phase 0 (token sync)** skips on greenfield projects — no lockfile exists yet.
+- **Phase 1 (figma-intake)** detects `"source": "conversation"` in the existing build spec and **fast-paths**: no second interview, no rediscovery — it validates the spec, backfills any missing `figmaNodeId` via `get_metadata`, and proceeds.
+- **Phase 2 (design-token-lock)** finds no Figma variables (captured designs carry styles, not variable definitions) and falls back to computed styles — the documented fallback. The extracted values match the design brief because the mockups were generated from its exact values.
+- **Phase 5 (visual diff)** compares the built app against the generated Figma frames — the same frames captured from your mockups, closing the loop from conversation to verified pixels.
+
+## Error Recovery
+
+- **Figma MCP unavailable or unauthenticated:** Complete Phase C0 anyway — the brief and spec are durable artifacts. Report that design generation is blocked, and resume at Phase C1 once the user has Figma access working (`whoami` to verify).
+- **Capture failures (timeout, rate limit, connection lost):** Apply `conversation.retry` exponential backoff with a fresh capture per attempt. If a page exhausts retries, continue with the remaining pages and list the failed ones for manual re-capture before the handoff.
+- **User rejects the generated design repeatedly:** After `maxRegenerationAttempts` loops, stop and summarize the disagreement — offer to hand-edit the Figma file (it's a real file in their account) and resume with `/build-from-figma <url>` directly.
+- **Multiple Figma plans:** Never guess which team/org to create the file in — ask.
+- **Session interrupted:** On resume, check TodoWrite progress and the resume checks above. The artifacts (`build-spec.json`, `design-brief.json`, mockups, the Figma file itself) make every phase resumable.
+
+## Completion
+
+When the handoff pipeline finishes, present:
+
+1. The Figma file URL (the user now owns a real, editable design file)
+2. The standard build report summary from `/build-from-figma` Phase 9
+3. Interview-to-app traceability: questions asked, assumptions the designer made (from `design-brief.json` notes), and any items needing manual review
+4. Next steps (e.g., "run `pnpm dev` to see the app; edit the Figma file and re-run `/build-from-figma` to iterate")

--- a/.claude/pipeline.config.json
+++ b/.claude/pipeline.config.json
@@ -384,6 +384,34 @@
       ]
     }
   },
+  "conversation": {
+    "enabled": true,
+    "interview": {
+      "maxQuestions": 7,
+      "confirmBriefWithUser": true
+    },
+    "designGeneration": {
+      "mockupDir": ".claude/design-mockups",
+      "mockupServerPort": 4173,
+      "reviewBeforeHandoff": true,
+      "maxRegenerationAttempts": 2,
+      "capturePollIntervalMs": 5000,
+      "capturePollMaxAttempts": 10
+    },
+    "retry": {
+      "maxAttempts": 3,
+      "initialDelayMs": 2000,
+      "backoffMultiplier": 2,
+      "maxDelayMs": 30000,
+      "retryableErrors": [
+        "rate_limit",
+        "timeout",
+        "server_error",
+        "capture_failed",
+        "mcp_connection_lost"
+      ]
+    }
+  },
   "orchestration": {
     "enabled": true,
     "maxConcurrent": 3,

--- a/.claude/pipeline.config.schema.json
+++ b/.claude/pipeline.config.schema.json
@@ -438,6 +438,36 @@
       }
     },
 
+    "conversation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Conversation pipeline configuration: structured-interview limits and Figma design generation from the design brief.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interview": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maxQuestions": { "type": "integer", "minimum": 1, "maximum": 10, "description": "Upper bound on interview questions asked during conversation-intake." },
+            "confirmBriefWithUser": { "type": "boolean", "description": "Block before design generation until the user confirms the design brief and build plan." }
+          }
+        },
+        "designGeneration": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mockupDir": { "type": "string", "description": "Directory where per-page HTML mockups are written before Figma capture." },
+            "mockupServerPort": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Local port for the static server that hosts mockups during generate_figma_design capture." },
+            "reviewBeforeHandoff": { "type": "boolean", "description": "Show the generated Figma file to the user for approval before invoking /build-from-figma." },
+            "maxRegenerationAttempts": { "type": "integer", "minimum": 0, "description": "Max brief-revision/regeneration loops when the user rejects the generated design." },
+            "capturePollIntervalMs": { "type": "integer", "minimum": 0, "description": "Delay between generate_figma_design capture status polls." },
+            "capturePollMaxAttempts": { "type": "integer", "minimum": 1, "description": "Max capture status polls per page before the capture is considered failed." }
+          }
+        },
+        "retry": { "$ref": "#/$defs/retryOptions" }
+      }
+    },
+
     "orchestration": {
       "type": "object",
       "additionalProperties": false,

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,7 +1,7 @@
 # Skills Catalog
 
-**Last Updated:** 2026-05-23
-**Total Skills:** 20
+**Last Updated:** 2026-06-11
+**Total Skills:** 22
 **Location:** `.claude/skills/`
 
 Skills are documentation-based workflows that trigger automatically when relevant keywords appear in conversation. They provide systematic guidance, not tool integrations.
@@ -68,58 +68,72 @@ These skills power the `/build-from-canva` and `/build-from-screenshot` autonomo
 - **Triggers:** Phase 1 of `/build-from-screenshot`, "build from screenshot", "clone this site"
 - **Output:** `.claude/plans/build-spec.json`
 
+### Conversation Pipeline Skills
+
+These skills power the `/build-from-conversation` autonomous pipeline. They run *before* the shared pipeline: Phase C0 produces the build spec and design brief from an interview, Phase C1 generates a real Figma file from the brief, and the standard `/build-from-figma` pipeline takes over from there (its `figma-intake` skill fast-paths on conversation-sourced build specs).
+
+#### 11. conversation-intake (Phase C0 -- Conversation)
+- **Purpose:** Structured interview (max 7 questions) that turns a natural-language app description into a `build-spec.json` with `source: "conversation"` plus a `design-brief.json`. Dispatches the conversation-designer agent to make concrete design decisions. No design file required.
+- **Triggers:** Phase C0 of `/build-from-conversation`, "describe an app", "talk to build"
+- **Output:** `.claude/plans/build-spec.json`, `.claude/plans/design-brief.json`
+
+#### 12. design-brief-to-figma (Phase C1 -- Conversation)
+- **Purpose:** Generates a real Figma file from the design brief: renders per-page HTML mockups (conversation-designer agent), serves them locally, creates a new Figma file, and captures each mockup into it via the Figma MCP `generate_figma_design` tool. Maps the generated node IDs back into the build spec.
+- **Triggers:** Phase C1 of `/build-from-conversation`, "generate a Figma design from a description"
+- **Output:** Figma file URL + updated `.claude/plans/build-spec.json`
+
 ### React Development Skills
 
 These skills provide patterns and best practices. They trigger on relevant keywords during any React development work.
 
-#### 11. react-component-development
+#### 13. react-component-development
 - **Purpose:** Component patterns, TypeScript conventions, custom hooks, composition, and Tailwind CSS best practices
 - **Triggers:** "create component", "component pattern", "custom hook", "React best practices"
 - **Works with:** frontend-developer agent, ui-designer agent
 
-#### 12. react-testing-workflows
+#### 14. react-testing-workflows
 - **Purpose:** Testing strategy with Vitest, React Testing Library, Playwright, and Storybook
 - **Triggers:** "write tests", "test coverage", "Vitest", "Playwright", "Storybook"
 - **Works with:** test-writer-fixer agent, test-results-analyzer agent
 
-#### 13. react-performance-optimization
+#### 15. react-performance-optimization
 - **Purpose:** Performance profiling, bundle analysis, code splitting, and Web Vitals
 - **Triggers:** "performance", "bundle size", "Web Vitals", "lazy loading", "profiling"
 - **Works with:** performance-benchmarker agent, analytics-reporter agent
 
-#### 14. react-accessibility
+#### 16. react-accessibility
 - **Purpose:** WCAG 2.1 AA patterns for React, ARIA usage, keyboard navigation, focus management
 - **Triggers:** "accessibility", "WCAG", "ARIA", "a11y", "keyboard navigation"
 - **Works with:** accessibility-auditor agent, ux-researcher agent
 
-#### 15. state-management
+#### 17. state-management
 - **Purpose:** State architecture decisions — Zustand for global UI state, TanStack Query for server state, URL state patterns, and anti-patterns to avoid
 - **Triggers:** "state management", "zustand", "tanstack query", "react query", "global state", "data fetching", "caching"
 - **Works with:** frontend-developer agent
 
-#### 16. form-handling
+#### 18. form-handling
 - **Purpose:** Form patterns with React Hook Form + Zod — typed forms, reusable field components, dynamic field arrays, multi-step wizards, server actions, and accessible error handling
 - **Triggers:** "form", "form handling", "react hook form", "zod", "validation", "multi-step form", "wizard"
 - **Works with:** frontend-developer agent, accessibility-auditor agent
 
-#### 17. auth-flows
+#### 19. auth-flows
 - **Purpose:** Authentication patterns — Auth.js v5 (NextAuth), Clerk, Supabase Auth. Covers session management, protected routes, OAuth, and role-based access control (RBAC)
 - **Triggers:** "auth", "authentication", "login", "sign in", "session", "protected route", "OAuth", "clerk", "supabase auth"
 - **Works with:** backend-architect agent, frontend-developer agent
 
-#### 18. animation-motion
+#### 20. animation-motion
 - **Purpose:** Animation patterns — Framer Motion (motion/react), CSS transitions, page transitions, scroll-driven animations, staggered lists, and reduced-motion accessibility
 - **Triggers:** "animation", "framer motion", "transition", "micro-interaction", "page transition", "scroll animation", "motion"
 - **Works with:** frontend-developer agent, whimsy-injector agent
 
-#### 19. seo-metadata
+#### 21. seo-metadata
 - **Purpose:** SEO patterns — Next.js Metadata API, Open Graph tags, dynamic OG images, structured data (JSON-LD), sitemaps, robots.txt, and Vite SPA SEO with react-helmet-async
 - **Triggers:** "SEO", "metadata", "open graph", "og image", "sitemap", "structured data", "json-ld", "meta tags"
 - **Works with:** frontend-developer agent, content-creator agent
 
 ### Export Skills
 
-#### 20. export-design-system
+#### 22. export-design-system
 - **Purpose:** Exports generated components + `design-tokens.lock.json` as a publishable pnpm workspace. Generates a framework-agnostic tokens package and a framework-specific component library (React/Vue/Svelte via Vite library mode, React Native via tsc), with Tailwind preset, ThemeProvider, and Changesets versioning.
 - **Triggers:** `/export-design-system`, "export design system", "publishable component library"
 - **Output:** `packages/` pnpm workspace (tokens + component library)
@@ -129,6 +143,15 @@ These skills provide patterns and best practices. They trigger on relevant keywo
 ## Pipeline Flow
 
 ```
+Conversation ("describe your app")
+    |
+    v
+[Phase C0] conversation-intake → build-spec.json + design-brief.json
+    |
+    v
+[Phase C1] design-brief-to-figma → generated Figma file
+    |
+    v  (figma-intake fast-paths conversation-sourced specs)
 Figma Design                    Canva Design
     |                               |
     v                               v

--- a/.claude/skills/conversation-intake/SKILL.md
+++ b/.claude/skills/conversation-intake/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: conversation-intake
+description: Structured interview that turns a natural-language app description into a build-spec.json and a design-brief.json — no design file required. Auto-discovers local project context, asks at most 7 targeted questions, and dispatches the conversation-designer agent to make concrete design decisions. Entry point (Phase C0) for the /build-from-conversation pipeline. Keywords: conversation intake, describe an app, talk to build, design brief, build spec, no Figma file
+---
+
+# Conversation Intake — Structured Discovery
+
+## Purpose
+
+Gather everything needed to design and build an app from nothing but a conversation. Where `figma-intake` discovers an existing design file, this skill discovers the user's *intent*: it interviews them (maximum of 7 questions), expands the answers into concrete design decisions via the `conversation-designer` agent, and outputs two machine-readable artifacts that the rest of the pipeline consumes without re-asking questions:
+
+- `.claude/plans/build-spec.json` with `"source": "conversation"` — same contract every other intake skill produces
+- `.claude/plans/design-brief.json` — the new artifact that drives Figma design generation in Phase C1
+
+## When to Use
+
+- Phase C0 of `/build-from-conversation`
+- Any time a user describes an app they want built but has no Figma/Canva file, screenshot, or URL
+- When you need a structured design brief from a free-form product description
+
+## Inputs
+
+- **Optional:** Initial description from `$ARGUMENTS` (seed answers; skip any question it already answers)
+- **Optional:** Existing project directory to integrate into
+- **Reads:** `.claude/pipeline.config.json` → `conversation.interview` (`maxQuestions`, `confirmBriefWithUser`)
+
+## Process
+
+### Step 1: Auto-Discovery (No User Input)
+
+Scan the local project exactly as the other intake skills do:
+
+```
+1. Detect framework via the renderer registry:
+   - Run: node scripts/renderer-registry.js detect . --json
+   - On { "renderer": "<name>", "language": "<lang>" }:
+       set build-spec renderer = <name>
+       set build-spec outputTarget = <language>  (react | vue | svelte | react-native)
+   - On { "renderer": null }:
+       no framework detected → ask the output-target question (Question 5)
+   Do not hand-sniff config files or package.json deps; the registry owns detection.
+
+2. Detect app type:
+   - manifest.json with "manifest_version" → Chrome Extension
+   - manifest.json with "start_url" or "display" → PWA
+   - Otherwise → Web App
+
+3. Scan existing components:
+   - Glob: src/components/**/*.tsx, app/components/**/*.tsx
+   - Build inventory: name, props interface, file path
+   - (Only triggers Question 7 if matches exist)
+
+4. Check package.json for UI libraries and state management
+   (same list as figma-intake)
+
+5. Check for existing design tokens:
+   - tailwind.config.ts theme.extend, src/styles/tokens.css,
+     design-tokens.lock.json (from prior runs)
+   - Existing tokens become constraints for the design brief, not questions
+
+6. Load pipeline config:
+   - .claude/pipeline.config.json → conversation.interview.maxQuestions (default 7)
+     and appTypes[detected] for E2E strategy defaults
+```
+
+If `$ARGUMENTS` contains an initial description, parse it first and pre-fill every answer it covers. A description like "a minimal analytics dashboard with auth and dark mode, brand color #2563EB" already answers Questions 1 (partially), 3, 4, and 6 — only ask what is still missing.
+
+### Step 2: Structured Interview (Maximum of 7 Questions)
+
+Hard cap: `conversation.interview.maxQuestions` (default 7). Skip any question whose answer is already known from `$ARGUMENTS`, the project scan, or an earlier answer. Use `AskUserQuestion` with concrete options wherever choices are enumerable.
+
+**Question 1 — Purpose & Audience (always asked unless fully covered by $ARGUMENTS):**
+> What does the app do, and who is it for?
+> (One or two sentences is plenty — this drives every downstream design decision)
+
+**Question 2 — Pages/Screens:**
+> Which pages or screens does it need?
+> (Offer a suggested set inferred from the purpose, e.g. for a dashboard: Dashboard, Settings — accept "yes" or a corrected list)
+
+**Question 3 — Style Direction:**
+> What should it look like?
+> a) Minimal — clean, restrained, lots of whitespace
+> b) Bold — high contrast, large type, saturated color
+> c) Playful — rounded, colorful, friendly
+> d) Corporate — conservative, dense, trustworthy
+> e) Dark — dark surfaces, accent highlights
+> f) Custom — describe it in your own words
+
+**Question 4 — Color Preferences:**
+> Any brand colors I should use? (hex codes welcome)
+> (Default: I'll derive a palette from the style direction)
+
+**Question 5 — Output Target (only if the registry detected no framework):**
+> Run `node scripts/renderer-registry.js list --json` and present the returned
+> renderer names as the choices (each entry has `name` and `language`).
+> Greenfield React default: `vite`. Set build-spec `renderer` = the chosen name
+> and `outputTarget` = its `language`.
+> (Skip if the registry already detected a framework.)
+
+**Question 6 — Special Requirements (multi-select):**
+> Anything beyond the visible UI?
+> Options: auth, dark mode, i18n, animations, forms with validation, API integration
+> (Default: none — pure presentational)
+
+**Question 7 — Component Reuse (only if Step 1 found existing components):**
+> I found [N] existing components. Should I:
+> a) Reuse them and only generate missing ones
+> b) Regenerate all (replaces existing)
+> c) Generate alongside with new names (no overwrites)
+
+### Step 3: Design Expansion (conversation-designer)
+
+Dispatch the `conversation-designer` agent with the interview answers and project constraints. The agent:
+
+1. Makes every remaining design decision concrete (layout grid, sidebar vs top-nav, density, type pairing, palette with exact hex values, component anatomy)
+2. Writes `.claude/plans/design-brief.json` (schema owned by the agent definition)
+3. Returns the component inventory and drafted text content for the build spec
+
+Do not relay the agent's open design questions to the user unless answering them is impossible from context — the agent is instructed to decide and record reasoning; the confirmation gate (Step 5) is where the user corrects course.
+
+### Step 4: Generate build-spec.json
+
+Write the spec file that all downstream phases consume:
+
+```jsonc
+// .claude/plans/build-spec.json
+{
+  "version": "1.0.0",
+  "source": "conversation",
+  "renderer": "vite",             // registry renderer name, from Step 1 detection or Question 5
+  "outputTarget": "react",        // equals the renderer's language
+  "createdAt": "2026-06-11T09:00:00Z",
+  "conversation": {
+    "description": "Verbatim or condensed user description of the app",
+    "designBrief": ".claude/plans/design-brief.json",
+    "interviewQuestionCount": 6
+  },
+  "figma": null,                  // populated by design-brief-to-figma after generation:
+                                  // { "fileKey", "fileName", "url", "generated": true }
+  "appType": "web-app",
+  "framework": { "type": "vite", "version": "8.0.0", "outputDir": "src" },
+  "styling": { "approach": "tailwind", "uiLibrary": "none", "existingTokens": false },
+  "pages": [
+    {
+      "figmaNodeId": null,        // filled in by design-brief-to-figma per captured page
+      "name": "Dashboard",
+      "route": "/",
+      "mockupPath": null,         // filled in by design-brief-to-figma (mockup HTML path)
+      "sections": ["sidebar", "stats-overview", "revenue-chart", "customer-table"]
+    }
+  ],
+  "components": [
+    {
+      "reactName": "StatsCard",   // described in design-brief.json > componentDescriptions
+      "category": "ui",           // "ui" | "layout" | "sections" | "pages"
+      "action": "generate",       // or "reuse"/"extend" per Question 7
+      "existingPath": null,
+      "variants": ["positive", "negative", "neutral"],
+      "props": ["label", "value", "delta"]
+    }
+  ],
+  "textContent": {
+    // Drafted by conversation-designer from the purpose/audience answers.
+    // Real copy, not lorem ipsum — TDD asserts against these strings.
+  },
+  "businessLogic": {
+    "forms": [],
+    "apiCalls": [],
+    "auth": null,                 // "required" when Question 6 selected auth
+    "stateManagement": null
+  },
+  "e2e": {
+    "strategy": "navigate-interact-verify",   // from pipeline.config.json appTypes
+    "flows": []                                // defaults per appType + flows implied by pages
+  },
+  "testStrategy": {
+    "unit": true, "e2e": true, "visual": true,
+    "crossBrowser": false, "coverageThreshold": 80
+  },
+  "options": { "componentReuse": "reuse", "integration": "standalone" }
+}
+```
+
+**Renderer fields** follow the same rules as every other intake skill: `renderer` is authoritative, `outputTarget` equals the renderer's language, and a spec carrying only `outputTarget` resolves to that language's default renderer.
+
+**Key differences from the figma/canva/screenshot build-specs:**
+- `source` is `"conversation"`
+- `conversation` block records the description and points at the design brief
+- `figma` starts as `null` and is populated by `design-brief-to-figma` — the spec is *completed*, not created, by design generation
+- `pages[].figmaNodeId` and `pages[].mockupPath` start as `null` for the same reason
+- Components are *designed* rather than *detected*, so there is no `confidence` field; their visual contracts live in `design-brief.json > componentDescriptions`
+
+### Step 5: Confirm and Proceed
+
+When `conversation.interview.confirmBriefWithUser` is `true` (default), present the combined plan and wait for confirmation:
+
+```
+## Build Plan Summary
+- App: Pulse Analytics — analytics dashboard for a small SaaS team
+- Style: minimal, cool-neutral palette, primary #2563EB (user-provided)
+- Pages: 2 (Dashboard, Settings)
+- Components: 6 to generate, 0 reused
+- Framework: Vite (react) — detected
+- Requirements: auth, dark mode
+
+Next: I'll generate the Figma design from this brief, show it to you,
+then run the standard build pipeline against it.
+
+Proceed with Figma design generation?
+```
+
+On corrections, update the brief/spec (re-dispatch `conversation-designer` for design-level changes) and re-confirm. This consumes no interview-question budget.
+
+## Output
+
+**Primary:** `.claude/plans/build-spec.json` (`"source": "conversation"`, `figma: null` pending generation)
+**Secondary:** `.claude/plans/design-brief.json` (written by `conversation-designer`)
+**Tertiary:** Build plan summary displayed to user
+
+## Error Handling
+
+- **User description too thin to design from:** Ask Question 1 follow-ups within the question budget; never proceed with an empty purpose.
+- **Question budget exhausted with gaps remaining:** Fill gaps with style-direction defaults from the `conversation-designer` agent and flag every assumption in the Step 5 summary.
+- **Existing build-spec.json found:** Ask whether to reuse it (skip to Phase C1 or the handoff, depending on its `figma` block) or start a fresh interview.
+- **Renderer registry detects nothing and the user declines to choose:** Default to `vite` / `react` and say so in the summary.
+
+## Integration
+
+- **Consumed by:** `design-brief-to-figma` (Phase C1), `/build-from-conversation` orchestrator; downstream phases consume the completed build-spec exactly as if `figma-intake` had produced it
+- **Uses:** `conversation-designer` agent, `AskUserQuestion`, renderer registry (`node scripts/renderer-registry.js detect . --json`), Glob, Read, Write
+- **Config keys read:** `pipeline.config.json` → `conversation.interview.*`, `appTypes.*`

--- a/.claude/skills/design-brief-to-figma/SKILL.md
+++ b/.claude/skills/design-brief-to-figma/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: design-brief-to-figma
+description: Generates a real Figma file from a design-brief.json. Renders the brief as one high-fidelity HTML mockup per page (via the conversation-designer agent), serves them locally, creates a new Figma file, and captures each mockup into it with the Figma MCP generate_figma_design tool. Outputs a Figma URL that /build-from-figma consumes. Phase C1 of /build-from-conversation. Keywords: design brief to Figma, generate Figma design, Figma file generation, HTML mockup capture, conversational design
+---
+
+# Design Brief to Figma — Generated Design Files
+
+## Purpose
+
+Turn the `design-brief.json` produced by `conversation-intake` into an actual Figma file, so the standard `/build-from-figma` pipeline can run against it unchanged. The mechanism is **HTML-mockup capture**: `mcp__figma__generate_figma_design` imports a rendered web page into an existing Figma file pixel-perfectly, so this skill renders the brief as static HTML first, then captures each page. The generated file becomes the single visual source of truth — Phase 5 pixel-diffs the built app against frames created here.
+
+## When to Use
+
+- Phase C1 of `/build-from-conversation`, immediately after `conversation-intake`
+- Any time a confirmed `design-brief.json` + `build-spec.json` pair exists and a Figma file needs to be generated from it
+
+## Inputs
+
+- **Required:** `.claude/plans/design-brief.json` and `.claude/plans/build-spec.json` (with `"source": "conversation"`)
+- **Reads:** `.claude/pipeline.config.json` → `conversation.designGeneration` (`mockupDir`, `mockupServerPort`, `reviewBeforeHandoff`, `maxRegenerationAttempts`, `capturePollIntervalMs`, `capturePollMaxAttempts`) and `conversation.retry`
+
+## Process
+
+### Step 1: Preflight — Figma Auth and Plan
+
+```
+1. Call mcp__figma__whoami
+   → Confirms authentication and returns the user's plans
+2. Resolve planKey:
+   - Exactly one plan → use its `key` field verbatim
+   - Multiple plans → ask the user which team/organization to use (one question)
+3. If the Figma MCP is unavailable or unauthenticated, stop here —
+   report it and leave the brief/spec artifacts intact for a later resume
+```
+
+### Step 2: Render the Brief as HTML Mockups
+
+Dispatch the `conversation-designer` agent to write one self-contained HTML mockup per page in `build-spec.json > pages[]` into `conversation.designGeneration.mockupDir` (default `.claude/design-mockups/`):
+
+```
+For each page: <mockupDir>/<route-slug>.html   (e.g. dashboard.html, settings.html)
+```
+
+The agent definition owns the mockup quality bar (deterministic, no JS, exact brief values, real text content, `data-section` landmarks). After generation, record each page's `mockupPath` in `build-spec.json`.
+
+### Step 3: Serve the Mockups Locally
+
+`generate_figma_design` captures a *served* page, so host the mockup directory on a local static server:
+
+```bash
+npx serve <mockupDir> -l <mockupServerPort>   # default port 4173
+```
+
+Run it in the background and verify each page responds (e.g. `http://localhost:4173/dashboard.html`) before capturing. Any static server works; `npx serve` keeps it dependency-free.
+
+### Step 4: Create the Figma File
+
+```
+1. If the Figma MCP serves a figma-create-new-file skill, load it first
+   (resource: skill://figma/figma-create-new-file/SKILL.md) — its tool
+   description requires this when available
+2. Call mcp__figma__create_new_file with:
+   - fileName:  design-brief.json > appName
+   - planKey:   from Step 1
+   - editorType: "design"
+3. Record the returned fileKey and file URL
+```
+
+### Step 5: Capture Each Page (generate_figma_design)
+
+Each capture is **single-use and captures exactly one page** — run this loop once per page in the build spec:
+
+```
+FOR each page IN build-spec.pages:
+  1. Call mcp__figma__generate_figma_design({ fileKey })
+     → Returns a capture script + a captureId (single-use; do not reuse across pages)
+  2. Follow the returned capture-script instructions against the page's local
+     mockup URL (http://localhost:<port>/<page>.html). For local URLs this
+     typically means opening the URL with the capture fragment so the script
+     can snapshot the rendered DOM.
+  3. Poll: mcp__figma__generate_figma_design({ fileKey, captureId })
+     every conversation.designGeneration.capturePollIntervalMs (default 5000ms),
+     up to capturePollMaxAttempts (default 10), until status is "completed"
+  4. On timeout or failure: apply conversation.retry (exponential backoff) and
+     retry the page with a FRESH captureId — the old one is spent
+```
+
+Each completed capture lands as a new page/frame in the Figma file.
+
+### Step 6: Map Generated Node IDs into the Build Spec
+
+```
+1. Call mcp__figma__get_metadata({ fileKey })          → top-level pages (guid + name)
+2. For each captured page, drill in as needed to identify its root frame
+3. Write the IDs back into build-spec.json:
+   - pages[].figmaNodeId = the captured frame's node ID (e.g. "1:2")
+4. Populate the figma block and keep the source untouched:
+   {
+     "source": "conversation",            // unchanged — this is how figma-intake fast-paths
+     "figma": {
+       "fileKey": "<fileKey>",
+       "fileName": "<appName>",
+       "url": "https://figma.com/design/<fileKey>/<appName>",
+       "generated": true
+     }
+   }
+```
+
+### Step 7: Review Gate (Conditional)
+
+When `conversation.designGeneration.reviewBeforeHandoff` is `true` (default):
+
+```
+1. Capture a screenshot of each generated page (mcp__figma__get_screenshot)
+2. Present the Figma URL + screenshots to the user
+3. On rejection: route feedback to conversation-designer, regenerate only the
+   affected mockups, and re-capture only those pages (fresh captureIds).
+   Max loops: conversation.designGeneration.maxRegenerationAttempts (default 2)
+4. On approval (or when the review gate is disabled): proceed
+```
+
+### Step 8: Cleanup and Output
+
+Stop the static server. Return the Figma file URL — `/build-from-conversation` passes it to `/build-from-figma`, whose Phase 1 (`figma-intake`) fast-paths on the conversation-sourced build spec.
+
+## Output
+
+**Primary:** Figma file URL (real, editable file in the user's account)
+**Secondary:** Updated `.claude/plans/build-spec.json` (populated `figma` block, `pages[].figmaNodeId`, `pages[].mockupPath`)
+**Tertiary:** `<mockupDir>/*.html` mockups (kept — they document the generated design and allow cheap re-capture)
+
+## Error Handling
+
+- **Figma MCP unavailable / unauthenticated:** Stop before generating anything; the brief and spec survive for a later resume. Suggest checking Figma auth (`whoami`).
+- **Multiple plans and no answer:** Do not guess a `planKey`; a file created in the wrong org is outward-facing. Wait for the user.
+- **Capture timeout (poll budget exhausted):** Retry per `conversation.retry` with a fresh captureId. If a page still fails, continue capturing remaining pages and report the failed page for manual capture.
+- **Mockup server port in use:** Increment the port, retry once, and record the port actually used.
+- **Generated file has no Figma variables:** Expected — captured designs carry styles, not variable definitions, so Phase 2 (`design-token-lock`) falls back to computed styles. This is the documented `figma-intake`/token-lock fallback; the lockfile is still authoritative because the mockups were generated *from* the brief's exact values.
+
+## Integration
+
+- **Consumed by:** `/build-from-conversation` (Phase C1); its output URL feeds `/build-from-figma`
+- **Uses:** `conversation-designer` agent, `mcp__figma__whoami`, `mcp__figma__create_new_file`, `mcp__figma__generate_figma_design`, `mcp__figma__get_metadata`, `mcp__figma__get_screenshot`, a local static server (`npx serve`)
+- **Config keys read:** `pipeline.config.json` → `conversation.designGeneration.*`, `conversation.retry`

--- a/.claude/skills/figma-intake/SKILL.md
+++ b/.claude/skills/figma-intake/SKILL.md
@@ -22,6 +22,29 @@ Gather everything needed to build a React app from a Figma design in a single st
 
 ## Process
 
+### Step 0: Conversation Fast-Path (Skip the Interview)
+
+If `.claude/plans/build-spec.json` already exists with `"source": "conversation"`, the spec was produced by the `conversation-intake` skill and the Figma file was generated from it by `design-brief-to-figma` — the interview already happened in `/build-from-conversation`. Do **not** re-interview the user. Instead:
+
+```
+1. Verify the spec's figma block is populated (fileKey, url) and matches the
+   URL this skill was invoked with. Mismatch → ask which file wins.
+2. Verify the file is reachable: get_metadata(fileKey).
+3. Backfill any pages[].figmaNodeId that is still null from the metadata
+   (match generated frames to pages by name/order).
+4. Keep "source": "conversation" unchanged — downstream phases treat the spec
+   exactly like a Figma-sourced one; the source value preserves provenance.
+5. Expect no Figma variables in the generated file: token extraction
+   (design-token-lock) will fall back to computed styles, which is correct
+   here because the captured mockups were rendered from the design brief's
+   exact values.
+6. Skip Steps 1-3 below entirely and proceed to Step 4 validation /
+   Step 5 confirmation only if the spec is incomplete; otherwise report
+   "fast-path: spec reused" and hand control back to the pipeline (Phase 2).
+```
+
+If the file at `figma.url` no longer exists, fall through to the normal flow below using the URL the user provided.
+
 ### Step 1: Auto-Discovery (No User Input)
 
 Run these Figma MCP calls to gather context automatically:
@@ -144,7 +167,7 @@ Write the spec file that all downstream phases consume:
 // .claude/plans/build-spec.json
 {
   "version": "1.0.0",
-  "source": "figma",              // "figma" | "canva"
+  "source": "figma",              // "figma" | "canva" | "screenshot" | "conversation"
   "renderer": "vite",             // registry renderer name (from `renderer-registry list`): "nextjs" | "vite" | "sveltekit" | "expo" | "astro" | ...
   "outputTarget": "react",    // resolved language; equals the renderer's language. "react" | "vue" | "svelte" | "react-native"
   "createdAt": "2026-03-16T12:00:00Z",
@@ -270,4 +293,5 @@ Wait for user confirmation before the pipeline continues.
 ## Integration
 
 - **Consumed by:** `design-token-lock`, `tdd-from-figma`, `figma-to-react-workflow`, `/build-from-figma`
+- **Fast-path trigger:** a build-spec with `"source": "conversation"` (written by `conversation-intake` and completed by `design-brief-to-figma` in `/build-from-conversation`) skips the interview — see Step 0
 - **Uses:** Figma MCP (`get_metadata`, `get_variable_defs`, `get_screenshot`), Glob, Read

--- a/.claude/test-fixtures/conversation-dashboard.build-spec.json
+++ b/.claude/test-fixtures/conversation-dashboard.build-spec.json
@@ -1,0 +1,136 @@
+{
+  "version": "1.0.0",
+  "source": "conversation",
+  "renderer": "vite",
+  "outputTarget": "react",
+  "createdAt": "2026-06-11T09:00:00Z",
+  "conversation": {
+    "description": "An analytics dashboard for a small SaaS team: revenue and usage stats at a glance, a sortable customer table, and a settings page. Clean and minimal, brand blue, needs auth and dark mode.",
+    "designBrief": ".claude/plans/design-brief.json",
+    "interviewQuestionCount": 6
+  },
+  "figma": {
+    "fileKey": "GENa1b2c3d4e5f6",
+    "fileName": "Pulse Analytics",
+    "url": "https://figma.com/design/GENa1b2c3d4e5f6/Pulse-Analytics",
+    "generated": true
+  },
+  "appType": "web-app",
+  "framework": {
+    "type": "vite",
+    "version": "8.0.0",
+    "outputDir": "src"
+  },
+  "styling": {
+    "approach": "tailwind",
+    "uiLibrary": "none",
+    "existingTokens": false
+  },
+  "pages": [
+    {
+      "figmaNodeId": "1:2",
+      "name": "Dashboard",
+      "route": "/",
+      "mockupPath": ".claude/design-mockups/dashboard.html",
+      "sections": ["sidebar", "stats-overview", "revenue-chart", "customer-table"]
+    },
+    {
+      "figmaNodeId": "1:48",
+      "name": "Settings",
+      "route": "/settings",
+      "mockupPath": ".claude/design-mockups/settings.html",
+      "sections": ["sidebar", "profile-form", "billing", "danger-zone"]
+    }
+  ],
+  "components": [
+    {
+      "reactName": "Sidebar",
+      "category": "layout",
+      "action": "generate",
+      "existingPath": null,
+      "variants": ["expanded", "collapsed"],
+      "props": ["activeRoute", "collapsed"]
+    },
+    {
+      "reactName": "Navbar",
+      "category": "layout",
+      "action": "generate",
+      "existingPath": null,
+      "variants": [],
+      "props": ["title", "user"]
+    },
+    {
+      "reactName": "StatsCard",
+      "category": "ui",
+      "action": "generate",
+      "existingPath": null,
+      "variants": ["positive", "negative", "neutral"],
+      "props": ["label", "value", "delta"]
+    },
+    {
+      "reactName": "DataTable",
+      "category": "ui",
+      "action": "generate",
+      "existingPath": null,
+      "variants": [],
+      "props": ["columns", "rows", "sortable"]
+    },
+    {
+      "reactName": "ChartPanel",
+      "category": "sections",
+      "action": "generate",
+      "existingPath": null,
+      "variants": [],
+      "props": ["title", "range", "data"]
+    },
+    {
+      "reactName": "SettingsForm",
+      "category": "sections",
+      "action": "generate",
+      "existingPath": null,
+      "variants": [],
+      "props": ["sections", "onSave"]
+    }
+  ],
+  "textContent": {
+    "app-name": "Pulse Analytics",
+    "nav-dashboard": "Dashboard",
+    "nav-settings": "Settings",
+    "stats-revenue-label": "Monthly Revenue",
+    "stats-users-label": "Active Users",
+    "table-heading": "Customers",
+    "settings-heading": "Workspace Settings"
+  },
+  "businessLogic": {
+    "forms": ["settings-profile", "settings-billing"],
+    "apiCalls": ["GET /api/stats", "GET /api/customers", "PATCH /api/settings"],
+    "auth": "required",
+    "stateManagement": "zustand"
+  },
+  "e2e": {
+    "strategy": "navigate-interact-verify",
+    "flows": [
+      {
+        "name": "page-navigation",
+        "description": "Navigate between dashboard and settings and verify rendering",
+        "steps": ["navigate to /", "verify stats cards visible", "click Settings nav item", "verify settings form visible"]
+      },
+      {
+        "name": "table-sorting",
+        "description": "Sort the customer table by a numeric column",
+        "steps": ["navigate to /", "click Revenue column header", "verify rows reorder"]
+      }
+    ]
+  },
+  "testStrategy": {
+    "unit": true,
+    "e2e": true,
+    "visual": true,
+    "crossBrowser": false,
+    "coverageThreshold": 80
+  },
+  "options": {
+    "componentReuse": "reuse",
+    "integration": "standalone"
+  }
+}

--- a/.claude/test-fixtures/conversation-dashboard.design-brief.json
+++ b/.claude/test-fixtures/conversation-dashboard.design-brief.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0.0",
+  "source": "conversation",
+  "createdAt": "2026-06-11T09:05:00Z",
+  "appName": "Pulse Analytics",
+  "styleDirection": "minimal",
+  "colorPreferences": {
+    "primary": "#2563EB",
+    "style": "cool-neutral",
+    "userProvided": true,
+    "notes": "User supplied their brand blue. Cool neutral surfaces keep dense data legible and let the blue carry hierarchy."
+  },
+  "typography": {
+    "style": "modern-sans",
+    "headingStyle": "bold-clean",
+    "notes": "Inter throughout: tight tracking on headings, tabular numerals for stats and tables."
+  },
+  "layoutStyle": {
+    "density": "comfortable",
+    "maxWidth": "1280px",
+    "sidebar": true,
+    "notes": "Persistent 240px left sidebar; content area uses a 12-column grid with 24px gutters."
+  },
+  "componentDescriptions": {
+    "Sidebar": "Fixed left navigation, app logo on top, vertical nav items with icon + label, active item gets a primary-tinted background and left accent bar, collapses to icons below 1024px.",
+    "Navbar": "Slim top bar inside the content area: page title on the left, search field and avatar menu on the right, bottom hairline border.",
+    "StatsCard": "White card with subtle border and small shadow; muted uppercase label, large bold metric, and a delta badge (green up / red down) in the corner.",
+    "DataTable": "Striped rows with sticky header, sortable column headers, row hover highlight, right-aligned numeric columns using tabular numerals, footer pagination.",
+    "ChartPanel": "Card wrapping a line/area chart placeholder with a header row (title left, time-range segmented control right) and a 16:6 plot area.",
+    "SettingsForm": "Two-column form sections with labeled inputs, helper text, destructive zone at the bottom, sticky save bar."
+  },
+  "darkMode": true,
+  "animations": "subtle",
+  "specialRequirements": ["auth", "dark-mode"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a **Claude Code-integrated multi-framework app development framework** p
 
 The framework is designed for:
 - Multi-framework app development (React/Next.js/Vite/Remix, Vue 3, SvelteKit, React Native/Expo)
-- Figma-to-code, Canva-to-code, and Screenshot/URL-to-code conversion with Tailwind CSS
+- Figma-to-code, Canva-to-code, Screenshot/URL-to-code, and Conversation-to-code (generated Figma designs) conversion with Tailwind CSS
 - Comprehensive testing (Vitest, React Testing Library, Playwright, Storybook)
 - Full product lifecycle support (engineering, design, testing, marketing, operations)
 
@@ -17,8 +17,8 @@ The framework is designed for:
 ```
 project-root/
 ├── .claude/              # Claude Code configuration
-│   ├── agents/           # 54 specialized agents
-│   ├── skills/           # 20 React-specific skills
+│   ├── agents/           # 55 specialized agents
+│   ├── skills/           # 22 React-specific skills
 │   ├── commands/         # Custom slash commands
 │   ├── hooks/            # Hook scripts (automated hooks configured in settings.json)
 │   └── pipeline.config.json  # Pipeline thresholds, iteration limits, app types
@@ -29,6 +29,7 @@ project-root/
 │   ├── figma-to-react/   # Figma conversion pipeline docs
 │   ├── canva-to-react/   # Canva conversion pipeline docs
 │   ├── screenshot-to-app/ # Screenshot/URL conversion pipeline docs
+│   ├── conversation-to-app/ # Conversation pipeline docs (generated Figma designs)
 │   ├── multi-framework/  # Multi-framework output target docs
 │   └── react-development/# React development standards
 └── CLAUDE.md             # This file
@@ -210,15 +211,15 @@ pnpm tsc --noEmit         # Type check without emitting
 
 ---
 
-### Custom Agents (54 Total)
+### Custom Agents (55 Total)
 
-54 specialized agents covering the full product lifecycle:
+55 specialized agents covering the full product lifecycle:
 
 | Category | Count | Key Agents |
 |----------|-------|------------|
 | Engineering | 12 | frontend-developer, backend-architect, rapid-prototyper, test-writer-fixer, error-boundary-architect, migration-specialist, i18n-engineer, animation-optimizer, bundle-analyzer |
 | Design | 5 | ui-designer, ux-researcher, brand-guardian |
-| Design-to-Code | 7 | figma-react-converter, canva-react-converter, astro-converter, asset-cataloger, vue-converter, svelte-converter, react-native-converter |
+| Design-to-Code | 8 | figma-react-converter, canva-react-converter, astro-converter, asset-cataloger, vue-converter, svelte-converter, react-native-converter, conversation-designer |
 | Testing & QA | 7 | visual-qa-agent, accessibility-auditor, api-tester, performance-benchmarker |
 | Product | 3 | sprint-prioritizer, feedback-synthesizer, trend-researcher |
 | Marketing | 7 | content-creator, growth-hacker, app-store-optimizer |
@@ -234,7 +235,7 @@ Agents are invoked automatically based on task context.
 
 ---
 
-### Skills (20 Total)
+### Skills (22 Total)
 
 | Skill | Purpose | Triggers |
 |-------|---------|----------|
@@ -251,6 +252,8 @@ Agents are invoked automatically based on task context.
 | canva-intake | Canva design discovery → build-spec.json (with appType) | Phase 1 of /build-from-canva |
 | canva-token-inference | AI-powered token extraction from Canva/screenshot sources | Phase 2 of /build-from-canva and /build-from-screenshot |
 | screenshot-intake | URL/screenshot discovery → build-spec.json (with outputTarget) | "build from screenshot", "clone this site" |
+| conversation-intake | Conversational interview → build-spec.json + design-brief.json (no design file) | Phase C0 of /build-from-conversation |
+| design-brief-to-figma | Generates a real Figma file from design-brief.json via HTML-mockup capture | Phase C1 of /build-from-conversation |
 | state-management | State architecture: Zustand, TanStack Query, URL state | "state management", "zustand", "data fetching" |
 | form-handling | React Hook Form + Zod: typed forms, field arrays, wizards | "form", "validation", "react hook form" |
 | auth-flows | Auth.js, Clerk, Supabase Auth, RBAC, protected routes | "auth", "login", "session", "OAuth" |
@@ -353,6 +356,25 @@ Same 12-phase pipeline as Figma/Canva with screenshot-specific Phase 1:
 Supports all output targets: React, Vue 3, Svelte/SvelteKit, React Native (Expo).
 
 **Documentation:** `docs/screenshot-to-app/README.md`
+
+---
+
+### Conversation-to-App Pipeline
+
+**Single command:** `/build-from-conversation [optional description]`
+
+"Talk to build" — no pre-existing design file required. Two new phases generate a real Figma design from a structured conversation, then hand off to the unchanged `/build-from-figma` pipeline:
+
+- **Phase C0:** conversation-intake (max-7-question interview + conversation-designer agent → `build-spec.json` with `"source": "conversation"` + `design-brief.json`)
+- **Phase C1:** design-brief-to-figma (per-page HTML mockups → new Figma file via `create_new_file` + `generate_figma_design` capture → node IDs mapped into the build spec)
+- **Handoff:** `/build-from-figma <generated URL>` runs phases 0-9 as usual; figma-intake fast-paths on the conversation-sourced build spec (no second interview), and design-token-lock falls back to computed styles (generated files carry no Figma variables)
+
+**Key artifacts:**
+- `design-brief.json` — Style direction, color/typography/layout decisions, and natural-language component descriptions
+- `.claude/design-mockups/*.html` — Per-page mockups captured into Figma (kept for cheap re-capture)
+- `pipeline.config.json` → `conversation` — Interview cap, mockup server, capture polling, review gate, retry policy
+
+**Documentation:** `docs/conversation-to-app/README.md`
 
 ---
 
@@ -512,6 +534,7 @@ Claude: [Uses test-writer-fixer agent]
 /build-from-figma <URL>       # Full autonomous Figma pipeline
 /build-from-canva <URL>       # Full autonomous Canva pipeline
 /build-from-screenshot <URL or paths>  # Full autonomous screenshot pipeline
+/build-from-conversation [description] # Conversational pipeline: interview → generated Figma → build
 /export-design-system [flags] # Export components + tokens as publishable pnpm workspace
 ```
 
@@ -590,7 +613,7 @@ node scripts/metrics-dashboard.js summary  # Quick metrics summary
 
 ---
 
-**Last Updated:** 2026-05-28
-**Architecture:** 54 agents, 20 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 40 scripts, 8 hooks, 5 renderers (nextjs, vite, astro, sveltekit, expo)
+**Last Updated:** 2026-06-11
+**Architecture:** 55 agents, 22 skills, 4 plugins + gh CLI, Figma + Canva + Playwright MCP, 40 scripts, 8 hooks, 5 renderers (nextjs, vite, astro, sveltekit, expo)
 
 > **Keeping counts in sync:** When adding or removing agents, skills, scripts, or hooks, update all count references across the project. Search for the old count number in `*.md` files to find all references: `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/onboarding/`, `docs/react-development/`, and `.claude/AGENT-NAMING-GUIDE.md`. The agent and skill counts are enforced automatically by `scripts/check-doc-counts.sh` (run in CI and on pre-commit), which recounts `.claude/agents/` and `.claude/skills/` and fails on any documented count that disagrees.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ Because the bump is derived from commit history, **conventional commit messages 
 
 ## Claude Code Agents
 
-Aurelius includes 54 specialized Claude Code agents and 20 skills that automate significant portions of the development workflow — from design-to-code conversion to testing, accessibility, and deployment.
+Aurelius includes 55 specialized Claude Code agents and 22 skills that automate significant portions of the development workflow — from design-to-code conversion to testing, accessibility, and deployment.
 
 If you have Claude Code installed, these agents and skills are available to you automatically when working in this repository. They can assist with component development, test writing, visual QA, and much more.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A Claude Code-integrated multi-framework app development framework with TypeScri
 
 ## What This Framework Provides
 
-- **54 Custom Agents** -- Specialized AI agents for engineering, design, testing, marketing, operations, and more
-- **20 Development Skills** -- Automated workflows for Figma/Canva conversion, TDD, E2E testing, visual QA, state management, forms, auth, animation, SEO, and more
-- **10-Phase Design-to-React Pipeline** -- Convert Figma or Canva designs into fully working, tested React apps with a single command
+- **55 Custom Agents** -- Specialized AI agents for engineering, design, testing, marketing, operations, and more
+- **22 Development Skills** -- Automated workflows for Figma/Canva/screenshot/conversation conversion, TDD, E2E testing, visual QA, state management, forms, auth, animation, SEO, and more
+- **10-Phase Design-to-React Pipeline** -- Convert Figma or Canva designs into fully working, tested React apps with a single command -- or just describe the app and let `/build-from-conversation` generate the Figma design first
 - **App-Type Awareness** -- Tailored build and test strategies for web apps, Chrome extensions, and PWAs
 - **Testing Stack** -- Vitest, React Testing Library, Playwright (cross-browser), Storybook, and pixel-diff visual QA
 - **Code Quality Scripts** -- Linting, formatting, type checking, bundle analysis, accessibility scanning, and design token verification
@@ -85,8 +85,8 @@ project-root/
 │   ├── canva-to-react/          # Canva pipeline guide
 │   └── react-development/       # Development standards
 ├── .claude/              # Claude Code configuration
-│   ├── agents/                  # 54 custom agents
-│   ├── skills/                  # 20 development skills
+│   ├── agents/                  # 55 custom agents
+│   ├── skills/                  # 22 development skills
 │   ├── commands/                # Slash commands (/build-from-figma, /lint, /test)
 │   ├── pipeline.config.json     # Pipeline thresholds and app-type definitions
 │   ├── CUSTOM-AGENTS-GUIDE.md   # Agent catalog
@@ -105,6 +105,17 @@ Same 12-phase pipeline as Figma, with AI-powered token inference:
 - Phase 1: Vision-based design discovery (screenshots + Claude analysis)
 - Phase 2: AI token extraction with confidence scoring (requires user confirmation)
 - Phases 3-9: Shared pipeline (TDD, build, visual diff, E2E, quality gate)
+
+### Build from Conversation (Autonomous Pipeline)
+
+```
+/build-from-conversation a minimal analytics dashboard with auth and dark mode
+```
+
+No design file needed -- describe the app and the pipeline designs it first:
+- Phase C0: Structured interview (max 7 questions) → `build-spec.json` + `design-brief.json`
+- Phase C1: The conversation-designer agent renders the brief as HTML mockups, which are captured into a **real Figma file** via the Figma MCP (`generate_figma_design`)
+- Handoff: The generated Figma URL feeds `/build-from-figma`, which runs unchanged (figma-intake fast-paths the interview)
 
 ## The Figma-to-React Pipeline
 
@@ -136,7 +147,7 @@ All thresholds and behavior are configurable in `.claude/pipeline.config.json`:
 - Lighthouse minimums (performance: 80, accessibility: 90)
 - App-type-specific E2E strategies
 
-## 54 Custom Agents
+## 55 Custom Agents
 
 Agents are auto-selected by Claude Code based on your task:
 
@@ -144,7 +155,7 @@ Agents are auto-selected by Claude Code based on your task:
 |----------|-------|------------|
 | Engineering | 12 | frontend-developer, backend-architect, rapid-prototyper, test-writer-fixer, error-boundary-architect, migration-specialist, i18n-engineer, animation-optimizer, bundle-analyzer |
 | Design | 5 | ui-designer, ux-researcher, brand-guardian |
-| Design-to-Code | 7 | figma-react-converter, canva-react-converter, astro-converter, vue-converter, svelte-converter, react-native-converter, asset-cataloger |
+| Design-to-Code | 8 | figma-react-converter, canva-react-converter, astro-converter, vue-converter, svelte-converter, react-native-converter, conversation-designer, asset-cataloger |
 | Testing & QA | 7 | visual-qa-agent, accessibility-auditor, api-tester, performance-benchmarker |
 | Product | 3 | sprint-prioritizer, feedback-synthesizer, trend-researcher |
 | Marketing | 7 | content-creator, growth-hacker, app-store-optimizer |
@@ -154,7 +165,7 @@ Agents are auto-selected by Claude Code based on your task:
 
 Full catalog: `.claude/CUSTOM-AGENTS-GUIDE.md`
 
-## 20 Development Skills
+## 22 Development Skills
 
 ### Pipeline Skills
 
@@ -168,33 +179,35 @@ Full catalog: `.claude/CUSTOM-AGENTS-GUIDE.md`
 | 6 | e2e-test-generator | Generate Playwright E2E tests (app-type-aware) |
 | 7 | parallel-orchestration | Concurrent phase execution with dependency graph |
 
-### Canva & Screenshot Pipeline Skills
+### Canva, Screenshot & Conversation Pipeline Skills
 
 | # | Skill | Purpose |
 |---|-------|---------|
 | 8 | canva-intake | Canva design discovery + build-spec.json generation |
 | 9 | canva-token-inference | AI-powered token extraction from Canva/screenshot sources |
 | 10 | screenshot-intake | URL/screenshot capture + vision-based discovery |
+| 11 | conversation-intake | Conversational interview → build-spec.json + design-brief.json |
+| 12 | design-brief-to-figma | Generate a real Figma file from the design brief (HTML-mockup capture) |
 
 ### React Development Skills
 
 | # | Skill | Purpose |
 |---|-------|---------|
-| 11 | react-component-development | Component patterns, hooks, composition |
-| 12 | react-testing-workflows | Vitest, RTL, Playwright, Storybook |
-| 13 | react-performance-optimization | Profiling, bundle analysis, Web Vitals |
-| 14 | react-accessibility | WCAG 2.1 AA patterns for React |
-| 15 | state-management | Zustand, TanStack Query, URL state architecture |
-| 16 | form-handling | React Hook Form + Zod: typed forms, wizards |
-| 17 | auth-flows | Auth.js, Clerk, Supabase Auth, RBAC |
-| 18 | animation-motion | Framer Motion, CSS transitions, reduced-motion a11y |
-| 19 | seo-metadata | Next.js Metadata API, JSON-LD, OG images, sitemaps |
+| 13 | react-component-development | Component patterns, hooks, composition |
+| 14 | react-testing-workflows | Vitest, RTL, Playwright, Storybook |
+| 15 | react-performance-optimization | Profiling, bundle analysis, Web Vitals |
+| 16 | react-accessibility | WCAG 2.1 AA patterns for React |
+| 17 | state-management | Zustand, TanStack Query, URL state architecture |
+| 18 | form-handling | React Hook Form + Zod: typed forms, wizards |
+| 19 | auth-flows | Auth.js, Clerk, Supabase Auth, RBAC |
+| 20 | animation-motion | Framer Motion, CSS transitions, reduced-motion a11y |
+| 21 | seo-metadata | Next.js Metadata API, JSON-LD, OG images, sitemaps |
 
 ### Export Skills
 
 | # | Skill | Purpose |
 |---|-------|---------|
-| 20 | export-design-system | Export components + tokens as a publishable pnpm workspace |
+| 22 | export-design-system | Export components + tokens as a publishable pnpm workspace |
 
 Full catalog: `.claude/skills/README.md`
 
@@ -270,15 +283,16 @@ Details: `.claude/PLUGINS-REFERENCE.md`
 |----------|----------|-------------|
 | **Developer onboarding** | `docs/onboarding/README.md` | Start here -- quickstart, architecture, configuration, troubleshooting |
 | Quickstart guide | `docs/onboarding/quickstart.md` | Clone to running project in 10 minutes |
-| Architecture overview | `docs/onboarding/architecture.md` | All 54 agents, 20 skills, 3 pipelines, and how they connect |
+| Architecture overview | `docs/onboarding/architecture.md` | All 55 agents, 22 skills, 4 pipelines, and how they connect |
 | Pipeline configuration | `docs/onboarding/pipeline-configuration.md` | Every setting in pipeline.config.json explained |
 | Troubleshooting FAQ | `docs/onboarding/troubleshooting.md` | Common issues and solutions |
 | Project instructions | `CLAUDE.md` | Full project config for Claude Code |
 | Figma pipeline guide | `docs/figma-to-react/README.md` | Pipeline overview and troubleshooting |
 | React standards | `docs/react-development/README.md` | TypeScript, Tailwind, testing conventions |
 | Canva pipeline guide | `docs/canva-to-react/README.md` | Canva pipeline overview and troubleshooting |
-| Agent catalog | `.claude/CUSTOM-AGENTS-GUIDE.md` | All 54 agents with use cases |
-| Skills catalog | `.claude/skills/README.md` | All 20 skills with triggers |
+| Conversation pipeline guide | `docs/conversation-to-app/README.md` | Conversational app creation via generated Figma designs |
+| Agent catalog | `.claude/CUSTOM-AGENTS-GUIDE.md` | All 55 agents with use cases |
+| Skills catalog | `.claude/skills/README.md` | All 22 skills with triggers |
 | Plugin reference | `.claude/PLUGINS-REFERENCE.md` | Plugin configuration and commands |
 | Scripts reference | `scripts/README.md` | All scripts with usage examples |
 | Templates reference | `templates/README.md` | Starter configs and how to use them |

--- a/docs/conversation-to-app/README.md
+++ b/docs/conversation-to-app/README.md
@@ -1,0 +1,127 @@
+# Conversation-to-App Pipeline
+
+Build a working, tested app from nothing but a conversation. `/build-from-conversation` interviews you, generates a **real Figma file** from the resulting design brief, and hands off to the standard `/build-from-figma` pipeline — which runs unchanged.
+
+## Overview
+
+```
+You describe the app ("a minimal analytics dashboard with auth and dark mode")
+        │
+        ▼
+[C0] conversation-intake ──► build-spec.json (source: "conversation")
+        │                    design-brief.json
+        ▼
+[C1] design-brief-to-figma ─► per-page HTML mockups (conversation-designer agent)
+        │                     new Figma file (create_new_file)
+        │                     one capture per page (generate_figma_design)
+        ▼
+/build-from-figma <generated URL> ─► phases 0-9, unchanged
+        (figma-intake fast-paths the conversation-sourced build spec)
+```
+
+The result is the same as any other pipeline run — locked tokens, TDD'd components, pixel-diff visual QA, E2E tests, quality gate — plus a real, editable Figma file in your account that you own going forward.
+
+## Prerequisites
+
+- Figma MCP connected and authenticated (`whoami` must succeed) — the pipeline creates a file in your Figma account
+- A Figma plan to create the file in (if you belong to multiple teams/orgs, the pipeline asks which one)
+- Node.js for the local mockup server (`npx serve`)
+
+No Figma desktop app, no existing design file, no screenshots required.
+
+## Quick Start
+
+```
+/build-from-conversation
+```
+
+or seed the interview with a description (questions it already answers are skipped):
+
+```
+/build-from-conversation a playful recipe-sharing app with three pages and dark mode
+```
+
+The interview asks at most 7 questions (purpose, pages, style direction, colors, framework if undetected, special requirements, component reuse if any exist). You confirm the build plan once before any Figma file is created, and review the generated design once before the build starts. Both gates are configurable.
+
+## How Design Generation Works
+
+There is no text-to-Figma API. The Figma MCP's `generate_figma_design` tool imports a **rendered web page** into an existing Figma file pixel-perfectly. The pipeline exploits that:
+
+1. The `conversation-designer` agent expands your answers into `design-brief.json` — concrete decisions with reasoning (exact palette, type pairing, layout grid, per-component anatomy)
+2. The same agent renders one **self-contained HTML mockup per page** (static, no JS, exact brief values, real copy from the build spec) into `.claude/design-mockups/`
+3. The mockups are served locally and a new Figma file is created (`whoami` → `create_new_file`)
+4. Each page is captured into the file with `generate_figma_design` — one single-use capture per page, polled until complete
+5. `get_metadata` maps the generated frame node IDs back into `build-spec.json`, completing the same contract `figma-intake` would have produced
+
+Because the captured Figma frames are rendered from the brief's exact values, Phase 5's pixel diff later verifies the built app against the very design the conversation produced — the loop is closed end to end.
+
+## How It Differs from the Other Pipelines
+
+| | Figma / Canva / Screenshot | Conversation |
+|---|---|---|
+| Input | An existing design (file, URL, or image) | A description |
+| Phase 1 | Discover the design | Interview → **design** the design |
+| Design artifact | Pre-existing | Generated Figma file (you keep it) |
+| Token source | Figma variables / AI inference | Computed styles from the generated file (no variables exist in captured designs — expected, and accurate because the mockups came from the brief) |
+| Extra artifact | — | `design-brief.json` + HTML mockups |
+
+Everything from TDD scaffolding onward is byte-for-byte the Figma pipeline. The `figma-intake` skill detects `"source": "conversation"` in the existing build spec and fast-paths: no second interview, no rediscovery.
+
+## Configuration
+
+All settings live in `.claude/pipeline.config.json` under `conversation` (see the [Pipeline Configuration Guide](../onboarding/pipeline-configuration.md#conversation-pipeline-conversation)):
+
+- `interview.maxQuestions` (default `7`) and `interview.confirmBriefWithUser` (default `true`)
+- `designGeneration.mockupDir`, `mockupServerPort`, `reviewBeforeHandoff`, `maxRegenerationAttempts`, `capturePollIntervalMs`, `capturePollMaxAttempts`
+- `retry` — exponential backoff for capture failures (shared `retryOptions` shape)
+
+## Conversation-Specific Skills
+
+| Skill | Phase | Output |
+|-------|-------|--------|
+| `conversation-intake` | C0 | `build-spec.json` (`source: "conversation"`) + `design-brief.json` |
+| `design-brief-to-figma` | C1 | Figma file URL + build spec completed with `figma` block and node IDs |
+
+## Conversation-Specific Agent
+
+`conversation-designer` — interprets natural language into concrete design decisions, authors the design brief, and generates the HTML mockups. Its style-direction defaults table (minimal / bold / playful / corporate / dark) is what turns "make it clean" into specific hex values and spacing.
+
+## The design-brief.json Artifact
+
+```jsonc
+{
+  "version": "1.0.0",
+  "source": "conversation",
+  "appName": "Pulse Analytics",
+  "styleDirection": "minimal",                  // minimal | bold | playful | corporate | dark | custom
+  "colorPreferences": { "primary": "#2563EB", "style": "cool-neutral", "userProvided": true, "notes": "…" },
+  "typography": { "style": "modern-sans", "headingStyle": "bold-clean", "notes": "…" },
+  "layoutStyle": { "density": "comfortable", "maxWidth": "1280px", "sidebar": true, "notes": "…" },
+  "componentDescriptions": { "StatsCard": "White card with muted label, large metric, delta badge…" },
+  "darkMode": true,
+  "animations": "subtle",                       // none | subtle | expressive
+  "specialRequirements": ["auth", "dark-mode"]
+}
+```
+
+Every decision carries a `notes` field — the designer's reasoning survives into review, so disagreements are about recorded choices, not guesses.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Figma MCP unauthenticated" at C1 | No Figma session | Verify with `whoami`; re-authenticate the Figma MCP. C0 artifacts survive — resume at C1. |
+| Asked which team/org to use | Multiple Figma plans | Answer once; the `planKey` is used for `create_new_file`. The pipeline never guesses. |
+| Capture times out | Slow render or MCP hiccup | Retried automatically per `conversation.retry` with a fresh capture. Persistent failures are listed for manual re-capture. |
+| Mockup server port conflict | Port 4173 in use | The pipeline increments the port and retries; or set `designGeneration.mockupServerPort`. |
+| "No Figma variables found" in Phase 2 | Captured designs carry styles, not variable definitions | Expected. `design-token-lock` falls back to computed styles, which match the brief because the mockups were generated from it. |
+| Generated design isn't what you meant | Brief misread your intent | Reject at the review gate with feedback — affected pages regenerate (max `maxRegenerationAttempts`), or hand-edit the Figma file and run `/build-from-figma <url>` directly. |
+
+## Related Documentation
+
+- [Figma-to-React Pipeline](../figma-to-react/README.md) — the pipeline this one hands off to
+- [Pipeline Configuration Guide](../onboarding/pipeline-configuration.md) — every `conversation.*` setting
+- [Architecture Overview](../onboarding/architecture.md) — how the four pipelines fit together
+- `.claude/commands/build-from-conversation.md` — the orchestrator command
+- `.claude/skills/conversation-intake/SKILL.md`, `.claude/skills/design-brief-to-figma/SKILL.md` — phase skills
+- `.claude/agents/conversation-designer.md` — the designing agent

--- a/docs/guides/agent-creation.md
+++ b/docs/guides/agent-creation.md
@@ -2,7 +2,7 @@
 
 Agents are specialized Markdown files with YAML frontmatter that live in `.claude/agents/`. Each agent defines a persona, a set of allowed tools, and detailed instructions that shape how Claude Code behaves when the agent is selected. Claude Code reads the `description` field to decide which agent best matches a given task, then loads that agent's instructions as the system prompt for the session.
 
-This framework ships with 54 agents covering engineering, design, testing, marketing, and operations. You can add your own by following the conventions below.
+This framework ships with 55 agents covering engineering, design, testing, marketing, and operations. You can add your own by following the conventions below.
 
 ## File Location
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,7 +11,7 @@ This guide will get you productive with the framework quickly, whether you are b
 | Document | What You Will Learn |
 |----------|-------------------|
 | [Quickstart Guide](quickstart.md) | Clone, install, create your first project, and run your first pipeline in under 10 minutes |
-| [Architecture Overview](architecture.md) | How the 54 agents, 20 skills, 3 pipelines, and 8 hooks fit together |
+| [Architecture Overview](architecture.md) | How the 55 agents, 22 skills, 4 pipelines, and 8 hooks fit together |
 | [Pipeline Configuration](pipeline-configuration.md) | Every setting in `pipeline.config.json` explained, with examples |
 | [Troubleshooting FAQ](troubleshooting.md) | Common issues, error messages, and how to resolve them |
 | [Framework Guides](../guides/README.md) | Deep dives into design tokens, visual QA, caching, hooks, error recovery, agent creation, and framework-specific workflows |
@@ -21,7 +21,7 @@ This guide will get you productive with the framework quickly, whether you are b
 ## Who Is This For?
 
 - **New contributors** who want to understand the project structure before making changes
-- **App developers** using Aurelius to build production applications from Figma, Canva, or screenshot designs
+- **App developers** using Aurelius to build production applications from Figma, Canva, or screenshot designs -- or from a plain conversation (`/build-from-conversation`)
 - **Claude Code users** who want to understand how the agents and skills enhance their workflow
 - **Framework maintainers** who need to add new agents, skills, or pipeline phases
 
@@ -52,14 +52,15 @@ Optional (for specific workflows):
 
 - [Main README](../../README.md) -- Project overview
 - [Contributing Guide](../../CONTRIBUTING.md) -- Branch naming, PR process, commit conventions
-- [Agent Catalog](../../.claude/CUSTOM-AGENTS-GUIDE.md) -- All 54 agents with use cases
-- [Skills Catalog](../../.claude/skills/README.md) -- All 20 skills with triggers
+- [Agent Catalog](../../.claude/CUSTOM-AGENTS-GUIDE.md) -- All 55 agents with use cases
+- [Skills Catalog](../../.claude/skills/README.md) -- All 22 skills with triggers
 - [Plugin Reference](../../.claude/PLUGINS-REFERENCE.md) -- Installed plugins and commands
 - [Pipeline Config](../../.claude/pipeline.config.json) -- Thresholds and app-type definitions
 - [React Development Standards](../react-development/README.md) -- TypeScript, Tailwind, testing conventions
 - [Figma Pipeline Guide](../figma-to-react/README.md) -- Figma-to-React pipeline deep dive
 - [Canva Pipeline Guide](../canva-to-react/README.md) -- Canva-to-React pipeline deep dive
 - [Screenshot Pipeline Guide](../screenshot-to-app/README.md) -- Screenshot/URL-to-app pipeline
+- [Conversation Pipeline Guide](../conversation-to-app/README.md) -- Conversational app creation via generated Figma designs
 - [Multi-Framework Guide](../multi-framework/README.md) -- Vue, Svelte, React Native output targets
 
 ---

--- a/docs/onboarding/architecture.md
+++ b/docs/onboarding/architecture.md
@@ -15,15 +15,16 @@ This document explains how Aurelius is structured and how its components work to
              ┌────────────────────┼─────────────────────┐
              │                    │                      │
      ┌───────▼──────┐   ┌────────▼────────┐   ┌────────▼────────┐
-     │   54 Agents   │   │    20 Skills    │   │    4 Plugins    │
+     │   55 Agents   │   │    22 Skills    │   │    4 Plugins    │
      │ (specialized  │   │  (workflow      │   │ (extensions:    │
      │  task workers) │   │   automation)  │   │  memory, git,   │
      └───────┬──────┘   └────────┬────────┘   │  superpowers)   │
              │                    │            └────────┬────────┘
              │           ┌────────▼────────┐            │
-             │           │  3 Pipelines    │            │
+             │           │  4 Pipelines    │            │
              │           │ (Figma, Canva,  │            │
-             │           │  Screenshot)    │            │
+             │           │  Screenshot,    │            │
+             │           │  Conversation)  │            │
              │           └────────┬────────┘            │
              │                    │                      │
      ┌───────▼────────────────────▼──────────────────────▼───────┐
@@ -37,7 +38,7 @@ This document explains how Aurelius is structured and how its components work to
 
 ---
 
-## Agents (54 Total)
+## Agents (55 Total)
 
 Agents are specialized Claude Code sub-processes that handle complex, multi-step tasks. Each agent is a markdown file in `.claude/agents/` with frontmatter defining its tools, capabilities, and instructions. Claude Code selects agents automatically based on your task context.
 
@@ -68,11 +69,12 @@ Agents are specialized Claude Code sub-processes that handle complex, multi-step
 | `visual-storyteller` | Create data visualizations, infographics, presentations |
 | `whimsy-injector` | Add micro-interactions and delightful UI details (runs proactively after UI changes) |
 
-### Design-to-Code Agents (7)
+### Design-to-Code Agents (8)
 
 | Agent | Purpose | Output |
 |-------|---------|--------|
 | `figma-react-converter` | Convert Figma designs to React components via Figma MCP | React + TypeScript + Tailwind |
+| `conversation-designer` | Turn described intent into concrete design decisions and mockups for Figma generation | design-brief.json + HTML mockups |
 | `canva-react-converter` | Convert Canva designs using screenshots and vision analysis | React + TypeScript + Tailwind |
 | `vue-converter` | Convert designs to Vue 3 components | Vue 3 + `<script setup>` + TypeScript |
 | `svelte-converter` | Convert designs to Svelte 5 components | SvelteKit + TypeScript + Tailwind |
@@ -142,7 +144,7 @@ Agents are specialized Claude Code sub-processes that handle complex, multi-step
 
 ---
 
-## Skills (20 Total)
+## Skills (22 Total)
 
 Skills are automated workflows triggered by slash commands or keyword detection. Unlike agents (which are general-purpose workers), skills encode specific multi-step processes.
 
@@ -153,6 +155,8 @@ Skills are automated workflows triggered by slash commands or keyword detection.
 | `figma-intake` | Phase 1 (Figma) | Auto-discovers Figma file structure, asks 3-5 targeted questions, produces `build-spec.json` |
 | `canva-intake` | Phase 1 (Canva) | Vision-based discovery from Canva screenshots via MCP |
 | `screenshot-intake` | Phase 1 (Screenshot) | Captures URL or reads images, vision-based analysis |
+| `conversation-intake` | Phase C0 (Conversation) | Max-7-question interview → `build-spec.json` + `design-brief.json` (no design file) |
+| `design-brief-to-figma` | Phase C1 (Conversation) | Generates a real Figma file from the brief via HTML-mockup capture |
 | `design-token-lock` | Phase 2 | Extracts design tokens into `design-tokens.lock.json` + Tailwind config |
 | `canva-token-inference` | Phase 2 (Canva/Screenshot) | AI-powered token extraction with confidence scoring |
 | `tdd-from-figma` | Phase 3 | Writes failing tests for every component (RED phase, app-type-aware) |
@@ -180,13 +184,15 @@ Skills are automated workflows triggered by slash commands or keyword detection.
 
 ## Pipelines
 
-Three autonomous pipelines convert designs into working, tested applications. All three share phases 3-9; they differ only in how they discover the design and extract tokens.
+Four autonomous pipelines convert designs into working, tested applications. All of them share phases 3-9; they differ in how they obtain the design and extract tokens. The conversation pipeline is the special case: it has no input design at all, so it *generates* a real Figma file first (interview → design brief → HTML mockups → Figma capture) and then joins the Figma path, whose `figma-intake` skill fast-paths conversation-sourced build specs.
 
 ### Pipeline Flow
 
 ```
 INPUT SOURCE                    SHARED PIPELINE
 ─────────────                   ───────────────
+Conversation ─► conversation-intake → design-brief-to-figma
+                  (generates a real Figma file, then joins ▼)
 Figma URL ──► figma-intake      [3] TDD Scaffold (hard gate)
 Canva URL ──► canva-intake      [4] Component Build
 Screenshot ──► screenshot-intake [5] Visual Diff (pixelmatch loop)
@@ -198,7 +204,9 @@ Screenshot ──► screenshot-intake [5] Visual Diff (pixelmatch loop)
          Token Extraction
          (Figma: direct API,
           Canva/Screenshot:
-          AI inference)
+          AI inference,
+          Conversation: computed
+          styles from generated file)
               │
               ▼
          design-tokens.lock.json
@@ -366,7 +374,7 @@ Model Context Protocol servers provide external tool access to agents.
 | Server | Purpose | Required For |
 |--------|---------|-------------|
 | Figma Desktop MCP | Local Figma integration (port 3845) | Figma pipeline phases 1-2, 5 |
-| Figma Remote MCP | Fallback remote Figma access | Figma pipeline (when desktop unavailable) |
+| Figma Remote MCP | Fallback remote Figma access; file creation and design capture | Figma pipeline (when desktop unavailable); conversation pipeline design generation (`create_new_file`, `generate_figma_design`) |
 | Chrome DevTools MCP | Screenshots, Lighthouse, DOM inspection | Visual QA, quality gate |
 | Playwright MCP | Cross-browser testing (Chromium, Firefox, WebKit) | E2E and cross-browser phases |
 | Canva AI Connector | Search, export, interact with Canva designs | Canva pipeline phases 1-2 |
@@ -381,6 +389,7 @@ These files are generated and consumed by the pipeline:
 | File | Created By | Used By | Purpose |
 |------|-----------|---------|---------|
 | `build-spec.json` | Intake skills | All pipeline phases | Machine-readable build plan (app type, components, output target, E2E flows) |
+| `design-brief.json` | conversation-intake (via conversation-designer agent) | design-brief-to-figma | Style direction, color/typography/layout decisions, and component descriptions that drive Figma generation |
 | `design-tokens.lock.json` | Token lock / inference skills | Component build, token verification | Single source of truth for all design values |
 | `build-report.md` | Report phase | Developer review | Final pipeline report with screenshots and metrics |
 | `pipeline.config.json` | Manual configuration | All pipeline phases | Thresholds, app types, orchestration settings |

--- a/docs/onboarding/pipeline-configuration.md
+++ b/docs/onboarding/pipeline-configuration.md
@@ -948,6 +948,70 @@ Screenshot/URL capture pipeline configuration.
 
 ---
 
+## Conversation Pipeline (`conversation`)
+
+Conversation pipeline configuration: structured-interview limits and Figma design generation for `/build-from-conversation`.
+
+| Field              | Type      | Default   | Description                                                  |
+| ------------------ | --------- | --------- | ------------------------------------------------------------ |
+| `enabled`          | `boolean` | `true`    | Enable the conversation pipeline.                            |
+| `interview`        | `object`  | see below | Interview limits (sub-table).                                |
+| `designGeneration` | `object`  | see below | HTML-mockup rendering and Figma capture options (sub-table). |
+| `retry`            | `retryOptions` | see below | Exponential-backoff retry for Figma MCP capture failures (shared type). |
+
+**`interview`:**
+
+| Field                  | Type             | Default | Description                                                              |
+| ---------------------- | ---------------- | ------- | ------------------------------------------------------------------------ |
+| `maxQuestions`         | `integer (1–10)` | `7`     | Upper bound on interview questions asked during `conversation-intake`.   |
+| `confirmBriefWithUser` | `boolean`        | `true`  | Block before design generation until the user confirms the design brief and build plan. |
+
+**`designGeneration`:**
+
+| Field                     | Type                | Default                     | Description                                                                    |
+| ------------------------- | ------------------- | --------------------------- | ------------------------------------------------------------------------------ |
+| `mockupDir`               | `string`            | `".claude/design-mockups"`  | Directory where per-page HTML mockups are written before Figma capture.        |
+| `mockupServerPort`        | `integer (1–65535)` | `4173`                      | Local port for the static server that hosts mockups during `generate_figma_design` capture. |
+| `reviewBeforeHandoff`     | `boolean`           | `true`                      | Show the generated Figma file to the user for approval before invoking `/build-from-figma`. |
+| `maxRegenerationAttempts` | `integer (≥0)`      | `2`                         | Max brief-revision/regeneration loops when the user rejects the generated design. |
+| `capturePollIntervalMs`   | `integer (≥0)`      | `5000`                      | Delay between `generate_figma_design` capture status polls.                    |
+| `capturePollMaxAttempts`  | `integer (≥1)`      | `10`                        | Max capture status polls per page before the capture is considered failed.     |
+
+**`retry`** (shared `retryOptions` type — same shape as `canva.retry`): `maxAttempts` `3`, `initialDelayMs` `2000`, `backoffMultiplier` `2`, `maxDelayMs` `30000`, `retryableErrors` `["rate_limit", "timeout", "server_error", "capture_failed", "mcp_connection_lost"]`.
+
+```json
+"conversation": {
+  "enabled": true,
+  "interview": {
+    "maxQuestions": 7,
+    "confirmBriefWithUser": true
+  },
+  "designGeneration": {
+    "mockupDir": ".claude/design-mockups",
+    "mockupServerPort": 4173,
+    "reviewBeforeHandoff": true,
+    "maxRegenerationAttempts": 2,
+    "capturePollIntervalMs": 5000,
+    "capturePollMaxAttempts": 10
+  },
+  "retry": {
+    "maxAttempts": 3,
+    "initialDelayMs": 2000,
+    "backoffMultiplier": 2,
+    "maxDelayMs": 30000,
+    "retryableErrors": [
+      "rate_limit",
+      "timeout",
+      "server_error",
+      "capture_failed",
+      "mcp_connection_lost"
+    ]
+  }
+}
+```
+
+---
+
 ## Orchestration (`orchestration`)
 
 Parallel phase-execution graph. Phase keys are arbitrary; each phase's `depends[]` entries must reference other keys in the same `phases` map.

--- a/docs/onboarding/quickstart.md
+++ b/docs/onboarding/quickstart.md
@@ -108,7 +108,7 @@ Captures the page, analyzes it with vision, and builds a working app. Supports a
 
 ## 5. Using Claude Code Agents
 
-When you work with Claude Code in this repository, **54 specialized agents** are available automatically. You do not need to invoke them manually -- Claude Code selects the right agent based on your task.
+When you work with Claude Code in this repository, **55 specialized agents** are available automatically. You do not need to invoke them manually -- Claude Code selects the right agent based on your task.
 
 ### Examples
 
@@ -142,6 +142,7 @@ Skills are invoked with slash commands. Key ones:
 | `/build-from-figma <URL>` | Full Figma-to-app pipeline |
 | `/build-from-canva <URL>` | Full Canva-to-app pipeline |
 | `/build-from-screenshot <URL>` | Full screenshot-to-app pipeline |
+| `/build-from-conversation [description]` | Describe an app → generated Figma design → full pipeline |
 | `/commit` | Structured git commit |
 | `/commit-push-pr` | Commit, push, and create PR |
 | `/lint` | Run ESLint + Prettier |
@@ -186,8 +187,8 @@ The pipeline auto-detects the framework from `package.json` if `outputTarget` is
 ```
 Aurelius/
 ├── .claude/
-│   ├── agents/              # 54 specialized agents
-│   ├── skills/              # 20 development skills
+│   ├── agents/              # 55 specialized agents
+│   ├── skills/              # 22 development skills
 │   ├── commands/            # Slash commands (/build-from-figma, /lint, /test)
 │   ├── hooks/               # Hook scripts (8 automated hooks)
 │   ├── pipeline.config.json # All pipeline thresholds and behavior

--- a/docs/plans/2026-06-11-build-from-conversation-pipeline.md
+++ b/docs/plans/2026-06-11-build-from-conversation-pipeline.md
@@ -1,0 +1,92 @@
+# /build-from-conversation Pipeline Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `/build-from-conversation` command that interviews the user, generates a real Figma file from the resulting design brief, and hands off to the existing `/build-from-figma` pipeline (issue #33).
+
+**Architecture:** Two new pre-pipeline phases. Phase C0 (`conversation-intake` skill) interviews the user (max 7 questions) and writes `build-spec.json` (`"source": "conversation"`) plus a new `design-brief.json` artifact. Phase C1 (`design-brief-to-figma` skill) has the new `conversation-designer` agent render the brief as one self-contained HTML mockup per page, serves them locally, creates a Figma file (`mcp__figma__whoami` → `mcp__figma__create_new_file`), captures each mockup into it via `mcp__figma__generate_figma_design` (one single-use captureId per page, poll ~5s up to 10×), maps generated node IDs into the build spec via `get_metadata`, then invokes `/build-from-figma` with the new URL. `figma-intake` gains a fast-path that skips the interview when the spec's source is `"conversation"`. The `/build-from-figma` pipeline itself is unchanged.
+
+**Tech Stack:** Markdown skill/agent/command definitions, `pipeline.config.json` + JSON Schema, Vitest structural tests (pattern: `scripts/__tests__/canva-pipeline.test.js`), Figma MCP (whoami / create_new_file / generate_figma_design / get_metadata).
+
+**Key facts discovered during research (do not re-derive):**
+
+- `mcp__figma__generate_figma_design` is a *web-page/HTML → Figma* capture tool, NOT text-to-design. It requires an existing `fileKey`, captures exactly one page per call, returns a capture script + single-use `captureId` on the first call, and is polled with that `captureId` (~every 5s, up to 10×) until `completed`. Localhost URLs are supported. Hence the HTML-mockup intermediate step.
+- `mcp__figma__create_new_file` requires `planKey` (from `whoami`; ask the user only if they have multiple plans) and `editorType: "design"`. Its description asks to load the Figma-served `figma-create-new-file` skill (`skill://figma/figma-create-new-file/SKILL.md`) first when available.
+- Captured designs have **no Figma variables**, so Phase 2 (`design-token-lock`) falls back to computed styles — an already-documented fallback in `figma-intake`.
+- `check-doc-counts.sh` counts agents (`.claude/agents/*.md`, README excluded) and skills (subdirs of `.claude/skills/` containing `SKILL.md`) and fails on any stale "N agents"/"N skills" claim in live `*.md` (CHANGELOG/RELEASE_NOTES/docs/plans excluded). New totals: **55 agents, 22 skills**. Also fix the two un-enforced "3 pipelines" claims → 4.
+- `build-spec.json` `source` values now: `"figma" | "canva" | "screenshot" | "conversation"`.
+- Husky pre-commit runs the doc-count guard; commitlint enforces Conventional Commits.
+
+---
+
+### Task 1: Failing structural tests + fixtures (RED)
+
+**Files:**
+- Create: `scripts/__tests__/conversation-pipeline.test.js`
+- Create: `.claude/test-fixtures/conversation-dashboard.build-spec.json`
+- Create: `.claude/test-fixtures/conversation-dashboard.design-brief.json`
+
+Test groups (mirror `canva-pipeline.test.js` style):
+1. design-brief fixture: version, `source: "conversation"`, styleDirection enum, colorPreferences (style enum, userProvided bool), typography.style enum, layoutStyle.density enum, componentDescriptions = non-empty map of strings, darkMode bool, animations enum, specialRequirements array.
+2. build-spec fixture: `source: "conversation"`, `conversation` block (description, designBrief path), populated `figma` block (fileKey, url matching `figma.com/design/`), pages with figmaNodeId/name/route/sections, components with reactName + category enum, valid outputTarget.
+3. `pipeline.config.json` → `conversation` section: enabled, interview.maxQuestions 1–7, interview.confirmBriefWithUser true, designGeneration (mockupDir, mockupServerPort, reviewBeforeHandoff, maxRegenerationAttempts ≥1, capturePollIntervalMs > 0, capturePollMaxAttempts ≥ 1), retry (same assertions as canva.retry).
+4. `pipeline.config.schema.json` declares `properties.conversation` with retry `$ref` to retryOptions.
+5. `conversation-intake/SKILL.md`: mentions design-brief.json, max-7-questions, `"source": "conversation"`, renderer registry detection.
+6. `design-brief-to-figma/SKILL.md`: mentions generate_figma_design, create_new_file, whoami/planKey, captureId + polling, get_metadata → figmaNodeId mapping, HTML mockups, single-use captures.
+7. `conversation-designer.md` agent: frontmatter name, design-brief.json schema ownership, HTML mockup rules, style directions (minimal/bold/playful/corporate/dark).
+8. `build-from-conversation.md` command: references conversation-intake, design-brief-to-figma, /build-from-figma handoff, $ARGUMENTS, fast-path note, `conversation` config.
+9. `figma-intake/SKILL.md` fast-path: contains `"source": "conversation"` skip-interview rule.
+
+Run: `pnpm vitest run scripts/__tests__/conversation-pipeline.test.js` → expect FAIL (missing config section + files).
+
+### Task 2: `pipeline.config.json` + schema (`conversation` section)
+
+- Modify: `.claude/pipeline.config.json` — add `conversation` after `screenshot`: enabled, interview{maxQuestions: 7, confirmBriefWithUser: true}, designGeneration{mockupDir ".claude/design-mockups", mockupServerPort 4173, reviewBeforeHandoff true, maxRegenerationAttempts 2, capturePollIntervalMs 5000, capturePollMaxAttempts 10}, retry (canva-style; retryableErrors include rate_limit, timeout, server_error, capture_failed, mcp_connection_lost).
+- Modify: `.claude/pipeline.config.schema.json` — add matching `conversation` property (additionalProperties: false throughout; retry → `#/$defs/retryOptions`).
+- Verify: `./scripts/validate-pipeline-config.sh`.
+
+### Task 3: `conversation-designer` agent
+
+Create `.claude/agents/conversation-designer.md` (frontmatter: name/description/color/tools). Owns: natural-language → concrete design decisions, design-brief.json authoring, style-direction defaults table, per-component visual specs, self-contained HTML mockup generation rules (1440px desktop frame, inline tokens, Google Fonts only, no JS, deterministic), regeneration on feedback.
+
+### Task 4: `conversation-intake` skill
+
+Create `.claude/skills/conversation-intake/SKILL.md`: local-project auto-discovery (renderer registry, app type, components, UI libs), max-7-question interview (purpose, pages, style, colors, renderer-if-undetected, special requirements, reuse-if-components-found), conversation-designer expansion, writes `.claude/plans/design-brief.json` + `.claude/plans/build-spec.json` with `"source": "conversation"` and `figma: null` (pending generation), confirm-and-proceed gate.
+
+### Task 5: `design-brief-to-figma` skill
+
+Create `.claude/skills/design-brief-to-figma/SKILL.md` per the architecture above (preflight whoami/planKey → mockups → static server (`npx serve`) → create_new_file → per-page generate_figma_design capture+poll → get_metadata node-ID mapping → build-spec figma block update → optional review gate → output URL). Error handling: capture timeout/retry, multiple plans, MCP down, no-variables token fallback note.
+
+### Task 6: `/build-from-conversation` command
+
+Create `.claude/commands/build-from-conversation.md` (allowed-tools frontmatter incl. figma write tools + chrome-devtools): Phase C0 (intake), Phase C1 (design generation), handoff (invoke `build-from-figma` with generated URL; note figma-intake fast-path, token-lock computed-style fallback, Phase 0 skip on greenfield), resume checks, error recovery, completion summary.
+
+### Task 7: `figma-intake` fast-path
+
+Modify `.claude/skills/figma-intake/SKILL.md`: new Step 0 — if `.claude/plans/build-spec.json` exists with `"source": "conversation"` and a populated `figma` block, skip discovery questions; validate spec, backfill missing `figmaNodeId`s via get_metadata, do not re-interview, proceed to Phase 2. Update `source` comment enum + Integration section.
+
+Run: `pnpm vitest run scripts/__tests__/conversation-pipeline.test.js` → expect PASS (GREEN).
+
+### Task 8: Documentation sweep
+
+- `CLAUDE.md`: tree counts 55/22, agents table (Design-to-Code 7→8 + conversation-designer), skills table header 22 + 2 rows, new "Conversation-to-App Pipeline" section, Quick Command Reference + docs tree + architecture footer (55 agents, 22 skills) + Last Updated 2026-06-11.
+- `README.md`: 55/22 claims, new quick-start block, Design-to-Code 7→8, skills tables renumbered (8–12 pipeline source skills, 13–21 react, 22 export), doc index row, "3 pipelines"→4.
+- `.claude/skills/README.md`: Total 22, two new entries, renumber, pipeline flow diagram + Last Updated.
+- `.claude/CUSTOM-AGENTS-GUIDE.md`: Total 55, Design-to-Code row, integration table row, "20 custom skills"→22, quick-reference row, Last Updated.
+- `.claude/AGENT-NAMING-GUIDE.md`: 54→55.
+- `docs/onboarding/architecture.md`: 54/20→55/22, "3 Pipelines"→4 (diagram), Design-to-Code (8), pipeline-skills table + flow, key artifacts (design-brief.json).
+- `docs/onboarding/README.md` (14), `docs/onboarding/quickstart.md` (111, 189–190), `docs/react-development/README.md` (178–179, 206–207), `CONTRIBUTING.md` (140), `docs/guides/agent-creation.md` (5): count updates.
+- `docs/onboarding/pipeline-configuration.md`: new "Conversation Pipeline (`conversation`)" section after Screenshot.
+- Create `docs/conversation-to-app/README.md` (pipeline guide, mirrors canva guide structure, concise; documents the HTML-capture mechanism and the no-variables token fallback).
+
+### Task 9: Verify
+
+- `pnpm vitest run` (full suite)
+- `./scripts/validate-pipeline-config.sh`
+- `./scripts/check-doc-counts.sh`
+- `pnpm eslint scripts/__tests__/conversation-pipeline.test.js`
+- `pnpm prettier --check` on touched JSON/JS
+
+### Task 10: Ship
+
+Conventional commits (feat + docs split if clean), push branch `33-feat-add-build-from-conversation-command-conversational-app-creation-via-figma-generation`, PR → main, body `Closes #33`. GPG signing may stall — retry, never bypass.

--- a/docs/react-development/README.md
+++ b/docs/react-development/README.md
@@ -175,8 +175,8 @@ project-root/
 ├── templates/            # Starter configs (shared, Next.js, Vite, Chrome ext)
 ├── docs/                 # Documentation
 └── .claude/              # Claude Code configuration
-    ├── agents/           # 54 custom agents
-    ├── skills/           # 20 development skills
+    ├── agents/           # 55 custom agents
+    ├── skills/           # 22 development skills
     └── pipeline.config.json
 ```
 
@@ -203,8 +203,8 @@ pnpm build
 
 - `docs/figma-to-react/README.md` -- Figma-to-React conversion pipeline
 - `docs/canva-to-react/README.md` -- Canva-to-React conversion pipeline
-- `.claude/skills/README.md` -- Skills catalog (20 skills)
-- `.claude/CUSTOM-AGENTS-GUIDE.md` -- Agent catalog (54 agents)
+- `.claude/skills/README.md` -- Skills catalog (22 skills)
+- `.claude/CUSTOM-AGENTS-GUIDE.md` -- Agent catalog (55 agents)
 - `.claude/PLUGINS-REFERENCE.md` -- Plugin reference
 - `scripts/README.md` -- Scripts reference
 - `templates/README.md` -- Template configs reference

--- a/scripts/__tests__/conversation-pipeline.test.js
+++ b/scripts/__tests__/conversation-pipeline.test.js
@@ -1,0 +1,298 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..", "..");
+const FIXTURES = join(ROOT, ".claude", "test-fixtures");
+const AGENTS = join(ROOT, ".claude", "agents");
+const SKILLS = join(ROOT, ".claude", "skills");
+const COMMANDS = join(ROOT, ".claude", "commands");
+const CONFIG_PATH = join(ROOT, ".claude", "pipeline.config.json");
+const SCHEMA_PATH = join(ROOT, ".claude", "pipeline.config.schema.json");
+
+function loadJson(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function loadMarkdown(path) {
+  return readFileSync(path, "utf-8");
+}
+
+// --- Design Brief Validation ---
+
+describe("conversation design-brief validation — dashboard template", () => {
+  const brief = loadJson(join(FIXTURES, "conversation-dashboard.design-brief.json"));
+
+  it("has version and conversation source", () => {
+    expect(brief.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(brief.source).toBe("conversation");
+  });
+
+  it("has a valid style direction", () => {
+    expect(["minimal", "bold", "playful", "corporate", "dark", "custom"]).toContain(
+      brief.styleDirection,
+    );
+  });
+
+  it("has color preferences with style family and provenance", () => {
+    const colors = brief.colorPreferences;
+    expect(colors).toBeDefined();
+    expect(["cool-neutral", "warm-neutral", "vibrant", "monochrome", "custom"]).toContain(
+      colors.style,
+    );
+    expect(typeof colors.userProvided).toBe("boolean");
+    if (colors.primary !== null) {
+      expect(colors.primary).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+    expect(colors.notes).toBeTruthy();
+  });
+
+  it("has typography decisions", () => {
+    expect(["modern-sans", "classic-serif", "geometric", "humanist", "monospace"]).toContain(
+      brief.typography.style,
+    );
+    expect(["bold-clean", "elegant", "casual", "technical"]).toContain(
+      brief.typography.headingStyle,
+    );
+  });
+
+  it("has layout style decisions", () => {
+    expect(["compact", "comfortable", "spacious"]).toContain(brief.layoutStyle.density);
+    expect(brief.layoutStyle.maxWidth).toMatch(/^\d+px$/);
+    expect(typeof brief.layoutStyle.sidebar).toBe("boolean");
+  });
+
+  it("describes every component in natural language", () => {
+    const descriptions = brief.componentDescriptions;
+    expect(Object.keys(descriptions).length).toBeGreaterThan(0);
+    for (const [name, description] of Object.entries(descriptions)) {
+      expect(name).toMatch(/^[A-Z][A-Za-z0-9]*$/);
+      expect(typeof description).toBe("string");
+      expect(description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("captures dark mode, animation, and special requirements", () => {
+    expect(typeof brief.darkMode).toBe("boolean");
+    expect(["none", "subtle", "expressive"]).toContain(brief.animations);
+    expect(brief.specialRequirements).toBeInstanceOf(Array);
+  });
+});
+
+// --- Build Spec Validation ---
+
+describe("conversation build-spec validation — dashboard template", () => {
+  const spec = loadJson(join(FIXTURES, "conversation-dashboard.build-spec.json"));
+
+  it("has source set to conversation", () => {
+    expect(spec.source).toBe("conversation");
+  });
+
+  it("has conversation metadata pointing at the design brief", () => {
+    expect(spec.conversation).toBeDefined();
+    expect(spec.conversation.description).toBeTruthy();
+    expect(spec.conversation.designBrief).toMatch(/design-brief\.json$/);
+  });
+
+  it("has a populated figma block after design generation", () => {
+    expect(spec.figma).toBeDefined();
+    expect(spec.figma.fileKey).toBeTruthy();
+    expect(spec.figma.url).toMatch(/figma\.com\/design\//);
+    expect(spec.figma.generated).toBe(true);
+  });
+
+  it("has valid outputTarget", () => {
+    expect(["react", "vue", "svelte", "react-native"]).toContain(spec.outputTarget);
+  });
+
+  it("has pages with generated Figma node IDs and mockup paths", () => {
+    expect(spec.pages.length).toBeGreaterThan(1);
+    for (const page of spec.pages) {
+      expect(page.figmaNodeId).toMatch(/^\d+:\d+$/);
+      expect(page).toHaveProperty("name");
+      expect(page).toHaveProperty("route");
+      expect(page.mockupPath).toMatch(/\.html$/);
+      expect(page.sections.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has components with valid categories", () => {
+    expect(spec.components.length).toBeGreaterThan(0);
+    for (const comp of spec.components) {
+      expect(comp).toHaveProperty("reactName");
+      expect(["ui", "layout", "sections", "pages"]).toContain(comp.category);
+    }
+  });
+
+  it("dashboard has sidebar and data components", () => {
+    const names = spec.components.map((c) => c.reactName);
+    expect(names).toContain("Sidebar");
+    expect(names).toContain("DataTable");
+    expect(names).toContain("StatsCard");
+  });
+
+  it("includes business logic requirements", () => {
+    expect(spec.businessLogic.auth).toBe("required");
+    expect(spec.businessLogic.apiCalls.length).toBeGreaterThan(0);
+  });
+});
+
+// --- Pipeline Config Validation ---
+
+describe("pipeline config — conversation section", () => {
+  const config = loadJson(CONFIG_PATH);
+
+  it("conversation section exists and is enabled", () => {
+    expect(config.conversation).toBeDefined();
+    expect(config.conversation.enabled).toBe(true);
+  });
+
+  it("caps the interview at 7 questions and confirms the brief", () => {
+    const interview = config.conversation.interview;
+    expect(interview.maxQuestions).toBeGreaterThanOrEqual(1);
+    expect(interview.maxQuestions).toBeLessThanOrEqual(7);
+    expect(interview.confirmBriefWithUser).toBe(true);
+  });
+
+  it("has design generation settings", () => {
+    const gen = config.conversation.designGeneration;
+    expect(gen.mockupDir).toBeTruthy();
+    expect(gen.mockupServerPort).toBeGreaterThan(0);
+    expect(typeof gen.reviewBeforeHandoff).toBe("boolean");
+    expect(gen.maxRegenerationAttempts).toBeGreaterThanOrEqual(1);
+    expect(gen.capturePollIntervalMs).toBeGreaterThan(0);
+    expect(gen.capturePollMaxAttempts).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has retry configuration", () => {
+    const retry = config.conversation.retry;
+    expect(retry).toBeDefined();
+    expect(retry.maxAttempts).toBeGreaterThanOrEqual(2);
+    expect(retry.initialDelayMs).toBeGreaterThan(0);
+    expect(retry.backoffMultiplier).toBeGreaterThan(1);
+    expect(retry.maxDelayMs).toBeGreaterThanOrEqual(retry.initialDelayMs);
+    expect(retry.retryableErrors).toBeInstanceOf(Array);
+    expect(retry.retryableErrors).toContain("rate_limit");
+    expect(retry.retryableErrors).toContain("timeout");
+    expect(retry.retryableErrors).toContain("capture_failed");
+  });
+});
+
+describe("pipeline config schema — conversation section", () => {
+  const schema = loadJson(SCHEMA_PATH);
+
+  it("declares the conversation property", () => {
+    expect(schema.properties.conversation).toBeDefined();
+    expect(schema.properties.conversation.additionalProperties).toBe(false);
+  });
+
+  it("reuses the shared retryOptions definition", () => {
+    expect(schema.properties.conversation.properties.retry.$ref).toBe("#/$defs/retryOptions");
+  });
+});
+
+// --- Agent & Skill Definition Validation ---
+
+describe("conversation-intake skill definition", () => {
+  const content = loadMarkdown(join(SKILLS, "conversation-intake", "SKILL.md"));
+
+  it("produces both the build spec and the design brief", () => {
+    expect(content).toContain("build-spec.json");
+    expect(content).toContain("design-brief.json");
+    expect(content).toContain('"source": "conversation"');
+  });
+
+  it("caps the interview via pipeline config", () => {
+    expect(content).toContain("maxQuestions");
+    expect(content).toMatch(/max(imum)? (of )?7 questions/i);
+  });
+
+  it("detects the framework through the renderer registry", () => {
+    expect(content).toContain("renderer-registry.js detect");
+  });
+
+  it("dispatches the conversation-designer agent", () => {
+    expect(content).toContain("conversation-designer");
+  });
+});
+
+describe("design-brief-to-figma skill definition", () => {
+  const content = loadMarkdown(join(SKILLS, "design-brief-to-figma", "SKILL.md"));
+
+  it("creates the Figma file with an authenticated plan", () => {
+    expect(content).toContain("whoami");
+    expect(content).toContain("planKey");
+    expect(content).toContain("create_new_file");
+  });
+
+  it("captures HTML mockups through generate_figma_design", () => {
+    expect(content).toContain("HTML mockup");
+    expect(content).toContain("generate_figma_design");
+    expect(content).toContain("captureId");
+    expect(content).toContain("single-use");
+    expect(content).toMatch(/poll/i);
+  });
+
+  it("maps generated node IDs back into the build spec", () => {
+    expect(content).toContain("get_metadata");
+    expect(content).toContain("figmaNodeId");
+  });
+
+  it("warns that captured designs have no Figma variables", () => {
+    expect(content).toMatch(/no Figma variables/i);
+    expect(content).toMatch(/computed styles/i);
+  });
+});
+
+describe("conversation-designer agent definition", () => {
+  const content = loadMarkdown(join(AGENTS, "conversation-designer.md"));
+
+  it("has the expected frontmatter name", () => {
+    expect(content).toMatch(/^---\r?\nname: conversation-designer\r?\n/);
+  });
+
+  it("owns the design brief and HTML mockups", () => {
+    expect(content).toContain("design-brief.json");
+    expect(content).toContain("HTML mockup");
+  });
+
+  it("documents concrete defaults per style direction", () => {
+    for (const direction of ["minimal", "bold", "playful", "corporate", "dark"]) {
+      expect(content).toContain(direction);
+    }
+  });
+});
+
+describe("build-from-conversation command definition", () => {
+  const content = loadMarkdown(join(COMMANDS, "build-from-conversation.md"));
+
+  it("orchestrates both new skills", () => {
+    expect(content).toContain("conversation-intake");
+    expect(content).toContain("design-brief-to-figma");
+  });
+
+  it("hands off to the figma pipeline", () => {
+    expect(content).toContain("/build-from-figma");
+    expect(content).toMatch(/fast-path/i);
+  });
+
+  it("accepts an optional initial description", () => {
+    expect(content).toContain("$ARGUMENTS");
+  });
+
+  it("reads the conversation section of the pipeline config", () => {
+    expect(content).toContain("pipeline.config.json");
+    expect(content).toMatch(/conversation\.(interview|designGeneration|retry)/);
+  });
+});
+
+describe("figma-intake conversation fast-path", () => {
+  const content = loadMarkdown(join(SKILLS, "figma-intake", "SKILL.md"));
+
+  it("skips the interview for conversation-sourced build specs", () => {
+    expect(content).toMatch(/fast-path/i);
+    expect(content).toContain('"source": "conversation"');
+  });
+});


### PR DESCRIPTION
## Summary

Implements #33 — "talk to build": describe an app in natural language, get a real Figma design generated from the conversation, and have the existing `/build-from-figma` pipeline build and verify it. The downstream pipeline is untouched; this adds two phases in front of it.

- **Phase C0 — `conversation-intake` skill:** structured interview (max 7 questions, configurable), local-project auto-discovery via the renderer registry, outputs `build-spec.json` with `"source": "conversation"` plus the new `design-brief.json` artifact
- **Phase C1 — `design-brief-to-figma` skill:** the new `conversation-designer` agent renders the brief as one self-contained HTML mockup per page; the skill serves them locally, creates a Figma file (`whoami` → `create_new_file`), captures each page with `generate_figma_design` (single-use captureId, polled), and maps generated node IDs back into the build spec via `get_metadata`. This matches the actual Figma MCP contract — `generate_figma_design` imports rendered web pages, so HTML mockups are the bridge from brief to Figma.
- **Handoff:** `/build-from-figma <generated URL>` runs unchanged; `figma-intake` gains a fast-path that skips the interview for conversation-sourced build specs, and `design-token-lock` uses its documented computed-styles fallback (captured designs carry no Figma variables)
- **Config:** new `conversation` section in `pipeline.config.json` + JSON Schema (interview cap, mockup server, capture polling, review gate, retry policy)
- **Tests:** `scripts/__tests__/conversation-pipeline.test.js` (37 structural tests, mirroring `canva-pipeline.test.js`) + fixtures
- **Docs:** new `docs/conversation-to-app/` guide, pipeline-configuration section, and all catalogs/counts updated (55 agents, 22 skills, 4 pipelines — enforced by `check-doc-counts.sh`)

## Test plan

- [x] `pnpm vitest run scripts/__tests__/conversation-pipeline.test.js` — 37/37 pass (written first, RED → GREEN)
- [x] `./scripts/validate-pipeline-config.sh` — config valid against schema
- [x] `./scripts/check-doc-counts.sh` — all 132 scanned docs match disk counts
- [x] `pnpm eslint` + `pnpm prettier --check` on touched JS/JSON — clean
- Note: `metrics-dashboard` / `pipeline-cache` / `agent-plugin-lib` test failures reproduce identically on a clean checkout of HEAD (local machine state / Windows-specific) and are unrelated to this PR

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)