### PR TITLE
feat(pipeline): add InDesign IDML parser and intermediate representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,36 @@ jobs:
       - name: Run script tests
         run: pnpm vitest run --config scripts/__tests__/vitest.config.js scripts/__tests__/ --reporter=verbose
 
+  # ── Pipeline package (TypeScript: InDesign IDML parser + IR) ───────────
+  pipeline-tests:
+    name: Pipeline Package
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm --filter @aurelius/pipeline typecheck
+
+      - name: Run pipeline tests
+        run: pnpm --filter @aurelius/pipeline test
+
+      - name: Build (tsc emit + declarations)
+        run: pnpm --filter @aurelius/pipeline build
+
   # ── Lint & format check (needs Node + project with eslint/prettier) ───
   lint:
     name: Lint & Format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ project-root/
 │   ├── hooks/            # Hook scripts (automated hooks configured in settings.json)
 │   └── pipeline.config.json  # Pipeline thresholds, iteration limits, app types
 ├── scripts/              # Development automation scripts
+├── packages/             # TypeScript pipeline packages (pnpm workspace)
+│   └── pipeline/         # Design-to-code core: InDesign IDML parser + IR (@aurelius/pipeline)
 ├── renderers/            # Pluggable framework renderer manifests (renderer.json + schema)
 ├── templates/            # Starter configs (ESLint, Tailwind, Vitest, Chrome ext, PWA, etc.)
 ├── docs/                 # Documentation
@@ -30,6 +32,7 @@ project-root/
 │   ├── canva-to-react/   # Canva conversion pipeline docs
 │   ├── screenshot-to-app/ # Screenshot/URL conversion pipeline docs
 │   ├── conversation-to-app/ # Conversation pipeline docs (generated Figma designs)
+│   ├── indesign-to-react/ # InDesign IDML conversion pipeline docs
 │   ├── multi-framework/  # Multi-framework output target docs
 │   └── react-development/# React development standards
 └── CLAUDE.md             # This file

--- a/docs/indesign-to-react/README.md
+++ b/docs/indesign-to-react/README.md
@@ -1,0 +1,91 @@
+# InDesign-to-React Pipeline
+
+Convert Adobe InDesign designs (brochures, pitch decks, editorial layouts) into
+typed React components, design tokens, and assets — a print-first sibling to the
+Figma/Canva/Screenshot pipelines.
+
+> **Status:** in progress. This document tracks the epic and details the first
+> shipped stage — the **IDML parser and intermediate representation (IR)**.
+> See the epic for the full plan: _Add InDesign-to-React conversion pipeline_.
+
+## Pipeline shape (target)
+
+```
+.idml ──▶ [1] IDML parser ──▶ IR ──▶ [2] style/token mapper ──▶ tokens.ts + Tailwind preset
+ .pdf ──▶ [1b] PDF fallback ─▶ IR ──┘                      └──▶ [3] component generator ──▶ *.tsx + Storybook
+```
+
+Both inputs converge on a single normalized **IR**, so every later stage is input
+agnostic. The IDML path (this stage) is the primary, high-fidelity route; a PDF
+fallback is a separate sub-issue.
+
+## Stage 1 — IDML parser and IR (shipped)
+
+Implemented in [`packages/pipeline/src/indesign`](../../packages/pipeline/src/indesign).
+
+An `.idml` file is a zip package of XML documents. The parser:
+
+1. **Unzips and validates** the package: `mimetype`, `designmap.xml`, and the
+   `Resources/`, `Stories/`, `Spreads/`, `MasterSpreads/` it references.
+2. **Parses** stories (text + paragraph/character style references), spreads
+   (frames, positions, transforms), master spreads, swatches, fonts, and
+   linked/embedded images.
+3. **Resolves cross-references** — `TextFrame.ParentStory` → `Story.Self`, and
+   image links → bundled asset paths inside the package.
+4. **Normalizes units** to pixels at a configurable DPI (default 96).
+5. **Emits a typed IR** validated by a zod schema.
+6. **Collects parse warnings** for unsupported features without aborting.
+
+### Intermediate representation
+
+The canonical types live in
+[`packages/pipeline/src/indesign/ir.ts`](../../packages/pipeline/src/indesign/ir.ts):
+
+`Document` → `{ meta, spreads[], masterSpreads[], stories[], swatches[], fonts[], paragraphStyles[], characterStyles[], assets[], warnings[] }`
+
+- **`Spread` / `MasterSpread`** → `pages[]` + `frames[]` (+ transform)
+- **`Page`** → pixel `bounds` + raw `geometricBounds` + transform
+- **`Frame`** = `TextFrame` | `ImageFrame` | `GraphicFrame` | `GroupFrame`
+  - `TextFrame.storyId` links to a `Story`; threading via `next/previousFrameId`
+  - `ImageFrame.image` (`ImageRef`) resolves `linkUri` to an in-package `resolvedPath`
+  - `GroupFrame.children` nest recursively
+- **`Story`** → `paragraphs[]` (`runs[]`) + `plainText` + distinct applied style refs
+- **`Swatch`** → color/tint/gradient with computed `hex`/`rgb` where convertible
+- **`Style`** → paragraph/character style with normalized `pointSize`/`leading`
+  (px) plus a `raw` passthrough of every source attribute for the mapper
+
+### Warnings vs. errors
+
+Recoverable problems are accumulated on `document.warnings` (each with a stable
+`code`, `severity`, `message`, and source `path`) and surfaced by the CLI; they
+never abort parsing. Codes include `MIMETYPE_MISMATCH`, `MISSING_RESOURCE_FILE`,
+`UNRESOLVED_LINK`, `MISSING_PARENT_STORY`, `UNSUPPORTED_PAGE_ITEM`,
+`MALFORMED_XML`, and `EMPTY_GEOMETRY`.
+
+Only unrecoverable conditions (not a zip, missing `designmap.xml`) throw an
+`IdmlParseError`.
+
+### Try it
+
+```bash
+pnpm --filter @aurelius/pipeline build
+node packages/pipeline/dist/indesign/cli.js your-design.idml          # summary + warnings
+node packages/pipeline/dist/indesign/cli.js your-design.idml --json   # full IR as JSON
+```
+
+See the [package README](../../packages/pipeline/README.md) for the library API,
+options, and known limitations.
+
+## Roadmap (remaining sub-issues)
+
+- [ ] PDF fallback parser and layout reconstruction (emits the same IR)
+- [ ] Style and design-token mapper (paragraph/character styles + swatches →
+      `tokens.ts` + Tailwind preset)
+- [ ] React component generator (TSX output, optional Tailwind/CSS Modules,
+      Storybook stories)
+- [ ] `indesign-to-react` Claude Code agent + skill + end-to-end CLI command
+
+## References
+
+- [Adobe IDML File Format Specification](https://www.adobe.com/devnet/indesign/documentation.html)
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,14 @@ export default [
     },
   },
   {
-    ignores: ["node_modules/", "dist/", "build/", ".claude/", "templates/", "docs/", "app/"],
+    ignores: [
+      "**/node_modules/",
+      "**/dist/",
+      "**/build/",
+      ".claude/",
+      "templates/",
+      "docs/",
+      "app/",
+    ],
   },
 ];

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,0 +1,121 @@
+# @aurelius/pipeline
+
+Core library for the Aurelius design-to-code pipeline. The first stage shipped
+here is the **InDesign IDML parser**, which reads Adobe InDesign Markup Language
+(`.idml`) packages and emits a normalized, typed intermediate representation
+(IR) that downstream stages (style/token mapper, component generator) consume.
+
+> Part of the [InDesign-to-React pipeline](../../docs/indesign-to-react/README.md)
+> epic. This package currently implements the foundational parser + IR only.
+
+## Install / build
+
+```bash
+pnpm install
+pnpm --filter @aurelius/pipeline build      # tsc → dist/
+pnpm --filter @aurelius/pipeline test       # vitest
+pnpm --filter @aurelius/pipeline typecheck  # tsc --noEmit
+```
+
+## Library usage
+
+```ts
+import { parseIdmlFile, parseIdml } from "@aurelius/pipeline/indesign";
+
+// From a file path…
+const { document, warnings } = parseIdmlFile("brochure.idml", { dpi: 96 });
+
+// …or from an in-memory buffer (e.g. an upload).
+const result = parseIdml(uint8Array);
+
+console.log(document.swatches); // every color / tint / gradient
+console.log(document.fonts); // every font
+console.log(document.paragraphStyles, document.characterStyles);
+console.log(document.spreads[0].frames); // text / image / graphic / group frames
+console.log(warnings); // non-fatal issues (unsupported features, unresolved links)
+```
+
+The IR is fully described by the TypeScript types in
+[`src/indesign/ir.ts`](src/indesign/ir.ts) and validated at runtime by the zod
+schema in [`src/indesign/schema.ts`](src/indesign/schema.ts):
+
+```ts
+import { DocumentSchema, validateDocument } from "@aurelius/pipeline/indesign";
+
+DocumentSchema.safeParse(document).success; // true for any parser output
+const validated = validateDocument(document); // throws ZodError on mismatch
+```
+
+### What the IR covers
+
+| Area    | IR types                                              |
+| ------- | ----------------------------------------------------- |
+| Layout  | `Document`, `Spread`, `MasterSpread`, `Page`          |
+| Frames  | `Frame` = `TextFrame` \| `ImageFrame` \| `GraphicFrame` \| `GroupFrame` |
+| Content | `Story`, `Paragraph`, `TextRun`                       |
+| Design  | `Swatch`, `Font`, `Style` (paragraph + character)     |
+| Assets  | `Asset`, `ImageRef` (resolved to in-package paths)    |
+
+All geometry is normalized from IDML points to **pixels** at a configurable DPI
+(default 96): `px = pt × dpi / 72`. Transform translation is converted to pixels;
+scale/shear components are preserved.
+
+## CLI
+
+The package ships an `aurelius-indesign` binary (built to `dist/indesign/cli.js`):
+
+```bash
+# Human-readable summary + warnings
+node dist/indesign/cli.js brochure.idml
+
+# Full IR as JSON (warnings summary goes to stderr so stdout stays pipeable)
+node dist/indesign/cli.js brochure.idml --json --pretty > ir.json
+
+# Options
+#   --json          emit the IR as JSON on stdout
+#   --pretty        pretty-print JSON
+#   --dpi <number>  pixel conversion DPI (default 96)
+#   --no-validate   skip zod validation of the produced IR
+```
+
+Example report:
+
+```
+InDesign IDML → IR
+  source:        brochure.idml
+  IDML version:  16.0
+  DPI:           96
+  mimetype:      valid
+
+Counts
+  spreads:           1
+  master spreads:    1
+  pages:             2
+  frames:            3 (text: 1, image: 1, graphic: 1, group: 0)
+  stories:           1
+  swatches:          6
+  fonts:             3
+  paragraph styles:  3
+  character styles:  2
+  assets:            1
+
+Warnings (1)
+  [warning] UNRESOLVED_LINK: Image link "file:Links/logo.ai" does not resolve … (Spreads/Spread_ub6.xml)
+```
+
+## Error handling
+
+- **Recoverable** issues (unsupported page items, unresolved image links, dangling
+  story references, malformed sub-documents) are collected on `document.warnings`
+  and never abort the parse.
+- **Unrecoverable** conditions (input is not a zip, missing `designmap.xml`) throw
+  an `IdmlParseError` with a stable `code`.
+
+## Known limitations
+
+- Forced line breaks (`<Br/>`) interleaved with text runs are not order-preserved;
+  paragraph boundaries are exact.
+- Color conversion is a deterministic approximation (no ICC profiles). CMYK, RGB,
+  Lab (D50), and Gray spaces are supported; others are recorded without a hex value.
+- Frame bounds are axis-aligned bounding boxes in spread (pasteboard) coordinates.
+```

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@aurelius/pipeline",
+  "version": "0.1.0",
+  "description": "Aurelius design-to-code pipeline core. Includes the InDesign IDML parser and intermediate representation (IR).",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "aurelius-indesign": "./dist/indesign/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./indesign": {
+      "types": "./dist/indesign/index.d.ts",
+      "import": "./dist/indesign/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "fast-xml-parser": "^4.5.1",
+    "fflate": "^0.8.2",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.0",
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/pipeline/src/indesign/__tests__/cli.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/cli.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { formatReport, runCli } from "../cli.js";
+import { parseIdml } from "../parser.js";
+import { buildIdml, buildSampleIdml, sampleFiles } from "./idml-fixtures.js";
+
+const tempDirs: string[] = [];
+
+function writeIdml(buffer: Uint8Array, name = "sample.idml"): string {
+  const dir = mkdtempSync(join(tmpdir(), "idml-cli-"));
+  tempDirs.push(dir);
+  const path = join(dir, name);
+  writeFileSync(path, buffer);
+  return path;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("runCli", () => {
+  it("prints usage and exits 2 when no input is given", () => {
+    const result = runCli([]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("no input file");
+  });
+
+  it("prints help on --help", () => {
+    const result = runCli(["--help"]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Usage:");
+  });
+
+  it("exits 1 with an error for a missing file", () => {
+    const result = runCli([join(tmpdir(), "does-not-exist-xyz.idml")]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/Error/);
+  });
+
+  it("prints a human-readable report with counts for a valid package", () => {
+    const path = writeIdml(buildSampleIdml());
+    const result = runCli([path]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("InDesign IDML → IR");
+    expect(result.stdout).toContain("swatches:          6");
+    expect(result.stdout).toContain("Warnings (0)");
+  });
+
+  it("surfaces collected parse warnings in the report", () => {
+    const files = sampleFiles();
+    delete files["Links/hero.png"];
+    const path = writeIdml(buildIdml(files));
+    const result = runCli([path]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("UNRESOLVED_LINK");
+    expect(result.stderr).toContain("warning(s)");
+  });
+
+  it("emits valid JSON with --json", () => {
+    const path = writeIdml(buildSampleIdml());
+    const result = runCli([path, "--json"]);
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.meta.dpi).toBe(96);
+    expect(Array.isArray(parsed.warnings)).toBe(true);
+    expect(parsed.swatches).toHaveLength(6);
+  });
+
+  it("rejects an invalid --dpi value", () => {
+    const result = runCli(["x.idml", "--dpi", "abc"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("Invalid --dpi");
+  });
+});
+
+describe("formatReport", () => {
+  it("renders frame type breakdown", () => {
+    const { document } = parseIdml(buildSampleIdml());
+    const report = formatReport(document);
+    // Totals span spreads and master spreads: 1 text + 1 image + 1 master band.
+    expect(report).toContain("frames:            3 (text: 1, image: 1, graphic: 1, group: 0)");
+    expect(report).toContain("master spreads:    1");
+  });
+});

--- a/packages/pipeline/src/indesign/__tests__/idml-fixtures.ts
+++ b/packages/pipeline/src/indesign/__tests__/idml-fixtures.ts
@@ -1,0 +1,202 @@
+/**
+ * Programmatic IDML fixtures.
+ *
+ * Builds real `.idml` (zip) buffers in memory from a map of XML strings, so the
+ * happy-path package and every malformed/edge-case variant live as readable
+ * source rather than committed binaries. `sampleFiles()` returns a fresh,
+ * mutable record each call so tests can delete/replace entries to construct
+ * edge cases.
+ */
+import { strToU8, zipSync } from "fflate";
+import { IDML_MIMETYPE } from "../package.js";
+
+/** A map of package-relative path → file contents. */
+export type IdmlFiles = Record<string, string | Uint8Array>;
+
+/** A 1×1 PNG, used as a resolvable bundled image asset. */
+export const PNG_1x1: Uint8Array = new Uint8Array(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC",
+    "base64",
+  ),
+);
+
+const DESIGNMAP = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?aid style="50" type="document" readerVersion="6.0" featureSet="257" product="16.0(44)" ?>
+<Document xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0" Self="doc">
+  <idPkg:Graphic src="Resources/Graphic.xml" />
+  <idPkg:Fonts src="Resources/Fonts.xml" />
+  <idPkg:Styles src="Resources/Styles.xml" />
+  <idPkg:MasterSpread src="MasterSpreads/MasterSpread_uMaster.xml" />
+  <idPkg:Spread src="Spreads/Spread_ub6.xml" />
+  <idPkg:Story src="Stories/Story_u100.xml" />
+</Document>`;
+
+const GRAPHIC = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:Graphic xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <Color Self="Color/Black" Model="Process" Space="CMYK" ColorValue="0 0 0 100" Name="Black" />
+  <Color Self="Color/Brand Blue" Model="Process" Space="RGB" ColorValue="20 90 200" Name="Brand Blue" />
+  <Color Self="Color/Paper" Model="Process" Space="CMYK" ColorValue="0 0 0 0" Name="Paper" />
+  <Swatch Self="Swatch/None" Name="None" />
+  <Tint Self="Tint/BlackTint" Name="Black 50%" BaseColor="Color/Black" TintValue="50" />
+  <Gradient Self="Gradient/Fade" Name="Fade" Type="Linear" />
+</idPkg:Graphic>`;
+
+const FONTS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:Fonts xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <FontFamily Self="font-family-1" Name="Minion Pro">
+    <Font Self="font-minion-regular" FontFamily="Minion Pro" Name="Minion Pro Regular" PostScriptName="MinionPro-Regular" Status="Installed" FontStyleName="Regular" />
+    <Font Self="font-minion-bold" FontFamily="Minion Pro" Name="Minion Pro Bold" PostScriptName="MinionPro-Bold" Status="Installed" FontStyleName="Bold" />
+  </FontFamily>
+  <FontFamily Self="font-family-2" Name="Helvetica">
+    <Font Self="font-helvetica" FontFamily="Helvetica" Name="Helvetica" PostScriptName="Helvetica" Status="Installed" FontStyleName="Regular" />
+  </FontFamily>
+</idPkg:Fonts>`;
+
+const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:Styles xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <RootParagraphStyleGroup Self="rpsg">
+    <ParagraphStyle Self="ParagraphStyle/$ID/[No paragraph style]" Name="$ID/[No paragraph style]" />
+    <ParagraphStyle Self="ParagraphStyle/Heading" Name="Heading" PointSize="24" FontStyle="Bold" FillColor="Color/Black" Justification="LeftAlign" Tracking="10">
+      <Properties>
+        <BasedOn type="object">ParagraphStyle/$ID/[No paragraph style]</BasedOn>
+        <AppliedFont type="string">Minion Pro</AppliedFont>
+        <Leading type="unit">28</Leading>
+      </Properties>
+    </ParagraphStyle>
+    <ParagraphStyleGroup Self="psg-body" Name="Body">
+      <ParagraphStyle Self="ParagraphStyle/Body" Name="Body" PointSize="12">
+        <Properties>
+          <AppliedFont type="string">Minion Pro</AppliedFont>
+          <Leading type="enumeration">Auto</Leading>
+        </Properties>
+      </ParagraphStyle>
+    </ParagraphStyleGroup>
+  </RootParagraphStyleGroup>
+  <RootCharacterStyleGroup Self="rcsg">
+    <CharacterStyle Self="CharacterStyle/$ID/[No character style]" Name="$ID/[No character style]" />
+    <CharacterStyle Self="CharacterStyle/Emphasis" Name="Emphasis" FontStyle="Italic" />
+  </RootCharacterStyleGroup>
+</idPkg:Styles>`;
+
+const STORY = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:Story xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <Story Self="u100" AppliedTOCStyle="n" TrackChanges="false" StoryTitle="$ID/">
+    <StoryPreference OpticalMarginAlignment="false" />
+    <ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/Heading">
+      <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]" PointSize="24">
+        <Content>Welcome to Aurelius</Content>
+      </CharacterStyleRange>
+    </ParagraphStyleRange>
+    <ParagraphStyleRange AppliedParagraphStyle="ParagraphStyle/Body">
+      <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/$ID/[No character style]">
+        <Content>Print to React, </Content>
+      </CharacterStyleRange>
+      <CharacterStyleRange AppliedCharacterStyle="CharacterStyle/Emphasis">
+        <Content>beautifully.</Content>
+      </CharacterStyleRange>
+    </ParagraphStyleRange>
+  </Story>
+</idPkg:Story>`;
+
+const SPREAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:Spread xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <Spread Self="ub6" PageCount="1" ItemTransform="1 0 0 1 0 0">
+    <Page Self="page-1" Name="1" GeometricBounds="0 0 792 612" ItemTransform="1 0 0 1 0 0" />
+    <TextFrame Self="text-hero" ParentStory="u100" ItemTransform="1 0 0 1 72 72" PreviousTextFrame="n" NextTextFrame="n" Name="Hero Headline">
+      <Properties>
+        <PathGeometry>
+          <GeometryPathType PathOpen="false">
+            <PathPointArray>
+              <PathPointType Anchor="0 0" LeftDirection="0 0" RightDirection="0 0" />
+              <PathPointType Anchor="468 0" LeftDirection="468 0" RightDirection="468 0" />
+              <PathPointType Anchor="468 100" LeftDirection="468 100" RightDirection="468 100" />
+              <PathPointType Anchor="0 100" LeftDirection="0 100" RightDirection="0 100" />
+            </PathPointArray>
+          </GeometryPathType>
+        </PathGeometry>
+      </Properties>
+    </TextFrame>
+    <Rectangle Self="rect-hero" ItemTransform="1 0 0 1 72 300" FillColor="Color/Paper" StrokeColor="Swatch/None" Name="Hero Image">
+      <Properties>
+        <PathGeometry>
+          <GeometryPathType PathOpen="false">
+            <PathPointArray>
+              <PathPointType Anchor="0 0" LeftDirection="0 0" RightDirection="0 0" />
+              <PathPointType Anchor="468 0" LeftDirection="468 0" RightDirection="468 0" />
+              <PathPointType Anchor="468 300" LeftDirection="468 300" RightDirection="468 300" />
+              <PathPointType Anchor="0 300" LeftDirection="0 300" RightDirection="0 300" />
+            </PathPointArray>
+          </GeometryPathType>
+        </PathGeometry>
+      </Properties>
+      <Image Self="img-hero" ItemTransform="1 0 0 1 72 300" ActualPpi="300 300">
+        <Properties>
+          <Profile type="string">$ID/EmbeddedProfile</Profile>
+        </Properties>
+        <Link Self="link-hero" LinkResourceURI="file:Links/hero.png" StoredState="Normal" />
+      </Image>
+    </Rectangle>
+  </Spread>
+</idPkg:Spread>`;
+
+const MASTER_SPREAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<idPkg:MasterSpread xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <MasterSpread Self="uMaster" Name="A-Master" NamePrefix="A" ItemTransform="1 0 0 1 0 0">
+    <Page Self="master-page-1" Name="A" GeometricBounds="0 0 792 612" ItemTransform="1 0 0 1 0 0" />
+    <Rectangle Self="master-band" ItemTransform="1 0 0 1 0 0" FillColor="Color/Brand Blue" Name="Header Band">
+      <Properties>
+        <PathGeometry>
+          <GeometryPathType PathOpen="false">
+            <PathPointArray>
+              <PathPointType Anchor="0 0" LeftDirection="0 0" RightDirection="0 0" />
+              <PathPointType Anchor="612 0" LeftDirection="612 0" RightDirection="612 0" />
+              <PathPointType Anchor="612 72" LeftDirection="612 72" RightDirection="612 72" />
+              <PathPointType Anchor="0 72" LeftDirection="0 72" RightDirection="0 72" />
+            </PathPointArray>
+          </GeometryPathType>
+        </PathGeometry>
+      </Properties>
+    </Rectangle>
+  </MasterSpread>
+</idPkg:MasterSpread>`;
+
+/** A fresh, mutable map of the canonical happy-path IDML package files. */
+export function sampleFiles(): IdmlFiles {
+  return {
+    mimetype: IDML_MIMETYPE,
+    "designmap.xml": DESIGNMAP,
+    "Resources/Graphic.xml": GRAPHIC,
+    "Resources/Fonts.xml": FONTS,
+    "Resources/Styles.xml": STYLES,
+    "Stories/Story_u100.xml": STORY,
+    "Spreads/Spread_ub6.xml": SPREAD,
+    "MasterSpreads/MasterSpread_uMaster.xml": MASTER_SPREAD,
+    "Links/hero.png": PNG_1x1,
+  };
+}
+
+/**
+ * Zip a file map into a real IDML buffer. The `mimetype` entry, if present, is
+ * written first and stored uncompressed, matching the IDML packaging convention.
+ */
+export function buildIdml(files: IdmlFiles): Uint8Array {
+  const zippable: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
+  if (files.mimetype !== undefined) {
+    zippable.mimetype = [toBytes(files.mimetype), { level: 0 }];
+  }
+  for (const [path, contents] of Object.entries(files)) {
+    if (path === "mimetype") continue;
+    zippable[path] = [toBytes(contents), { level: 6 }];
+  }
+  return zipSync(zippable);
+}
+
+/** Build the canonical happy-path IDML buffer. */
+export function buildSampleIdml(): Uint8Array {
+  return buildIdml(sampleFiles());
+}
+
+function toBytes(value: string | Uint8Array): Uint8Array {
+  return typeof value === "string" ? strToU8(value) : value;
+}

--- a/packages/pipeline/src/indesign/__tests__/package.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/package.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { IdmlParseError } from "../errors.js";
+import { IDML_MIMETYPE, IdmlPackage } from "../package.js";
+import { buildSampleIdml } from "./idml-fixtures.js";
+
+function open(): IdmlPackage {
+  return IdmlPackage.fromBuffer(buildSampleIdml());
+}
+
+describe("IdmlPackage", () => {
+  it("unzips entries and reads text", () => {
+    const pkg = open();
+    expect(pkg.has("designmap.xml")).toBe(true);
+    expect(pkg.readText("designmap.xml")).toContain("<Document");
+    expect(pkg.list()).toContain("Spreads/Spread_ub6.xml");
+  });
+
+  it("exposes and validates the mimetype", () => {
+    const pkg = open();
+    expect(pkg.mimetype()).toBe(IDML_MIMETYPE);
+    expect(pkg.hasValidMimetype()).toBe(true);
+  });
+
+  it("reports byte length of bundled assets", () => {
+    const pkg = open();
+    expect(pkg.byteLength("Links/hero.png")).toBeGreaterThan(0);
+    expect(pkg.byteLength("missing")).toBe(0);
+  });
+
+  it("throws IdmlParseError for non-zip input", () => {
+    expect(() => IdmlPackage.fromBuffer(new Uint8Array([0, 1, 2, 3]))).toThrowError(IdmlParseError);
+  });
+
+  describe("resolveAssetUri", () => {
+    it("matches an exact package path", () => {
+      expect(open().resolveAssetUri("Links/hero.png")).toBe("Links/hero.png");
+    });
+
+    it("strips the file: scheme", () => {
+      expect(open().resolveAssetUri("file:Links/hero.png")).toBe("Links/hero.png");
+    });
+
+    it("falls back to basename matching for absolute URIs", () => {
+      expect(open().resolveAssetUri("file:///C:/Users/designer/links/hero.png")).toBe(
+        "Links/hero.png",
+      );
+    });
+
+    it("decodes percent-encoded paths", () => {
+      expect(open().resolveAssetUri("file:Links/hero%2Epng")).toBe("Links/hero.png");
+    });
+
+    it("returns undefined when nothing matches", () => {
+      expect(open().resolveAssetUri("file:Links/missing.png")).toBeUndefined();
+      expect(open().resolveAssetUri("")).toBeUndefined();
+    });
+  });
+});

--- a/packages/pipeline/src/indesign/__tests__/parser.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/parser.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import { IdmlParseError } from "../errors.js";
+import type { GroupFrame, ImageFrame, TextFrame } from "../ir.js";
+import { parseIdml } from "../parser.js";
+import { safeValidateDocument } from "../schema.js";
+import { WarningCode } from "../warnings.js";
+import { buildIdml, buildSampleIdml, sampleFiles } from "./idml-fixtures.js";
+
+function parse(files = sampleFiles()) {
+  return parseIdml(buildIdml(files));
+}
+
+describe("parseIdml — happy path", () => {
+  it("produces an IR that passes zod schema validation", () => {
+    const { document } = parseIdml(buildSampleIdml());
+    const result = safeValidateDocument(document);
+    expect(result.success).toBe(true);
+  });
+
+  it("records document metadata", () => {
+    const { document } = parse();
+    expect(document.meta.dpi).toBe(96);
+    expect(document.meta.mimetypeValid).toBe(true);
+    expect(document.meta.idmlVersion).toBe("16.0");
+  });
+
+  it("enumerates all swatches with computed hex colors", () => {
+    const { document } = parse();
+    const names = document.swatches.map((s) => s.name).sort();
+    expect(names).toEqual(["Black", "Black 50%", "Brand Blue", "Fade", "None", "Paper"]);
+
+    const black = document.swatches.find((s) => s.id === "Color/Black");
+    expect(black?.hex).toBe("#000000");
+    const blue = document.swatches.find((s) => s.id === "Color/Brand Blue");
+    expect(blue?.rgb).toEqual({ r: 20, g: 90, b: 200 });
+    expect(blue?.hex).toBe("#145ac8");
+
+    const types = new Set(document.swatches.map((s) => s.type));
+    expect(types).toEqual(new Set(["color", "tint", "gradient", "unknown"]));
+  });
+
+  it("enumerates all fonts", () => {
+    const { document } = parse();
+    expect(document.fonts).toHaveLength(3);
+    expect(document.fonts.map((f) => f.name)).toContain("Minion Pro Bold");
+    const helvetica = document.fonts.find((f) => f.family === "Helvetica");
+    expect(helvetica?.postScriptName).toBe("Helvetica");
+    expect(helvetica?.status).toBe("Installed");
+  });
+
+  it("enumerates paragraph and character styles, including nested groups", () => {
+    const { document } = parse();
+    expect(document.paragraphStyles.map((s) => s.name).sort()).toEqual([
+      "Body",
+      "Heading",
+      "[No paragraph style]",
+    ]);
+    expect(document.characterStyles.map((s) => s.name).sort()).toEqual([
+      "Emphasis",
+      "[No character style]",
+    ]);
+
+    const heading = document.paragraphStyles.find((s) => s.id === "ParagraphStyle/Heading");
+    expect(heading?.properties.pointSize).toBe(32); // 24pt → 32px @96dpi
+    expect(heading?.properties.leading).toBe(37.33); // 28pt → 37.33px
+    expect(heading?.properties.fontFamily).toBe("Minion Pro");
+    expect(heading?.properties.fontStyle).toBe("Bold");
+    expect(heading?.properties.fillColor).toBe("Color/Black");
+    expect(heading?.properties.alignment).toBe("LeftAlign");
+    expect(heading?.basedOn).toBe("ParagraphStyle/$ID/[No paragraph style]");
+
+    const body = document.paragraphStyles.find((s) => s.id === "ParagraphStyle/Body");
+    expect(body?.group).toBe("Body");
+    expect(body?.properties.leading).toBe("auto");
+  });
+
+  it("parses stories with paragraphs, runs, and plain text", () => {
+    const { document } = parse();
+    expect(document.stories).toHaveLength(1);
+    const story = document.stories[0]!;
+    expect(story.id).toBe("u100");
+    expect(story.plainText).toBe("Welcome to Aurelius\nPrint to React, beautifully.");
+    expect(story.paragraphs).toHaveLength(2);
+    expect(story.paragraphs[1]!.runs).toHaveLength(2);
+    expect(story.paragraphs[1]!.runs[1]!.appliedCharacterStyle).toBe("CharacterStyle/Emphasis");
+    expect(story.appliedStyles.character).toContain("CharacterStyle/Emphasis");
+  });
+
+  it("parses spreads, pages, and frames with pixel geometry", () => {
+    const { document } = parse();
+    expect(document.spreads).toHaveLength(1);
+    const spread = document.spreads[0]!;
+
+    expect(spread.pages).toHaveLength(1);
+    expect(spread.pages[0]!.bounds).toEqual({ x: 0, y: 0, width: 816, height: 1056 });
+
+    expect(spread.frames).toHaveLength(2);
+    const text = spread.frames.find((f) => f.type === "text") as TextFrame;
+    expect(text.storyId).toBe("u100");
+    expect(text.pageId).toBe("page-1");
+    expect(text.bounds).toEqual({ x: 96, y: 96, width: 624, height: 133.33 });
+  });
+
+  it("resolves image frames to assets inside the package", () => {
+    const { document } = parse();
+    const spread = document.spreads[0]!;
+    const image = spread.frames.find((f) => f.type === "image") as ImageFrame;
+    expect(image.image.kind).toBe("image");
+    expect(image.image.embedded).toBe(false);
+    expect(image.image.resolvedPath).toBe("Links/hero.png");
+    expect(image.image.actualPpi).toBe(300);
+
+    // The resolved path is a real entry surfaced as a document asset.
+    const asset = document.assets.find((a) => a.path === "Links/hero.png");
+    expect(asset).toBeDefined();
+    expect(asset!.bytes).toBeGreaterThan(0);
+  });
+
+  it("parses master spreads with names and frames", () => {
+    const { document } = parse();
+    expect(document.masterSpreads).toHaveLength(1);
+    const master = document.masterSpreads[0]!;
+    expect(master.name).toBe("A-Master");
+    expect(master.namePrefix).toBe("A");
+    expect(master.pages).toHaveLength(1);
+    const band = master.frames[0]!;
+    expect(band.type).toBe("graphic");
+    expect(band.fillColor).toBe("Color/Brand Blue");
+  });
+
+  it("emits no warnings for a well-formed package", () => {
+    const { document, warnings } = parse();
+    expect(warnings).toEqual([]);
+    expect(document.warnings).toEqual([]);
+  });
+
+  it("honors a custom DPI", () => {
+    const { document } = parseIdml(buildSampleIdml(), { dpi: 72 });
+    const heading = document.paragraphStyles.find((s) => s.id === "ParagraphStyle/Heading");
+    expect(heading?.properties.pointSize).toBe(24); // 24pt → 24px @72dpi
+    expect(document.spreads[0]!.pages[0]!.bounds.width).toBe(612);
+  });
+});
+
+describe("parseIdml — malformed and edge-case packages", () => {
+  it("throws IdmlParseError when the input is not a zip", () => {
+    const notZip = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(() => parseIdml(notZip)).toThrowError(IdmlParseError);
+    try {
+      parseIdml(notZip);
+    } catch (err) {
+      expect((err as IdmlParseError).code).toBe("NOT_A_ZIP");
+    }
+  });
+
+  it("throws IdmlParseError when designmap.xml is missing", () => {
+    const files = sampleFiles();
+    delete files["designmap.xml"];
+    expect(() => parseIdml(buildIdml(files))).toThrowError(/designmap/i);
+  });
+
+  it("flags an invalid mimetype but still parses", () => {
+    const files = sampleFiles();
+    files.mimetype = "text/plain";
+    const { document, warnings } = parse(files);
+    expect(document.meta.mimetypeValid).toBe(false);
+    expect(warnings.some((w) => w.code === WarningCode.MIMETYPE_MISMATCH)).toBe(true);
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+
+  it("warns on an image link that does not resolve inside the package", () => {
+    const files = sampleFiles();
+    delete files["Links/hero.png"];
+    const { document, warnings } = parse(files);
+    const image = document.spreads[0]!.frames.find((f) => f.type === "image") as ImageFrame;
+    expect(image.image.resolvedPath).toBeUndefined();
+    expect(warnings.some((w) => w.code === WarningCode.UNRESOLVED_LINK)).toBe(true);
+  });
+
+  it("warns when a TextFrame references a missing story", () => {
+    const files = sampleFiles();
+    delete files["Stories/Story_u100.xml"];
+    const { document, warnings } = parse(files);
+    expect(document.stories).toHaveLength(0);
+    expect(warnings.some((w) => w.code === WarningCode.MISSING_PARENT_STORY)).toBe(true);
+    expect(warnings.some((w) => w.code === WarningCode.MISSING_RESOURCE_FILE)).toBe(true);
+  });
+
+  it("recovers from a story file with no <Story> element", () => {
+    const files = sampleFiles();
+    files["Stories/Story_u100.xml"] =
+      '<idPkg:Story xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0"></idPkg:Story>';
+    const { document, warnings } = parse(files);
+    expect(document.stories).toHaveLength(0);
+    expect(warnings.some((w) => w.code === WarningCode.MALFORMED_XML)).toBe(true);
+    // The document still validates despite the recoverable error.
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+
+  it("produces a valid empty IR when resources are absent", () => {
+    const minimalDesignmap =
+      '<?xml version="1.0"?><Document xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0" Self="doc"></Document>';
+    const buffer = buildIdml({
+      mimetype: "application/vnd.adobe.indesign-idml-package",
+      "designmap.xml": minimalDesignmap,
+    });
+    const { document, warnings } = parseIdml(buffer);
+    expect(document.spreads).toEqual([]);
+    expect(document.swatches).toEqual([]);
+    expect(warnings.some((w) => w.code === WarningCode.MISSING_RESOURCE_FILE)).toBe(true);
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+});
+
+describe("parseIdml — nested groups", () => {
+  const groupSpread = `<?xml version="1.0"?>
+<idPkg:Spread xmlns:idPkg="http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging" DOMVersion="16.0">
+  <Spread Self="ub6" ItemTransform="1 0 0 1 0 0">
+    <Page Self="page-1" Name="1" GeometricBounds="0 0 792 612" ItemTransform="1 0 0 1 0 0" />
+    <Group Self="grp-1" ItemTransform="1 0 0 1 100 100">
+      <Properties><PathGeometry><GeometryPathType><PathPointArray>
+        <PathPointType Anchor="0 0" /><PathPointType Anchor="200 0" />
+        <PathPointType Anchor="200 90" /><PathPointType Anchor="0 90" />
+      </PathPointArray></GeometryPathType></PathGeometry></Properties>
+      <TextFrame Self="grp-text" ParentStory="u100" ItemTransform="1 0 0 1 10 10">
+        <Properties><PathGeometry><GeometryPathType><PathPointArray>
+          <PathPointType Anchor="0 0" /><PathPointType Anchor="180 0" />
+          <PathPointType Anchor="180 40" /><PathPointType Anchor="0 40" />
+        </PathPointArray></GeometryPathType></PathGeometry></Properties>
+      </TextFrame>
+      <Rectangle Self="grp-rect" ItemTransform="1 0 0 1 10 60">
+        <Properties><PathGeometry><GeometryPathType><PathPointArray>
+          <PathPointType Anchor="0 0" /><PathPointType Anchor="180 0" />
+          <PathPointType Anchor="180 30" /><PathPointType Anchor="0 30" />
+        </PathPointArray></GeometryPathType></PathGeometry></Properties>
+      </Rectangle>
+    </Group>
+  </Spread>
+</idPkg:Spread>`;
+
+  function parseWithGroup() {
+    const files = sampleFiles();
+    files["Spreads/Spread_ub6.xml"] = groupSpread;
+    return parseIdml(buildIdml(files));
+  }
+
+  it("parses groups with recursively nested children and composed geometry", () => {
+    const { document } = parseWithGroup();
+    const group = document.spreads[0]!.frames[0] as GroupFrame;
+    expect(group.type).toBe("group");
+    expect(group.children).toHaveLength(2);
+
+    const text = group.children.find((f) => f.type === "text") as TextFrame;
+    // Group translate (100,100) ∘ child translate (10,10) → origin (110pt → 146.67px).
+    expect(text.bounds.x).toBe(146.67);
+    expect(text.storyId).toBe("u100");
+    expect(text.pageId).toBe("page-1"); // page assignment recurses into groups
+
+    const rect = group.children.find((f) => f.type === "graphic");
+    expect(rect?.id).toBe("grp-rect");
+  });
+
+  it("validates a document containing nested group frames", () => {
+    const { document } = parseWithGroup();
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+});

--- a/packages/pipeline/src/indesign/__tests__/units.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/units.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMatrix,
+  boundsFromPoints,
+  compose,
+  containsCenter,
+  IDENTITY,
+  normalizeMatrix,
+  parseGeometricBounds,
+  parseTransform,
+  ptToPx,
+  round,
+} from "../units.js";
+
+describe("ptToPx", () => {
+  it("converts points to pixels at the given DPI", () => {
+    expect(ptToPx(72, 96)).toBe(96);
+    expect(ptToPx(72, 72)).toBe(72);
+    expect(ptToPx(12, 96)).toBe(16);
+  });
+});
+
+describe("round", () => {
+  it("rounds to two places and avoids negative zero", () => {
+    expect(round(37.33333)).toBe(37.33);
+    expect(round(-0.0001)).toBe(0);
+    expect(round(1.236, 2)).toBe(1.24);
+  });
+
+  it("returns 0 for non-finite input", () => {
+    expect(round(Number.NaN)).toBe(0);
+    expect(round(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe("parseTransform", () => {
+  it("parses six-component transforms", () => {
+    expect(parseTransform("1 0 0 1 72 144")).toEqual([1, 0, 0, 1, 72, 144]);
+  });
+
+  it("falls back to identity on malformed input", () => {
+    expect(parseTransform(undefined)).toEqual(IDENTITY);
+    expect(parseTransform("1 2 3")).toEqual(IDENTITY);
+    expect(parseTransform("a b c d e f")).toEqual(IDENTITY);
+  });
+});
+
+describe("applyMatrix and compose", () => {
+  it("applies translation and scale", () => {
+    expect(applyMatrix([1, 0, 0, 1, 10, 20], 5, 5)).toEqual({ x: 15, y: 25 });
+    expect(applyMatrix([2, 0, 0, 3, 0, 0], 5, 5)).toEqual({ x: 10, y: 15 });
+  });
+
+  it("composes parent ∘ child so child is applied first", () => {
+    const parent = [1, 0, 0, 1, 100, 0] as const;
+    const child = [1, 0, 0, 1, 0, 50] as const;
+    const combined = compose([...parent], [...child]);
+    // A local origin maps through child (0,50) then parent (+100 x) → (100,50).
+    expect(applyMatrix(combined, 0, 0)).toEqual({ x: 100, y: 50 });
+  });
+
+  it("composes scale and translation correctly", () => {
+    const combined = compose([2, 0, 0, 2, 0, 0], [1, 0, 0, 1, 10, 10]);
+    expect(applyMatrix(combined, 0, 0)).toEqual({ x: 20, y: 20 });
+  });
+});
+
+describe("boundsFromPoints", () => {
+  it("computes an axis-aligned bounding box", () => {
+    expect(
+      boundsFromPoints([
+        { x: 10, y: 5 },
+        { x: 30, y: 5 },
+        { x: 30, y: 25 },
+        { x: 10, y: 25 },
+      ]),
+    ).toEqual({ x: 10, y: 5, width: 20, height: 20 });
+  });
+
+  it("returns undefined for an empty set", () => {
+    expect(boundsFromPoints([])).toBeUndefined();
+  });
+});
+
+describe("parseGeometricBounds", () => {
+  it("parses top-left-bottom-right into a rect", () => {
+    expect(parseGeometricBounds("0 0 792 612")).toEqual({ x: 0, y: 0, width: 612, height: 792 });
+    expect(parseGeometricBounds("-10 -20 10 20")).toEqual({
+      x: -20,
+      y: -10,
+      width: 40,
+      height: 20,
+    });
+  });
+
+  it("returns undefined for malformed bounds", () => {
+    expect(parseGeometricBounds("0 0 792")).toBeUndefined();
+    expect(parseGeometricBounds(undefined)).toBeUndefined();
+  });
+});
+
+describe("normalizeMatrix", () => {
+  it("converts translation to pixels and preserves scale", () => {
+    expect(normalizeMatrix([1, 0, 0, 1, 72, 36], 96)).toEqual([1, 0, 0, 1, 96, 48]);
+  });
+});
+
+describe("containsCenter", () => {
+  const page = { x: 0, y: 0, width: 100, height: 100 };
+  it("detects a frame whose center is inside the page", () => {
+    expect(containsCenter(page, { x: 10, y: 10, width: 20, height: 20 })).toBe(true);
+  });
+  it("rejects a frame whose center is outside the page", () => {
+    expect(containsCenter(page, { x: 200, y: 200, width: 20, height: 20 })).toBe(false);
+  });
+});

--- a/packages/pipeline/src/indesign/cli.ts
+++ b/packages/pipeline/src/indesign/cli.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Command-line interface for the IDML parser.
+ *
+ * `runCli` is a pure function (no `process.exit`, returns captured output) so it
+ * is unit-testable; the module tail wires it to `process` only when executed
+ * directly as `aurelius-indesign`.
+ */
+import { pathToFileURL } from "node:url";
+import { IdmlParseError } from "./errors.js";
+import type { Document, Frame } from "./ir.js";
+import { parseIdmlFile } from "./parser.js";
+import type { ParseWarning } from "./warnings.js";
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+const USAGE = `aurelius-indesign — parse an InDesign IDML package into a normalized IR
+
+Usage:
+  aurelius-indesign <file.idml> [options]
+
+Options:
+  --json           Emit the full IR as JSON on stdout
+  --pretty         Pretty-print JSON (use with --json)
+  --dpi <number>   Pixel conversion DPI (default 96)
+  --no-validate    Skip zod validation of the produced IR
+  -h, --help       Show this help
+`;
+
+interface ParsedArgs {
+  input?: string;
+  json: boolean;
+  pretty: boolean;
+  validate: boolean;
+  help: boolean;
+  dpi?: number;
+  error?: string;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = { json: false, pretty: false, validate: true, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--json":
+        args.json = true;
+        break;
+      case "--pretty":
+        args.pretty = true;
+        break;
+      case "--no-validate":
+        args.validate = false;
+        break;
+      case "-h":
+      case "--help":
+        args.help = true;
+        break;
+      case "--dpi": {
+        const value = Number(argv[++i]);
+        if (!Number.isFinite(value) || value <= 0) {
+          args.error = `Invalid --dpi value: ${argv[i] ?? "(missing)"}`;
+        } else {
+          args.dpi = value;
+        }
+        break;
+      }
+      default:
+        if (arg && arg.startsWith("-")) {
+          args.error = `Unknown option: ${arg}`;
+        } else if (arg && args.input === undefined) {
+          args.input = arg;
+        }
+    }
+  }
+  return args;
+}
+
+/** Run the CLI against an argv array, returning captured output and exit code. */
+export function runCli(argv: string[]): CliResult {
+  const args = parseArgs(argv);
+
+  if (args.error) {
+    return { code: 2, stdout: "", stderr: `${args.error}\n\n${USAGE}` };
+  }
+  if (args.help) {
+    return { code: 0, stdout: USAGE, stderr: "" };
+  }
+  if (!args.input) {
+    return { code: 2, stdout: "", stderr: `Error: no input file provided\n\n${USAGE}` };
+  }
+
+  let document: Document;
+  try {
+    const result = parseIdmlFile(args.input, {
+      validate: args.validate,
+      ...(args.dpi ? { dpi: args.dpi } : {}),
+    });
+    document = result.document;
+  } catch (err) {
+    const label = err instanceof IdmlParseError ? `Error [${err.code}]` : "Error";
+    const reason = err instanceof Error ? err.message : String(err);
+    return { code: 1, stdout: "", stderr: `${label}: ${reason}\n` };
+  }
+
+  const warningSummary = formatWarningSummary(document.warnings);
+
+  if (args.json) {
+    const json = JSON.stringify(document, null, args.pretty ? 2 : 0);
+    return { code: 0, stdout: `${json}\n`, stderr: warningSummary };
+  }
+
+  return { code: 0, stdout: formatReport(document), stderr: warningSummary };
+}
+
+interface FrameCounts {
+  text: number;
+  image: number;
+  graphic: number;
+  group: number;
+  total: number;
+}
+
+function countFrames(frames: Frame[], counts: FrameCounts): void {
+  for (const frame of frames) {
+    counts[frame.type]++;
+    counts.total++;
+    if (frame.type === "group") countFrames(frame.children, counts);
+  }
+}
+
+/** Build the human-readable summary report (stdout in non-JSON mode). */
+export function formatReport(document: Document): string {
+  const counts: FrameCounts = { text: 0, image: 0, graphic: 0, group: 0, total: 0 };
+  for (const spread of document.spreads) countFrames(spread.frames, counts);
+  for (const master of document.masterSpreads) countFrames(master.frames, counts);
+
+  const pages =
+    document.spreads.reduce((n, s) => n + s.pages.length, 0) +
+    document.masterSpreads.reduce((n, s) => n + s.pages.length, 0);
+
+  const lines: string[] = [];
+  lines.push("InDesign IDML → IR");
+  if (document.meta.sourcePath) lines.push(`  source:        ${document.meta.sourcePath}`);
+  lines.push(`  IDML version:  ${document.meta.idmlVersion ?? "(unknown)"}`);
+  lines.push(`  DPI:           ${document.meta.dpi}`);
+  lines.push(`  mimetype:      ${document.meta.mimetypeValid ? "valid" : "INVALID"}`);
+  lines.push("");
+  lines.push("Counts");
+  lines.push(`  spreads:           ${document.spreads.length}`);
+  lines.push(`  master spreads:    ${document.masterSpreads.length}`);
+  lines.push(`  pages:             ${pages}`);
+  lines.push(
+    `  frames:            ${counts.total} (text: ${counts.text}, image: ${counts.image}, graphic: ${counts.graphic}, group: ${counts.group})`,
+  );
+  lines.push(`  stories:           ${document.stories.length}`);
+  lines.push(`  swatches:          ${document.swatches.length}`);
+  lines.push(`  fonts:             ${document.fonts.length}`);
+  lines.push(`  paragraph styles:  ${document.paragraphStyles.length}`);
+  lines.push(`  character styles:  ${document.characterStyles.length}`);
+  lines.push(`  assets:            ${document.assets.length}`);
+  lines.push("");
+  lines.push(`Warnings (${document.warnings.length})`);
+  if (document.warnings.length === 0) {
+    lines.push("  none");
+  } else {
+    for (const warning of document.warnings) {
+      lines.push(`  ${formatWarning(warning)}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatWarning(warning: ParseWarning): string {
+  const location = warning.path ? ` (${warning.path})` : "";
+  return `[${warning.severity}] ${warning.code}: ${warning.message}${location}`;
+}
+
+function formatWarningSummary(warnings: ParseWarning[]): string {
+  if (warnings.length === 0) return "";
+  const errors = warnings.filter((w) => w.severity === "error").length;
+  const warns = warnings.filter((w) => w.severity === "warning").length;
+  const infos = warnings.filter((w) => w.severity === "info").length;
+  return `${warnings.length} warning(s): ${errors} error, ${warns} warning, ${infos} info\n`;
+}
+
+/* ── Direct-execution entry point ────────────────────────────────────────── */
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  const result = runCli(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.code);
+}

--- a/packages/pipeline/src/indesign/colors.ts
+++ b/packages/pipeline/src/indesign/colors.ts
@@ -1,0 +1,89 @@
+/**
+ * Color-space conversion for IDML swatches.
+ *
+ * IDML colors carry a `Space` (`CMYK`, `RGB`, `LAB`, `Gray`) and a raw
+ * `ColorValue`. This module converts those to an sRGB triple and `#rrggbb` hex
+ * so downstream token mapping has a usable web color. Conversions are
+ * deterministic approximations (no ICC profiles); unknown spaces return
+ * `undefined` and the caller records a warning.
+ */
+import type { RGB } from "./ir.js";
+
+function clamp255(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+/** Format an sRGB triple as `#rrggbb`. */
+export function rgbToHex(rgb: RGB): string {
+  const hex = (n: number) => clamp255(n).toString(16).padStart(2, "0");
+  return `#${hex(rgb.r)}${hex(rgb.g)}${hex(rgb.b)}`;
+}
+
+/** CMYK (each component 0–100) to sRGB. */
+export function cmykToRgb(c: number, m: number, y: number, k: number): RGB {
+  const cc = c / 100;
+  const mm = m / 100;
+  const yy = y / 100;
+  const kk = k / 100;
+  return {
+    r: clamp255(255 * (1 - cc) * (1 - kk)),
+    g: clamp255(255 * (1 - mm) * (1 - kk)),
+    b: clamp255(255 * (1 - yy) * (1 - kk)),
+  };
+}
+
+/** Single-channel gray (0 = white, 100 = black) to sRGB. */
+export function grayToRgb(value: number): RGB {
+  const channel = clamp255(255 * (1 - value / 100));
+  return { r: channel, g: channel, b: channel };
+}
+
+/** CIE L*a*b* (D50 reference white, as InDesign uses) to sRGB. */
+export function labToRgb(l: number, a: number, b: number): RGB {
+  const fy = (l + 16) / 116;
+  const fx = fy + a / 500;
+  const fz = fy - b / 200;
+  const inv = (t: number): number => {
+    const t3 = t ** 3;
+    return t3 > 0.008856 ? t3 : (t - 16 / 116) / 7.787;
+  };
+  // D50 reference white.
+  const x = 0.96422 * inv(fx);
+  const y = 1.0 * inv(fy);
+  const z = 0.82521 * inv(fz);
+  // D50-adapted XYZ → linear sRGB.
+  const rl = x * 3.1338561 + y * -1.6168667 + z * -0.4906146;
+  const gl = x * -0.9787684 + y * 1.9161415 + z * 0.033454;
+  const bl = x * 0.0719453 + y * -0.2289914 + z * 1.4052427;
+  const gamma = (ch: number): number =>
+    ch <= 0.0031308 ? 12.92 * ch : 1.055 * Math.pow(Math.max(ch, 0), 1 / 2.4) - 0.055;
+  return {
+    r: clamp255(gamma(rl) * 255),
+    g: clamp255(gamma(gl) * 255),
+    b: clamp255(gamma(bl) * 255),
+  };
+}
+
+/**
+ * Convert a swatch color space + raw component values to sRGB. Returns
+ * `undefined` for unknown spaces or insufficient component counts.
+ */
+export function colorToRgb(space: string | undefined, values: number[]): RGB | undefined {
+  if (!space) return undefined;
+  switch (space.toUpperCase()) {
+    case "CMYK":
+      if (values.length < 4) return undefined;
+      return cmykToRgb(values[0]!, values[1]!, values[2]!, values[3]!);
+    case "RGB":
+      if (values.length < 3) return undefined;
+      return { r: clamp255(values[0]!), g: clamp255(values[1]!), b: clamp255(values[2]!) };
+    case "LAB":
+      if (values.length < 3) return undefined;
+      return labToRgb(values[0]!, values[1]!, values[2]!);
+    case "GRAY":
+      if (values.length < 1) return undefined;
+      return grayToRgb(values[0]!);
+    default:
+      return undefined;
+  }
+}

--- a/packages/pipeline/src/indesign/errors.ts
+++ b/packages/pipeline/src/indesign/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Fatal errors for the IDML parser.
+ *
+ * Unlike {@link import("./warnings.js").ParseWarning}, an `IdmlParseError`
+ * represents an unrecoverable condition (the input is not a zip, `designmap.xml`
+ * is absent, etc.) that prevents producing any intermediate representation.
+ */
+export class IdmlParseError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code = "IDML_PARSE_ERROR") {
+    super(message);
+    this.name = "IdmlParseError";
+    this.code = code;
+    // Restore the prototype chain for instanceof checks across transpile targets.
+    Object.setPrototypeOf(this, IdmlParseError.prototype);
+  }
+}

--- a/packages/pipeline/src/indesign/index.ts
+++ b/packages/pipeline/src/indesign/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Public API for the InDesign IDML parser and intermediate representation.
+ *
+ * @example
+ * ```ts
+ * import { parseIdmlFile } from "@aurelius/pipeline/indesign";
+ *
+ * const { document, warnings } = parseIdmlFile("brochure.idml", { dpi: 96 });
+ * console.log(document.swatches, document.paragraphStyles, warnings);
+ * ```
+ */
+export type * from "./ir.js";
+export {
+  parseIdml,
+  parseIdmlFile,
+  parsePackage,
+  DEFAULT_DPI,
+  type ParseOptions,
+  type ParseResult,
+} from "./parser.js";
+export { DocumentSchema, validateDocument, safeValidateDocument } from "./schema.js";
+export { IdmlPackage, IDML_MIMETYPE } from "./package.js";
+export { IdmlParseError } from "./errors.js";
+export {
+  WarningCode,
+  WarningCollector,
+  type ParseWarning,
+  type WarningSeverity,
+  type WarningCodeValue,
+} from "./warnings.js";
+export { runCli, formatReport, type CliResult } from "./cli.js";
+export { ptToPx, parseTransform, compose, applyMatrix } from "./units.js";

--- a/packages/pipeline/src/indesign/ir.ts
+++ b/packages/pipeline/src/indesign/ir.ts
@@ -1,0 +1,288 @@
+/**
+ * Intermediate representation (IR) for parsed InDesign IDML packages.
+ *
+ * These are the canonical, framework-agnostic types that downstream pipeline
+ * stages (the style/token mapper and the React component generator) consume.
+ * Every geometric value is expressed in **pixels**, normalized from the points
+ * native to IDML at a configurable DPI (default 96) — see {@link DocumentMeta.dpi}.
+ *
+ * The runtime zod schema in `./schema.ts` mirrors these types exactly; a
+ * compile-time assertion there keeps the two in lockstep.
+ */
+import type { ParseWarning } from "./warnings.js";
+
+/** An axis-aligned rectangle in pixels. `x`/`y` are the top-left corner. */
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * A 2D affine transform in IDML's `ItemTransform` component order
+ * `[a, b, c, d, tx, ty]`, mapping a local point `(x, y)` to its parent space via
+ * `x' = a·x + c·y + tx`, `y' = b·x + d·y + ty`. Translation components are
+ * normalized to pixels; the scale/shear components are unitless.
+ */
+export type Matrix = [number, number, number, number, number, number];
+
+/** An sRGB color with 8-bit channels. */
+export interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Top-level facts about the parsed document. */
+export interface DocumentMeta {
+  /** IDML DOM version from `designmap.xml` (`@DOMVersion`), when present. */
+  idmlVersion?: string;
+  /** Dots per inch used to convert IDML points to pixels. */
+  dpi: number;
+  /** Whether the package `mimetype` entry matched the IDML media type. */
+  mimetypeValid: boolean;
+  /** Absolute path the package was read from, when parsed from a file. */
+  sourcePath?: string;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Resources: swatches, fonts, styles
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export type SwatchType = "color" | "tint" | "gradient" | "mixedInk" | "unknown";
+
+/** A color, tint, or gradient enumerated from `Resources/Graphic.xml`. */
+export interface Swatch {
+  /** `Self` identifier, e.g. `"Color/Black"`. */
+  id: string;
+  name: string;
+  type: SwatchType;
+  /** Color model: `Process`, `Spot`, `Registration`, … */
+  model?: string;
+  /** Color space: `CMYK`, `RGB`, `LAB`, … */
+  space?: string;
+  /** Raw numeric components exactly as authored in `ColorValue`. */
+  colorValue?: number[];
+  /** Six-digit `#rrggbb` hex, computed when the space is convertible. */
+  hex?: string;
+  /** Resolved sRGB triple, computed alongside {@link Swatch.hex}. */
+  rgb?: RGB;
+}
+
+/** A font enumerated from `Resources/Fonts.xml`. */
+export interface Font {
+  /** `Self` identifier, when present. */
+  id?: string;
+  family: string;
+  /** Full font name, e.g. `"Minion Pro Regular"`. */
+  name: string;
+  /** Style/weight name, e.g. `"Regular"`, `"Bold Italic"`. */
+  styleName?: string;
+  postScriptName?: string;
+  /** Availability status reported by InDesign, e.g. `"Installed"`. */
+  status?: string;
+}
+
+export type StyleKind = "paragraph" | "character";
+
+/** A normalized, frequently-used subset of style attributes plus raw passthrough. */
+export interface StyleProperties {
+  fontFamily?: string;
+  fontStyle?: string;
+  /** Type size in pixels. */
+  pointSize?: number;
+  /** Leading in pixels, or the literal `"auto"`. */
+  leading?: number | "auto";
+  tracking?: number;
+  /** Swatch id reference for the fill. */
+  fillColor?: string;
+  /** Swatch id reference for the stroke. */
+  strokeColor?: string;
+  /** Paragraph justification, e.g. `"LeftAlign"`. */
+  alignment?: string;
+  /** Every attribute from the source element, verbatim, for the mapper. */
+  raw: Record<string, string>;
+}
+
+/** A paragraph or character style from `Resources/Styles.xml`. */
+export interface Style {
+  /** `Self` identifier, e.g. `"ParagraphStyle/Heading"`. */
+  id: string;
+  name: string;
+  kind: StyleKind;
+  /** Slash-delimited group path when the style is nested in style groups. */
+  group?: string;
+  /** `BasedOn` style reference. */
+  basedOn?: string;
+  properties: StyleProperties;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Stories: text content
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** A run of text sharing a single applied character style. */
+export interface TextRun {
+  text: string;
+  /** `AppliedCharacterStyle` reference. */
+  appliedCharacterStyle: string;
+  /** Local character-level attribute overrides, verbatim. */
+  overrides: Record<string, string>;
+}
+
+/** A paragraph sharing a single applied paragraph style. */
+export interface Paragraph {
+  /** `AppliedParagraphStyle` reference. */
+  appliedParagraphStyle: string;
+  /** Local paragraph-level attribute overrides, verbatim. */
+  overrides: Record<string, string>;
+  runs: TextRun[];
+  /** Concatenated text of all runs in this paragraph. */
+  text: string;
+}
+
+/** A story from `Stories/Story_*.xml`. */
+export interface Story {
+  /** `Self` identifier. */
+  id: string;
+  paragraphs: Paragraph[];
+  /** All paragraphs joined with newlines. */
+  plainText: string;
+  /** Distinct style references used anywhere in the story. */
+  appliedStyles: { paragraph: string[]; character: string[] };
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Layout: spreads, pages, frames
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export type FrameType = "text" | "image" | "graphic" | "group" | "unknown";
+
+/** Properties shared by every page item. Bounds are in spread space, pixels. */
+export interface FrameBase {
+  /** `Self` identifier. */
+  id: string;
+  type: FrameType;
+  name?: string;
+  /** Resolved containing page id, when the frame sits on a page. */
+  pageId?: string;
+  /** Axis-aligned bounding box in spread coordinates, pixels. */
+  bounds: Rect;
+  /** The item's own `ItemTransform` (translation normalized to pixels). */
+  transform: Matrix;
+  visible: boolean;
+  /** Swatch id reference for the fill. */
+  fillColor?: string;
+  /** Swatch id reference for the stroke. */
+  strokeColor?: string;
+}
+
+/** A text frame, linked to a story via {@link TextFrame.storyId}. */
+export interface TextFrame extends FrameBase {
+  type: "text";
+  /** Resolved `ParentStory`. Present even when unresolved (a warning is emitted). */
+  storyId?: string;
+  /** `NextTextFrame` in the threading chain, when threaded. */
+  nextFrameId?: string;
+  /** `PreviousTextFrame` in the threading chain, when threaded. */
+  previousFrameId?: string;
+}
+
+export type ImageKind = "image" | "eps" | "pdf" | "unknown";
+
+/** A placed graphic inside an {@link ImageFrame}. */
+export interface ImageRef {
+  kind: ImageKind;
+  /** True when pixel data is embedded in the IDML rather than externally linked. */
+  embedded: boolean;
+  /** Original `LinkResourceURI`. */
+  linkUri?: string;
+  /** Package-relative path when the link resolves to a bundled asset. */
+  resolvedPath?: string;
+  /** Effective resolution reported by InDesign, when present. */
+  actualPpi?: number;
+  /** The graphic's own `ItemTransform` (translation normalized to pixels). */
+  itemTransform?: Matrix;
+}
+
+/** A frame whose content is a placed image, EPS, or PDF. */
+export interface ImageFrame extends FrameBase {
+  type: "image";
+  image: ImageRef;
+}
+
+/** A geometric frame (rectangle, oval, polygon, line) with no placed content. */
+export interface GraphicFrame extends FrameBase {
+  type: "graphic";
+}
+
+/** A group of nested page items. */
+export interface GroupFrame extends FrameBase {
+  type: "group";
+  children: Frame[];
+}
+
+export type Frame = TextFrame | ImageFrame | GraphicFrame | GroupFrame;
+
+/** A page within a spread or master spread. */
+export interface Page {
+  /** `Self` identifier. */
+  id: string;
+  /** Page name/number, e.g. `"1"`. */
+  name?: string;
+  /** Page rectangle in spread coordinates, pixels. */
+  bounds: Rect;
+  /** Raw `GeometricBounds` rectangle in pixels (pre-transform). */
+  geometricBounds: Rect;
+  /** The page's own `ItemTransform` (translation normalized to pixels). */
+  transform: Matrix;
+}
+
+/** A spread from `Spreads/Spread_*.xml`. */
+export interface Spread {
+  /** `Self` identifier. */
+  id: string;
+  pages: Page[];
+  frames: Frame[];
+  /** The spread's own `ItemTransform` (translation normalized to pixels). */
+  transform: Matrix;
+}
+
+/** A master spread from `MasterSpreads/MasterSpread_*.xml`. */
+export interface MasterSpread {
+  /** `Self` identifier. */
+  id: string;
+  /** Master name, e.g. `"A-Master"`. */
+  name?: string;
+  /** Master name prefix, e.g. `"A"`. */
+  namePrefix?: string;
+  pages: Page[];
+  frames: Frame[];
+  /** The master spread's own `ItemTransform` (translation normalized to pixels). */
+  transform: Matrix;
+}
+
+/** A binary asset bundled inside the IDML package (typically under `Links/`). */
+export interface Asset {
+  /** Package-relative path. */
+  path: string;
+  /** Size in bytes. */
+  bytes: number;
+}
+
+/** The complete intermediate representation of a parsed IDML package. */
+export interface Document {
+  meta: DocumentMeta;
+  spreads: Spread[];
+  masterSpreads: MasterSpread[];
+  stories: Story[];
+  swatches: Swatch[];
+  fonts: Font[];
+  paragraphStyles: Style[];
+  characterStyles: Style[];
+  /** Bundled binary assets discovered in the package. */
+  assets: Asset[];
+  /** Non-fatal issues collected during parsing. */
+  warnings: ParseWarning[];
+}

--- a/packages/pipeline/src/indesign/package.ts
+++ b/packages/pipeline/src/indesign/package.ts
@@ -1,0 +1,133 @@
+/**
+ * IDML package abstraction.
+ *
+ * An `.idml` file is a zip archive. This class unzips it into an in-memory map
+ * of normalized entry paths and offers typed accessors plus link-URI resolution
+ * used to map placed images back to bundled assets.
+ */
+import { readFileSync } from "node:fs";
+import { unzipSync } from "fflate";
+import { IdmlParseError } from "./errors.js";
+
+/** The media type stored in the `mimetype` entry of a valid IDML package. */
+export const IDML_MIMETYPE = "application/vnd.adobe.indesign-idml-package";
+
+const decoder = new TextDecoder("utf-8");
+
+export class IdmlPackage {
+  private readonly entries: Map<string, Uint8Array>;
+
+  constructor(entries: Map<string, Uint8Array>) {
+    this.entries = entries;
+  }
+
+  /** Unzip an in-memory buffer. Throws {@link IdmlParseError} when not a zip. */
+  static fromBuffer(buffer: Uint8Array): IdmlPackage {
+    let unzipped: Record<string, Uint8Array>;
+    try {
+      unzipped = unzipSync(buffer);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new IdmlParseError(`Input is not a valid zip/IDML package: ${reason}`, "NOT_A_ZIP");
+    }
+    const entries = new Map<string, Uint8Array>();
+    for (const [path, data] of Object.entries(unzipped)) {
+      // Directory entries have zero-length data and a trailing slash; skip them.
+      if (path.endsWith("/")) continue;
+      entries.set(normalizePath(path), data);
+    }
+    return new IdmlPackage(entries);
+  }
+
+  /** Read and unzip a file from disk. Throws {@link IdmlParseError} on IO error. */
+  static fromFile(path: string): IdmlPackage {
+    let buffer: Uint8Array;
+    try {
+      buffer = readFileSync(path);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new IdmlParseError(`Cannot read IDML file "${path}": ${reason}`, "FILE_READ_ERROR");
+    }
+    return IdmlPackage.fromBuffer(buffer);
+  }
+
+  has(path: string): boolean {
+    return this.entries.has(normalizePath(path));
+  }
+
+  read(path: string): Uint8Array | undefined {
+    return this.entries.get(normalizePath(path));
+  }
+
+  readText(path: string): string | undefined {
+    const data = this.read(path);
+    return data ? decoder.decode(data) : undefined;
+  }
+
+  /** Byte size of an entry, or 0 when absent. */
+  byteLength(path: string): number {
+    return this.read(path)?.byteLength ?? 0;
+  }
+
+  /** All entry paths, normalized. */
+  list(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  /** Entry paths matching a predicate. */
+  filter(predicate: (path: string) => boolean): string[] {
+    return this.list().filter(predicate);
+  }
+
+  /** The raw `mimetype` entry contents, trimmed. */
+  mimetype(): string | undefined {
+    const data = this.read("mimetype");
+    return data ? decoder.decode(data).trim() : undefined;
+  }
+
+  hasValidMimetype(): boolean {
+    return this.mimetype() === IDML_MIMETYPE;
+  }
+
+  /**
+   * Resolve a link URI to a package-relative entry path. Matches by exact
+   * (percent-decoded) path first, then by basename. Returns `undefined` when no
+   * bundled entry corresponds — the link is external.
+   */
+  resolveAssetUri(uri: string): string | undefined {
+    if (!uri) return undefined;
+    const cleaned = decodePath(stripFileScheme(uri));
+    for (const candidate of [cleaned, normalizePath(cleaned)]) {
+      if (this.entries.has(candidate)) return candidate;
+    }
+    const base = basename(cleaned);
+    if (base) {
+      for (const key of this.entries.keys()) {
+        if (basename(key) === base) return key;
+      }
+    }
+    return undefined;
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+function stripFileScheme(uri: string): string {
+  return uri.replace(/^file:\/\/\/?/i, "").replace(/^file:/i, "");
+}
+
+function decodePath(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function basename(path: string): string {
+  const normalized = normalizePath(path);
+  const slash = normalized.lastIndexOf("/");
+  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
+}

--- a/packages/pipeline/src/indesign/parser.ts
+++ b/packages/pipeline/src/indesign/parser.ts
@@ -1,0 +1,282 @@
+/**
+ * Top-level IDML parser.
+ *
+ * Orchestrates the package, resource, story, and spread parsers into a single
+ * validated {@link Document} intermediate representation. Recoverable issues are
+ * accumulated as warnings; only truly unrecoverable conditions (not a zip,
+ * missing `designmap.xml`) throw {@link IdmlParseError}.
+ */
+import { IdmlParseError } from "./errors.js";
+import type { Asset, Document, Frame, Story } from "./ir.js";
+import { IDML_MIMETYPE, IdmlPackage } from "./package.js";
+import { parseFonts, parseGraphic, parseStyles } from "./resources.js";
+import { validateDocument } from "./schema.js";
+import { parseMasterSpread, parseSpread } from "./spreads.js";
+import { parseStory } from "./stories.js";
+import { WarningCode, WarningCollector } from "./warnings.js";
+import { getAttr, getChild, getChildren, parseXml, type XmlNode } from "./xml.js";
+
+/** Default DPI used to convert IDML points to pixels. */
+export const DEFAULT_DPI = 96;
+
+export interface ParseOptions {
+  /** Dots per inch for point→pixel conversion. Default 96. */
+  dpi?: number;
+  /** Run zod validation on the produced IR (default true). */
+  validate?: boolean;
+  /** Recorded on `document.meta.sourcePath`. */
+  sourcePath?: string;
+}
+
+export interface ParseResult {
+  document: Document;
+  warnings: Document["warnings"];
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "tif",
+  "tiff",
+  "bmp",
+  "webp",
+  "svg",
+  "eps",
+  "pdf",
+  "ai",
+  "psd",
+]);
+
+/** Parse an in-memory IDML buffer. */
+export function parseIdml(buffer: Uint8Array, options: ParseOptions = {}): ParseResult {
+  return parsePackage(IdmlPackage.fromBuffer(buffer), options);
+}
+
+/** Read and parse an IDML file from disk. */
+export function parseIdmlFile(path: string, options: ParseOptions = {}): ParseResult {
+  const pkg = IdmlPackage.fromFile(path);
+  return parsePackage(pkg, { sourcePath: path, ...options });
+}
+
+/** Parse an already-unzipped {@link IdmlPackage}. */
+export function parsePackage(pkg: IdmlPackage, options: ParseOptions = {}): ParseResult {
+  const dpi = options.dpi ?? DEFAULT_DPI;
+  const validate = options.validate ?? true;
+  const collector = new WarningCollector();
+
+  const mimetypeValid = pkg.hasValidMimetype();
+  if (!mimetypeValid) {
+    collector.warn(
+      WarningCode.MIMETYPE_MISMATCH,
+      `mimetype is "${pkg.mimetype() ?? "(absent)"}", expected "${IDML_MIMETYPE}"`,
+      "mimetype",
+    );
+  }
+
+  const designmapText = pkg.readText("designmap.xml");
+  if (designmapText === undefined) {
+    throw new IdmlParseError("Package is missing designmap.xml", "MISSING_DESIGNMAP");
+  }
+  let designmap: XmlNode;
+  try {
+    designmap = parseXml(designmapText);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IdmlParseError(`designmap.xml is malformed: ${reason}`, "MALFORMED_DESIGNMAP");
+  }
+  const documentEl = getChild(designmap, "Document") ?? designmap;
+
+  // ── Resources ──────────────────────────────────────────────────────────
+  const graphicXml = readResource(
+    pkg,
+    collector,
+    documentEl,
+    "idPkg:Graphic",
+    "Resources/Graphic.xml",
+  );
+  const fontsXml = readResource(pkg, collector, documentEl, "idPkg:Fonts", "Resources/Fonts.xml");
+  const stylesXml = readResource(
+    pkg,
+    collector,
+    documentEl,
+    "idPkg:Styles",
+    "Resources/Styles.xml",
+  );
+
+  const swatches = graphicXml ? parseGraphic(graphicXml.text, collector, graphicXml.path) : [];
+  const fonts = fontsXml ? parseFonts(fontsXml.text, collector, fontsXml.path) : [];
+  const styles = stylesXml
+    ? parseStyles(stylesXml.text, collector, stylesXml.path, dpi)
+    : { paragraphStyles: [], characterStyles: [] };
+
+  // ── Stories ────────────────────────────────────────────────────────────
+  const storyPaths = resolveSrcs(documentEl, "idPkg:Story", pkg, "Stories/");
+  const stories: Story[] = [];
+  for (const path of storyPaths) {
+    const text = pkg.readText(path);
+    if (text === undefined) {
+      collector.warn(WarningCode.MISSING_RESOURCE_FILE, `Story file "${path}" is missing`, path);
+      continue;
+    }
+    const story = parseStory(text, collector, path);
+    if (story) stories.push(story);
+  }
+
+  // ── Spreads & master spreads ─────────────────────────────────────────────
+  const resolveAsset = (uri: string): string | undefined => pkg.resolveAssetUri(uri);
+
+  const spreadPaths = resolveSrcs(documentEl, "idPkg:Spread", pkg, "Spreads/");
+  const spreads = spreadPaths
+    .map((path) => {
+      const text = pkg.readText(path);
+      if (text === undefined) {
+        collector.warn(WarningCode.MISSING_RESOURCE_FILE, `Spread file "${path}" is missing`, path);
+        return undefined;
+      }
+      return parseSpread(text, collector, dpi, resolveAsset, path);
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== undefined);
+
+  const masterPaths = resolveSrcs(documentEl, "idPkg:MasterSpread", pkg, "MasterSpreads/");
+  const masterSpreads = masterPaths
+    .map((path) => {
+      const text = pkg.readText(path);
+      if (text === undefined) {
+        collector.warn(
+          WarningCode.MISSING_RESOURCE_FILE,
+          `Master spread "${path}" is missing`,
+          path,
+        );
+        return undefined;
+      }
+      return parseMasterSpread(text, collector, dpi, resolveAsset, path);
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== undefined);
+
+  // ── Cross-reference resolution: TextFrame.ParentStory → Story.Self ───────
+  const storyIds = new Set(stories.map((s) => s.id));
+  const allFrames: Frame[][] = [
+    ...spreads.map((s) => s.frames),
+    ...masterSpreads.map((s) => s.frames),
+  ];
+  for (const frames of allFrames) {
+    resolveStoryRefs(frames, storyIds, collector);
+  }
+
+  // ── Assets ───────────────────────────────────────────────────────────────
+  const assets = gatherAssets(pkg, [
+    ...spreads.flatMap((s) => s.frames),
+    ...masterSpreads.flatMap((s) => s.frames),
+  ]);
+
+  const meta: Document["meta"] = { dpi, mimetypeValid };
+  const idmlVersion = getAttr(documentEl, "DOMVersion");
+  if (idmlVersion) meta.idmlVersion = idmlVersion;
+  if (options.sourcePath) meta.sourcePath = options.sourcePath;
+
+  const document: Document = {
+    meta,
+    spreads,
+    masterSpreads,
+    stories,
+    swatches,
+    fonts,
+    paragraphStyles: styles.paragraphStyles,
+    characterStyles: styles.characterStyles,
+    assets,
+    warnings: collector.all(),
+  };
+
+  const finalDoc = validate ? validateOrThrow(document) : document;
+  return { document: finalDoc, warnings: finalDoc.warnings };
+}
+
+interface ResourceText {
+  text: string;
+  path: string;
+}
+
+function readResource(
+  pkg: IdmlPackage,
+  collector: WarningCollector,
+  documentEl: XmlNode,
+  tag: string,
+  fallback: string,
+): ResourceText | undefined {
+  const src = getChildren(documentEl, tag)
+    .map((n) => getAttr(n, "src"))
+    .find((s): s is string => Boolean(s));
+  const candidates = src ? [src, fallback] : [fallback];
+  for (const path of candidates) {
+    const text = pkg.readText(path);
+    if (text !== undefined) return { text, path };
+  }
+  collector.warn(
+    WarningCode.MISSING_RESOURCE_FILE,
+    `Resource "${tag}" (${src ?? fallback}) not found in package`,
+    src ?? fallback,
+  );
+  return undefined;
+}
+
+function resolveSrcs(
+  documentEl: XmlNode,
+  tag: string,
+  pkg: IdmlPackage,
+  fallbackDir: string,
+): string[] {
+  const declared = getChildren(documentEl, tag)
+    .map((n) => getAttr(n, "src"))
+    .filter((s): s is string => Boolean(s));
+  if (declared.length > 0) return declared;
+  // Fallback: enumerate the conventional directory deterministically.
+  return pkg.filter((p) => p.startsWith(fallbackDir) && p.toLowerCase().endsWith(".xml")).sort();
+}
+
+function resolveStoryRefs(
+  frames: Frame[],
+  storyIds: Set<string>,
+  collector: WarningCollector,
+): void {
+  for (const frame of frames) {
+    if (frame.type === "text" && frame.storyId && !storyIds.has(frame.storyId)) {
+      collector.warn(
+        WarningCode.MISSING_PARENT_STORY,
+        `TextFrame "${frame.id}" references unknown story "${frame.storyId}"`,
+      );
+    }
+    if (frame.type === "group") resolveStoryRefs(frame.children, storyIds, collector);
+  }
+}
+
+function gatherAssets(pkg: IdmlPackage, frames: Frame[]): Asset[] {
+  const paths = new Set<string>();
+  for (const entry of pkg.list()) {
+    if (entry.startsWith("Links/")) {
+      paths.add(entry);
+      continue;
+    }
+    const ext = entry.slice(entry.lastIndexOf(".") + 1).toLowerCase();
+    if (IMAGE_EXTENSIONS.has(ext)) paths.add(entry);
+  }
+  collectResolvedPaths(frames, paths);
+  return [...paths].sort().map((path) => ({ path, bytes: pkg.byteLength(path) }));
+}
+
+function collectResolvedPaths(frames: Frame[], out: Set<string>): void {
+  for (const frame of frames) {
+    if (frame.type === "image" && frame.image.resolvedPath) out.add(frame.image.resolvedPath);
+    if (frame.type === "group") collectResolvedPaths(frame.children, out);
+  }
+}
+
+function validateOrThrow(document: Document): Document {
+  try {
+    return validateDocument(document);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IdmlParseError(`Internal IR validation failed: ${reason}`, "IR_VALIDATION_FAILED");
+  }
+}

--- a/packages/pipeline/src/indesign/resources.ts
+++ b/packages/pipeline/src/indesign/resources.ts
@@ -1,0 +1,288 @@
+/**
+ * Parsers for `Resources/Graphic.xml` (swatches), `Resources/Fonts.xml`
+ * (fonts), and `Resources/Styles.xml` (paragraph & character styles).
+ *
+ * Each parser is defensive: malformed XML is downgraded to a warning and an
+ * empty result rather than aborting the whole package parse.
+ */
+import { colorToRgb, rgbToHex } from "./colors.js";
+import type { Font, Style, StyleKind, StyleProperties, Swatch } from "./ir.js";
+import { ptToPx, round } from "./units.js";
+import { WarningCode, type WarningCollector } from "./warnings.js";
+import {
+  getAttr,
+  getAttributes,
+  getChild,
+  getChildren,
+  getNumAttr,
+  getTextContent,
+  isRecord,
+  parseXml,
+  type XmlNode,
+} from "./xml.js";
+
+/** Strip InDesign's `$ID/` localization prefix from a name. */
+function cleanName(name: string | undefined, fallback: string): string {
+  if (!name) return fallback;
+  return name.replace(/^\$ID\//, "");
+}
+
+function numberList(value: string | undefined): number[] {
+  if (!value) return [];
+  return value
+    .trim()
+    .split(/\s+/)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
+}
+
+/** Parse swatches (colors, tints, gradients) from `Resources/Graphic.xml`. */
+export function parseGraphic(xml: string, collector: WarningCollector, path: string): Swatch[] {
+  let root: XmlNode;
+  try {
+    root = parseXml(xml);
+  } catch (err) {
+    collector.error(WarningCode.MALFORMED_XML, `Failed to parse graphics: ${asMessage(err)}`, path);
+    return [];
+  }
+  const graphic = getChild(root, "idPkg:Graphic") ?? root;
+  const swatches: Swatch[] = [];
+
+  for (const color of getChildren(graphic, "Color")) {
+    const id = getAttr(color, "Self");
+    if (!id) continue;
+    const space = getAttr(color, "Space");
+    const colorValue = numberList(getAttr(color, "ColorValue"));
+    const swatch: Swatch = {
+      id,
+      name: cleanName(getAttr(color, "Name"), id),
+      type: "color",
+    };
+    const model = getAttr(color, "Model");
+    if (model) swatch.model = model;
+    if (space) swatch.space = space;
+    if (colorValue.length > 0) swatch.colorValue = colorValue;
+    const rgb = colorToRgb(space, colorValue);
+    if (rgb) {
+      swatch.rgb = rgb;
+      swatch.hex = rgbToHex(rgb);
+    } else if (space) {
+      collector.info(
+        WarningCode.UNKNOWN_COLOR_SPACE,
+        `Color "${id}" uses unconvertible space "${space}"`,
+        path,
+      );
+    }
+    swatches.push(swatch);
+  }
+
+  for (const tint of getChildren(graphic, "Tint")) {
+    const id = getAttr(tint, "Self");
+    if (!id) continue;
+    const tintValue = getNumAttr(tint, "TintValue");
+    swatches.push({
+      id,
+      name: cleanName(getAttr(tint, "Name"), id),
+      type: "tint",
+      ...(tintValue !== undefined ? { colorValue: [tintValue] } : {}),
+    });
+  }
+
+  for (const gradient of getChildren(graphic, "Gradient")) {
+    const id = getAttr(gradient, "Self");
+    if (!id) continue;
+    swatches.push({ id, name: cleanName(getAttr(gradient, "Name"), id), type: "gradient" });
+  }
+
+  for (const swatch of getChildren(graphic, "Swatch")) {
+    const id = getAttr(swatch, "Self");
+    if (!id) continue;
+    swatches.push({ id, name: cleanName(getAttr(swatch, "Name"), id), type: "unknown" });
+  }
+
+  return swatches;
+}
+
+/** Parse fonts from `Resources/Fonts.xml`. */
+export function parseFonts(xml: string, collector: WarningCollector, path: string): Font[] {
+  let root: XmlNode;
+  try {
+    root = parseXml(xml);
+  } catch (err) {
+    collector.error(WarningCode.MALFORMED_XML, `Failed to parse fonts: ${asMessage(err)}`, path);
+    return [];
+  }
+  const fontsRoot = getChild(root, "idPkg:Fonts") ?? root;
+  const fonts: Font[] = [];
+
+  for (const family of getChildren(fontsRoot, "FontFamily")) {
+    const familyName = getAttr(family, "Name") ?? "";
+    for (const font of getChildren(family, "Font")) {
+      const name = getAttr(font, "Name");
+      if (!name) continue;
+      const entry: Font = {
+        family: getAttr(font, "FontFamily") ?? familyName,
+        name,
+      };
+      const id = getAttr(font, "Self");
+      if (id) entry.id = id;
+      const styleName = getAttr(font, "FontStyleName");
+      if (styleName) entry.styleName = styleName;
+      const postScriptName = getAttr(font, "PostScriptName");
+      if (postScriptName) entry.postScriptName = postScriptName;
+      const status = getAttr(font, "Status");
+      if (status) entry.status = status;
+      fonts.push(entry);
+    }
+  }
+
+  return fonts;
+}
+
+interface StyleAccumulator {
+  paragraphStyles: Style[];
+  characterStyles: Style[];
+}
+
+/** Parse paragraph and character styles from `Resources/Styles.xml`. */
+export function parseStyles(
+  xml: string,
+  collector: WarningCollector,
+  path: string,
+  dpi: number,
+): StyleAccumulator {
+  const acc: StyleAccumulator = { paragraphStyles: [], characterStyles: [] };
+  let root: XmlNode;
+  try {
+    root = parseXml(xml);
+  } catch (err) {
+    collector.error(WarningCode.MALFORMED_XML, `Failed to parse styles: ${asMessage(err)}`, path);
+    return acc;
+  }
+  const stylesRoot = getChild(root, "idPkg:Styles") ?? root;
+
+  const paragraphRoot = getChild(stylesRoot, "RootParagraphStyleGroup");
+  if (paragraphRoot) {
+    collectStyles(
+      paragraphRoot,
+      "paragraph",
+      "ParagraphStyle",
+      "ParagraphStyleGroup",
+      [],
+      dpi,
+      acc,
+    );
+  }
+  const characterRoot = getChild(stylesRoot, "RootCharacterStyleGroup");
+  if (characterRoot) {
+    collectStyles(
+      characterRoot,
+      "character",
+      "CharacterStyle",
+      "CharacterStyleGroup",
+      [],
+      dpi,
+      acc,
+    );
+  }
+
+  return acc;
+}
+
+function collectStyles(
+  group: XmlNode,
+  kind: StyleKind,
+  styleTag: string,
+  groupTag: string,
+  groupPath: string[],
+  dpi: number,
+  acc: StyleAccumulator,
+): void {
+  for (const node of getChildren(group, styleTag)) {
+    const style = toStyle(node, kind, groupPath, dpi);
+    if (!style) continue;
+    if (kind === "paragraph") acc.paragraphStyles.push(style);
+    else acc.characterStyles.push(style);
+  }
+  for (const nested of getChildren(group, groupTag)) {
+    const name = cleanName(getAttr(nested, "Name"), getAttr(nested, "Self") ?? "");
+    collectStyles(nested, kind, styleTag, groupTag, [...groupPath, name], dpi, acc);
+  }
+}
+
+function toStyle(
+  node: XmlNode,
+  kind: StyleKind,
+  groupPath: string[],
+  dpi: number,
+): Style | undefined {
+  const id = getAttr(node, "Self");
+  if (!id) return undefined;
+  const properties = readStyleProperties(node, dpi);
+  const style: Style = {
+    id,
+    name: cleanName(getAttr(node, "Name"), id),
+    kind,
+    properties,
+  };
+  if (groupPath.length > 0) style.group = groupPath.join("/");
+  const basedOn = readBasedOn(node);
+  if (basedOn) style.basedOn = basedOn;
+  return style;
+}
+
+function readBasedOn(node: XmlNode): string | undefined {
+  const props = getChild(node, "Properties");
+  const fromProps = getTextContent(getChild(props, "BasedOn"));
+  if (fromProps) return fromProps;
+  return getAttr(node, "BasedOn");
+}
+
+function readStyleProperties(node: XmlNode, dpi: number): StyleProperties {
+  const raw = getAttributes(node);
+  const properties: StyleProperties = { raw };
+
+  const props = getChild(node, "Properties");
+  const appliedFont = getTextContent(getChild(props, "AppliedFont"));
+  if (appliedFont) properties.fontFamily = appliedFont;
+
+  const fontStyle = getAttr(node, "FontStyle");
+  if (fontStyle) properties.fontStyle = fontStyle;
+
+  const pointSize = getNumAttr(node, "PointSize");
+  if (pointSize !== undefined) properties.pointSize = round(ptToPx(pointSize, dpi));
+
+  const leading = readLeading(props, dpi);
+  if (leading !== undefined) properties.leading = leading;
+
+  const tracking = getNumAttr(node, "Tracking");
+  if (tracking !== undefined) properties.tracking = tracking;
+
+  const fillColor = getAttr(node, "FillColor");
+  if (fillColor) properties.fillColor = fillColor;
+
+  const strokeColor = getAttr(node, "StrokeColor");
+  if (strokeColor) properties.strokeColor = strokeColor;
+
+  const alignment = getAttr(node, "Justification");
+  if (alignment) properties.alignment = alignment;
+
+  return properties;
+}
+
+function readLeading(props: XmlNode | undefined, dpi: number): number | "auto" | undefined {
+  if (!props) return undefined;
+  const leadingNode = props["Leading"];
+  if (leadingNode === undefined) return undefined;
+  const node = Array.isArray(leadingNode) ? leadingNode[0] : leadingNode;
+  const type = isRecord(node) ? getAttr(node, "type") : undefined;
+  if (type === "enumeration") return "auto";
+  const text = getTextContent(node);
+  const value = Number(text);
+  if (Number.isFinite(value)) return round(ptToPx(value, dpi));
+  return undefined;
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/pipeline/src/indesign/schema.ts
+++ b/packages/pipeline/src/indesign/schema.ts
@@ -1,0 +1,225 @@
+/**
+ * Runtime (zod) schemas mirroring the IR types in `./ir.ts`.
+ *
+ * `validateDocument` is the single source of runtime truth used by the parser
+ * and tests to guarantee a produced {@link Document} is structurally valid. The
+ * `_schemaProducesDocument` / `_documentSatisfiesSchema` functions below are
+ * never called — they exist purely so the compiler fails if the schemas and the
+ * hand-written IR types ever drift apart.
+ */
+import { z } from "zod";
+import type { Document, Frame, GroupFrame } from "./ir.js";
+
+const RectSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+const MatrixSchema = z.tuple([
+  z.number(),
+  z.number(),
+  z.number(),
+  z.number(),
+  z.number(),
+  z.number(),
+]);
+
+const RGBSchema = z.object({ r: z.number(), g: z.number(), b: z.number() });
+
+const DocumentMetaSchema = z.object({
+  idmlVersion: z.string().optional(),
+  dpi: z.number(),
+  mimetypeValid: z.boolean(),
+  sourcePath: z.string().optional(),
+});
+
+const SwatchSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["color", "tint", "gradient", "mixedInk", "unknown"]),
+  model: z.string().optional(),
+  space: z.string().optional(),
+  colorValue: z.array(z.number()).optional(),
+  hex: z.string().optional(),
+  rgb: RGBSchema.optional(),
+});
+
+const FontSchema = z.object({
+  id: z.string().optional(),
+  family: z.string(),
+  name: z.string(),
+  styleName: z.string().optional(),
+  postScriptName: z.string().optional(),
+  status: z.string().optional(),
+});
+
+const StylePropertiesSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontStyle: z.string().optional(),
+  pointSize: z.number().optional(),
+  leading: z.union([z.number(), z.literal("auto")]).optional(),
+  tracking: z.number().optional(),
+  fillColor: z.string().optional(),
+  strokeColor: z.string().optional(),
+  alignment: z.string().optional(),
+  raw: z.record(z.string()),
+});
+
+const StyleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  kind: z.enum(["paragraph", "character"]),
+  group: z.string().optional(),
+  basedOn: z.string().optional(),
+  properties: StylePropertiesSchema,
+});
+
+const TextRunSchema = z.object({
+  text: z.string(),
+  appliedCharacterStyle: z.string(),
+  overrides: z.record(z.string()),
+});
+
+const ParagraphSchema = z.object({
+  appliedParagraphStyle: z.string(),
+  overrides: z.record(z.string()),
+  runs: z.array(TextRunSchema),
+  text: z.string(),
+});
+
+const StorySchema = z.object({
+  id: z.string(),
+  paragraphs: z.array(ParagraphSchema),
+  plainText: z.string(),
+  appliedStyles: z.object({
+    paragraph: z.array(z.string()),
+    character: z.array(z.string()),
+  }),
+});
+
+const frameBase = {
+  id: z.string(),
+  name: z.string().optional(),
+  pageId: z.string().optional(),
+  bounds: RectSchema,
+  transform: MatrixSchema,
+  visible: z.boolean(),
+  fillColor: z.string().optional(),
+  strokeColor: z.string().optional(),
+};
+
+const baseFrameObject = z.object(frameBase);
+
+const ImageRefSchema = z.object({
+  kind: z.enum(["image", "eps", "pdf", "unknown"]),
+  embedded: z.boolean(),
+  linkUri: z.string().optional(),
+  resolvedPath: z.string().optional(),
+  actualPpi: z.number().optional(),
+  itemTransform: MatrixSchema.optional(),
+});
+
+const TextFrameSchema = baseFrameObject.extend({
+  type: z.literal("text"),
+  storyId: z.string().optional(),
+  nextFrameId: z.string().optional(),
+  previousFrameId: z.string().optional(),
+});
+
+const ImageFrameSchema = baseFrameObject.extend({
+  type: z.literal("image"),
+  image: ImageRefSchema,
+});
+
+const GraphicFrameSchema = baseFrameObject.extend({
+  type: z.literal("graphic"),
+});
+
+const GroupFrameSchema = baseFrameObject.extend({
+  type: z.literal("group"),
+  children: z.array(z.lazy((): z.ZodType<Frame> => FrameSchema)),
+});
+
+const FrameSchema: z.ZodType<Frame> = z.discriminatedUnion("type", [
+  TextFrameSchema,
+  ImageFrameSchema,
+  GraphicFrameSchema,
+  GroupFrameSchema,
+]);
+
+const PageSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  bounds: RectSchema,
+  geometricBounds: RectSchema,
+  transform: MatrixSchema,
+});
+
+const SpreadSchema = z.object({
+  id: z.string(),
+  pages: z.array(PageSchema),
+  frames: z.array(FrameSchema),
+  transform: MatrixSchema,
+});
+
+const MasterSpreadSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  namePrefix: z.string().optional(),
+  pages: z.array(PageSchema),
+  frames: z.array(FrameSchema),
+  transform: MatrixSchema,
+});
+
+const AssetSchema = z.object({
+  path: z.string(),
+  bytes: z.number(),
+});
+
+const ParseWarningSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  severity: z.enum(["info", "warning", "error"]),
+  path: z.string().optional(),
+});
+
+/** Zod schema for the full IDML intermediate representation. */
+export const DocumentSchema = z.object({
+  meta: DocumentMetaSchema,
+  spreads: z.array(SpreadSchema),
+  masterSpreads: z.array(MasterSpreadSchema),
+  stories: z.array(StorySchema),
+  swatches: z.array(SwatchSchema),
+  fonts: z.array(FontSchema),
+  paragraphStyles: z.array(StyleSchema),
+  characterStyles: z.array(StyleSchema),
+  assets: z.array(AssetSchema),
+  warnings: z.array(ParseWarningSchema),
+});
+
+/** Parse-and-validate, throwing a `ZodError` on structural mismatch. */
+export function validateDocument(value: unknown): Document {
+  return DocumentSchema.parse(value) as Document;
+}
+
+/** Non-throwing validation, returning a discriminated result. */
+export function safeValidateDocument(value: unknown): z.SafeParseReturnType<unknown, Document> {
+  return DocumentSchema.safeParse(value) as z.SafeParseReturnType<unknown, Document>;
+}
+
+/* ── Compile-time drift guards (never executed) ─────────────────────────── */
+
+function _schemaProducesDocument(value: z.infer<typeof DocumentSchema>): Document {
+  return value;
+}
+function _documentSatisfiesSchema(value: Document): z.infer<typeof DocumentSchema> {
+  return value;
+}
+function _groupChildrenAreFrames(value: z.infer<typeof GroupFrameSchema>): GroupFrame {
+  return value;
+}
+void _schemaProducesDocument;
+void _documentSatisfiesSchema;
+void _groupChildrenAreFrames;

--- a/packages/pipeline/src/indesign/spreads.ts
+++ b/packages/pipeline/src/indesign/spreads.ts
@@ -1,0 +1,391 @@
+/**
+ * Parsers for `Spreads/Spread_*.xml` and `MasterSpreads/MasterSpread_*.xml`.
+ *
+ * Walks pages and page items, computing axis-aligned bounding boxes in spread
+ * (pasteboard) coordinates by applying each item's `ItemTransform` to its
+ * `PathGeometry` anchor points, then normalizing points → pixels. Items are
+ * classified into text / image / graphic / group frames, and assigned to the
+ * page whose rectangle contains their center.
+ */
+import type {
+  Frame,
+  GraphicFrame,
+  GroupFrame,
+  ImageFrame,
+  ImageKind,
+  ImageRef,
+  Matrix,
+  Page,
+  Rect,
+  Spread,
+  MasterSpread,
+  TextFrame,
+} from "./ir.js";
+import type { Point } from "./units.js";
+import {
+  IDENTITY,
+  applyMatrix,
+  boundsFromPoints,
+  compose,
+  containsCenter,
+  normalizeMatrix,
+  parseGeometricBounds,
+  parseTransform,
+  rectPtToPx,
+  round,
+} from "./units.js";
+import { WarningCode, type WarningCollector } from "./warnings.js";
+import { getAttr, getBoolAttr, getChild, getChildren, parseXml, type XmlNode } from "./xml.js";
+
+/** Resolves a link URI to a package-relative path, or `undefined` if external. */
+export type LinkResolver = (uri: string) => string | undefined;
+
+interface ParseContext {
+  dpi: number;
+  collector: WarningCollector;
+  path: string;
+  resolveAsset: LinkResolver;
+}
+
+/** Page item tags that contain placed graphics when they wrap an image element. */
+const SHAPE_TAGS = ["Rectangle", "Oval", "Polygon", "GraphicLine"] as const;
+/** Child elements that represent placed graphic content inside a shape. */
+const GRAPHIC_TAGS: Record<string, ImageKind> = {
+  Image: "image",
+  EPS: "eps",
+  PDF: "pdf",
+  ImportedPage: "pdf",
+  WMF: "unknown",
+  PICT: "unknown",
+};
+/** Additional interactive/compound item tags we record as graphic frames. */
+const OTHER_ITEM_TAGS = ["Button", "MultiStateObject", "FormField", "EPSText"] as const;
+
+/** Parse a spread document. Returns `undefined` on malformed XML. */
+export function parseSpread(
+  xml: string,
+  collector: WarningCollector,
+  dpi: number,
+  resolveAsset: LinkResolver,
+  path: string,
+): Spread | undefined {
+  const ctx: ParseContext = { dpi, collector, path, resolveAsset };
+  const element = readSpreadElement(xml, "idPkg:Spread", "Spread", ctx);
+  if (!element) return undefined;
+  const common = parseSpreadCommon(element, ctx);
+  return { id: common.id, pages: common.pages, frames: common.frames, transform: common.transform };
+}
+
+/** Parse a master spread document. Returns `undefined` on malformed XML. */
+export function parseMasterSpread(
+  xml: string,
+  collector: WarningCollector,
+  dpi: number,
+  resolveAsset: LinkResolver,
+  path: string,
+): MasterSpread | undefined {
+  const ctx: ParseContext = { dpi, collector, path, resolveAsset };
+  const element = readSpreadElement(xml, "idPkg:MasterSpread", "MasterSpread", ctx);
+  if (!element) return undefined;
+  const common = parseSpreadCommon(element, ctx);
+  const master: MasterSpread = {
+    id: common.id,
+    pages: common.pages,
+    frames: common.frames,
+    transform: common.transform,
+  };
+  const name = getAttr(element, "Name");
+  if (name) master.name = name;
+  const prefix = getAttr(element, "NamePrefix");
+  if (prefix) master.namePrefix = prefix;
+  return master;
+}
+
+function readSpreadElement(
+  xml: string,
+  wrapperTag: string,
+  elementTag: string,
+  ctx: ParseContext,
+): XmlNode | undefined {
+  let root: XmlNode;
+  try {
+    root = parseXml(xml);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    ctx.collector.error(WarningCode.MALFORMED_XML, `Failed to parse spread: ${reason}`, ctx.path);
+    return undefined;
+  }
+  const wrapper = getChild(root, wrapperTag) ?? root;
+  const element = getChild(wrapper, elementTag);
+  if (!element) {
+    ctx.collector.warn(
+      WarningCode.MALFORMED_XML,
+      `Spread file has no <${elementTag}> element`,
+      ctx.path,
+    );
+    return undefined;
+  }
+  return element;
+}
+
+interface SpreadCommon {
+  id: string;
+  pages: Page[];
+  frames: Frame[];
+  transform: Matrix;
+}
+
+function parseSpreadCommon(element: XmlNode, ctx: ParseContext): SpreadCommon {
+  const id = getAttr(element, "Self") ?? "";
+  if (!id)
+    ctx.collector.warn(WarningCode.MISSING_IDENTIFIER, "Spread is missing a Self id", ctx.path);
+
+  const pages = getChildren(element, "Page").map((node) => parsePage(node, ctx));
+  const frames = parseItems(element, IDENTITY, ctx);
+  assignPages(frames, pages);
+
+  return {
+    id,
+    pages,
+    frames,
+    transform: normalizeMatrix(parseTransform(getAttr(element, "ItemTransform")), ctx.dpi),
+  };
+}
+
+function parsePage(node: XmlNode, ctx: ParseContext): Page {
+  const id = getAttr(node, "Self") ?? "";
+  if (!id)
+    ctx.collector.warn(WarningCode.MISSING_IDENTIFIER, "Page is missing a Self id", ctx.path);
+
+  const matrix = parseTransform(getAttr(node, "ItemTransform"));
+  const geom = parseGeometricBounds(getAttr(node, "GeometricBounds"));
+  const page: Page = {
+    id,
+    bounds: { x: 0, y: 0, width: 0, height: 0 },
+    geometricBounds: { x: 0, y: 0, width: 0, height: 0 },
+    transform: normalizeMatrix(matrix, ctx.dpi),
+  };
+  const name = getAttr(node, "Name");
+  if (name) page.name = name;
+
+  if (geom) {
+    page.geometricBounds = rectPtToPx(geom, ctx.dpi);
+    const corners = rectCorners(geom).map((p) => applyMatrix(matrix, p.x, p.y));
+    const world = boundsFromPoints(corners);
+    if (world) page.bounds = rectPtToPx(world, ctx.dpi);
+  } else {
+    ctx.collector.warn(WarningCode.EMPTY_GEOMETRY, `Page "${id}" has no GeometricBounds`, ctx.path);
+  }
+  return page;
+}
+
+function parseItems(parent: XmlNode, parentMatrix: Matrix, ctx: ParseContext): Frame[] {
+  const frames: Frame[] = [];
+
+  for (const node of getChildren(parent, "TextFrame")) {
+    frames.push(parseTextFrame(node, parentMatrix, ctx));
+  }
+  for (const tag of SHAPE_TAGS) {
+    for (const node of getChildren(parent, tag)) {
+      frames.push(parseShape(node, parentMatrix, ctx));
+    }
+  }
+  for (const node of getChildren(parent, "Group")) {
+    frames.push(parseGroup(node, parentMatrix, ctx));
+  }
+  for (const tag of OTHER_ITEM_TAGS) {
+    for (const node of getChildren(parent, tag)) {
+      ctx.collector.info(
+        WarningCode.UNSUPPORTED_PAGE_ITEM,
+        `Page item "${tag}" modelled as a generic graphic frame`,
+        ctx.path,
+      );
+      frames.push(makeGraphicFrame(node, parentMatrix, ctx));
+    }
+  }
+
+  return frames;
+}
+
+function baseFrame(
+  node: XmlNode,
+  parentMatrix: Matrix,
+  ctx: ParseContext,
+): {
+  id: string;
+  bounds: Rect;
+  transform: Matrix;
+  visible: boolean;
+  fillColor?: string;
+  strokeColor?: string;
+} {
+  const id = getAttr(node, "Self") ?? "";
+  const itemTransform = parseTransform(getAttr(node, "ItemTransform"));
+  const world = compose(parentMatrix, itemTransform);
+  const localPoints = extractAnchorPoints(node);
+  let bounds: Rect;
+  if (localPoints.length > 0) {
+    const worldPoints = localPoints.map((p) => applyMatrix(world, p.x, p.y));
+    bounds = rectPtToPx(boundsFromPoints(worldPoints)!, ctx.dpi);
+  } else {
+    ctx.collector.info(
+      WarningCode.EMPTY_GEOMETRY,
+      `Page item "${id}" has no path geometry; bounds derived from origin`,
+      ctx.path,
+    );
+    bounds = {
+      x: round((world[4] * ctx.dpi) / 72),
+      y: round((world[5] * ctx.dpi) / 72),
+      width: 0,
+      height: 0,
+    };
+  }
+  const result = {
+    id,
+    bounds,
+    transform: normalizeMatrix(itemTransform, ctx.dpi),
+    visible: getBoolAttr(node, "Visible", true),
+  } as {
+    id: string;
+    bounds: Rect;
+    transform: Matrix;
+    visible: boolean;
+    fillColor?: string;
+    strokeColor?: string;
+  };
+  const fill = getAttr(node, "FillColor");
+  if (fill) result.fillColor = fill;
+  const stroke = getAttr(node, "StrokeColor");
+  if (stroke) result.strokeColor = stroke;
+  return result;
+}
+
+function parseTextFrame(node: XmlNode, parentMatrix: Matrix, ctx: ParseContext): TextFrame {
+  const base = baseFrame(node, parentMatrix, ctx);
+  const frame: TextFrame = { ...base, type: "text" };
+  const parentStory = getAttr(node, "ParentStory");
+  if (parentStory && parentStory !== "n") frame.storyId = parentStory;
+  const next = getAttr(node, "NextTextFrame");
+  if (next && next !== "n") frame.nextFrameId = next;
+  const prev = getAttr(node, "PreviousTextFrame");
+  if (prev && prev !== "n") frame.previousFrameId = prev;
+  const name = getAttr(node, "Name");
+  if (name) frame.name = name;
+  return frame;
+}
+
+function parseShape(
+  node: XmlNode,
+  parentMatrix: Matrix,
+  ctx: ParseContext,
+): ImageFrame | GraphicFrame {
+  const graphic = findGraphicChild(node);
+  if (!graphic) return makeGraphicFrame(node, parentMatrix, ctx);
+
+  const base = baseFrame(node, parentMatrix, ctx);
+  const image = readImageRef(graphic.node, graphic.kind, ctx);
+  const frame: ImageFrame = { ...base, type: "image", image };
+  const name = getAttr(node, "Name");
+  if (name) frame.name = name;
+  return frame;
+}
+
+function makeGraphicFrame(node: XmlNode, parentMatrix: Matrix, ctx: ParseContext): GraphicFrame {
+  const base = baseFrame(node, parentMatrix, ctx);
+  const frame: GraphicFrame = { ...base, type: "graphic" };
+  const name = getAttr(node, "Name");
+  if (name) frame.name = name;
+  return frame;
+}
+
+function parseGroup(node: XmlNode, parentMatrix: Matrix, ctx: ParseContext): GroupFrame {
+  const base = baseFrame(node, parentMatrix, ctx);
+  const world = compose(parentMatrix, parseTransform(getAttr(node, "ItemTransform")));
+  const frame: GroupFrame = { ...base, type: "group", children: parseItems(node, world, ctx) };
+  const name = getAttr(node, "Name");
+  if (name) frame.name = name;
+  return frame;
+}
+
+function findGraphicChild(node: XmlNode): { node: XmlNode; kind: ImageKind } | undefined {
+  for (const [tag, kind] of Object.entries(GRAPHIC_TAGS)) {
+    const child = getChild(node, tag);
+    if (child) return { node: child, kind };
+  }
+  return undefined;
+}
+
+function readImageRef(graphic: XmlNode, kind: ImageKind, ctx: ParseContext): ImageRef {
+  const link = getChild(graphic, "Link");
+  const linkUri = getAttr(link, "LinkResourceURI");
+  const storedState = getAttr(link, "StoredState");
+  const embedded = !linkUri || storedState === "Embedded";
+
+  const ref: ImageRef = { kind, embedded };
+  if (linkUri) {
+    ref.linkUri = linkUri;
+    const resolved = ctx.resolveAsset(linkUri);
+    if (resolved) {
+      ref.resolvedPath = resolved;
+    } else if (!embedded) {
+      ctx.collector.warn(
+        WarningCode.UNRESOLVED_LINK,
+        `Image link "${linkUri}" does not resolve to a file inside the package`,
+        ctx.path,
+      );
+    }
+  }
+  const ppi = firstNumber(getAttr(graphic, "ActualPpi"));
+  if (ppi !== undefined) ref.actualPpi = ppi;
+  const transform = getAttr(graphic, "ItemTransform");
+  if (transform) ref.itemTransform = normalizeMatrix(parseTransform(transform), ctx.dpi);
+  return ref;
+}
+
+function extractAnchorPoints(node: XmlNode): Point[] {
+  const props = getChild(node, "Properties");
+  const geometry = getChild(props, "PathGeometry");
+  const points: Point[] = [];
+  for (const geoPath of getChildren(geometry, "GeometryPathType")) {
+    const array = getChild(geoPath, "PathPointArray");
+    for (const pointType of getChildren(array, "PathPointType")) {
+      const anchor = numberPair(getAttr(pointType, "Anchor"));
+      if (anchor) points.push(anchor);
+    }
+  }
+  return points;
+}
+
+function assignPages(frames: Frame[], pages: Page[]): void {
+  if (pages.length === 0) return;
+  for (const frame of frames) {
+    const page = pages.find((p) => containsCenter(p.bounds, frame.bounds));
+    if (page) frame.pageId = page.id;
+    if (frame.type === "group") assignPages(frame.children, pages);
+  }
+}
+
+function rectCorners(rect: Rect): Point[] {
+  return [
+    { x: rect.x, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y },
+    { x: rect.x + rect.width, y: rect.y + rect.height },
+    { x: rect.x, y: rect.y + rect.height },
+  ];
+}
+
+function numberPair(value: string | undefined): Point | undefined {
+  if (!value) return undefined;
+  const parts = value.trim().split(/\s+/).map(Number);
+  if (parts.length < 2 || !Number.isFinite(parts[0]) || !Number.isFinite(parts[1]))
+    return undefined;
+  return { x: parts[0]!, y: parts[1]! };
+}
+
+function firstNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const first = value.trim().split(/\s+/)[0];
+  if (first === undefined) return undefined;
+  const n = Number(first);
+  return Number.isFinite(n) ? n : undefined;
+}

--- a/packages/pipeline/src/indesign/stories.ts
+++ b/packages/pipeline/src/indesign/stories.ts
@@ -1,0 +1,102 @@
+/**
+ * Parser for `Stories/Story_*.xml`.
+ *
+ * A story is a tree of `ParagraphStyleRange` → `CharacterStyleRange` →
+ * `Content`. Each paragraph range becomes a {@link Paragraph}; each character
+ * range becomes a {@link TextRun} carrying its applied style reference and any
+ * local attribute overrides.
+ *
+ * Known limitation: forced line breaks (`<Br/>`) interleaved with `<Content>`
+ * are not order-preserved, so within-paragraph hard breaks are dropped. Para-
+ * graph boundaries (the `ParagraphStyleRange` elements) are preserved exactly.
+ */
+import type { Paragraph, Story, TextRun } from "./ir.js";
+import { WarningCode, type WarningCollector } from "./warnings.js";
+import {
+  getAttr,
+  getAttributes,
+  getChild,
+  getChildren,
+  getTextContent,
+  parseXml,
+  toArray,
+  type XmlNode,
+} from "./xml.js";
+
+const DEFAULT_PARAGRAPH_STYLE = "ParagraphStyle/$ID/[No paragraph style]";
+const DEFAULT_CHARACTER_STYLE = "CharacterStyle/$ID/[No character style]";
+
+/** Parse a single story document. Returns `undefined` on malformed XML. */
+export function parseStory(
+  xml: string,
+  collector: WarningCollector,
+  path: string,
+): Story | undefined {
+  let root: XmlNode;
+  try {
+    root = parseXml(xml);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    collector.error(WarningCode.MALFORMED_XML, `Failed to parse story: ${reason}`, path);
+    return undefined;
+  }
+
+  const storyRoot = getChild(root, "idPkg:Story") ?? root;
+  const story = getChild(storyRoot, "Story");
+  if (!story) {
+    collector.warn(WarningCode.MALFORMED_XML, "Story file has no <Story> element", path);
+    return undefined;
+  }
+
+  const id = getAttr(story, "Self");
+  if (!id) {
+    collector.warn(WarningCode.MISSING_IDENTIFIER, "Story is missing a Self id", path);
+    return undefined;
+  }
+
+  const paragraphs: Paragraph[] = [];
+  const paragraphStyleRefs = new Set<string>();
+  const characterStyleRefs = new Set<string>();
+
+  for (const psr of getChildren(story, "ParagraphStyleRange")) {
+    const appliedParagraphStyle = getAttr(psr, "AppliedParagraphStyle") ?? DEFAULT_PARAGRAPH_STYLE;
+    paragraphStyleRefs.add(appliedParagraphStyle);
+
+    const runs: TextRun[] = [];
+    for (const csr of getChildren(psr, "CharacterStyleRange")) {
+      const appliedCharacterStyle =
+        getAttr(csr, "AppliedCharacterStyle") ?? DEFAULT_CHARACTER_STYLE;
+      characterStyleRefs.add(appliedCharacterStyle);
+
+      const text = toArray(csr["Content"]).map(getTextContent).join("");
+      runs.push({
+        text,
+        appliedCharacterStyle,
+        overrides: stripAttr(getAttributes(csr), "AppliedCharacterStyle"),
+      });
+    }
+
+    paragraphs.push({
+      appliedParagraphStyle,
+      overrides: stripAttr(getAttributes(psr), "AppliedParagraphStyle"),
+      runs,
+      text: runs.map((r) => r.text).join(""),
+    });
+  }
+
+  return {
+    id,
+    paragraphs,
+    plainText: paragraphs.map((p) => p.text).join("\n"),
+    appliedStyles: {
+      paragraph: [...paragraphStyleRefs],
+      character: [...characterStyleRefs],
+    },
+  };
+}
+
+function stripAttr(attrs: Record<string, string>, name: string): Record<string, string> {
+  if (!(name in attrs)) return attrs;
+  const { [name]: _omit, ...rest } = attrs;
+  return rest;
+}

--- a/packages/pipeline/src/indesign/units.ts
+++ b/packages/pipeline/src/indesign/units.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit conversion and 2D affine geometry for the IDML parser.
+ *
+ * IDML expresses coordinates in points (1/72 inch). The parser normalizes every
+ * geometric value to pixels at a configurable DPI: `px = pt · dpi / 72`.
+ */
+import type { Matrix, Rect } from "./ir.js";
+
+/** A point in a 2D coordinate space. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Points per inch — the IDML coordinate unit. */
+export const POINTS_PER_INCH = 72;
+
+/** The identity affine transform. */
+export const IDENTITY: Matrix = [1, 0, 0, 1, 0, 0];
+
+/** Convert a length in points to pixels at the given DPI. */
+export function ptToPx(value: number, dpi: number): number {
+  return (value * dpi) / POINTS_PER_INCH;
+}
+
+/** Round to a fixed number of decimal places, avoiding `-0`. */
+export function round(value: number, places = 2): number {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** places;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded === 0 ? 0 : rounded;
+}
+
+/**
+ * Parse an `ItemTransform` attribute (`"a b c d tx ty"`) into a {@link Matrix}.
+ * Returns the identity transform when the input is missing or malformed.
+ */
+export function parseTransform(value: string | undefined): Matrix {
+  if (!value) return [...IDENTITY];
+  const parts = value.trim().split(/\s+/).map(Number);
+  if (parts.length !== 6 || parts.some((n) => !Number.isFinite(n))) {
+    return [...IDENTITY];
+  }
+  return [parts[0]!, parts[1]!, parts[2]!, parts[3]!, parts[4]!, parts[5]!];
+}
+
+/** Apply an affine transform to a point. */
+export function applyMatrix(m: Matrix, x: number, y: number): Point {
+  return { x: m[0] * x + m[2] * y + m[4], y: m[1] * x + m[3] * y + m[5] };
+}
+
+/**
+ * Compose two transforms so the result maps a point through `child` and then
+ * `parent` (i.e. `result · p = parent · (child · p)`). Used to flatten nested
+ * group/page transforms into spread coordinates.
+ */
+export function compose(parent: Matrix, child: Matrix): Matrix {
+  const [pa, pb, pc, pd, ptx, pty] = parent;
+  const [ca, cb, cc, cd, ctx, cty] = child;
+  return [
+    pa * ca + pc * cb,
+    pb * ca + pd * cb,
+    pa * cc + pc * cd,
+    pb * cc + pd * cd,
+    pa * ctx + pc * cty + ptx,
+    pb * ctx + pd * cty + pty,
+  ];
+}
+
+/** Axis-aligned bounding box of a set of points, or `undefined` when empty. */
+export function boundsFromPoints(points: Point[]): Rect | undefined {
+  if (points.length === 0) return undefined;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/**
+ * Parse a `GeometricBounds` attribute (`"y1 x1 y2 x2"` = top left bottom right,
+ * in points) into a {@link Rect} in points. Returns `undefined` when malformed.
+ */
+export function parseGeometricBounds(value: string | undefined): Rect | undefined {
+  if (!value) return undefined;
+  const parts = value.trim().split(/\s+/).map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) return undefined;
+  const [top, left, bottom, right] = parts as [number, number, number, number];
+  return { x: left, y: top, width: right - left, height: bottom - top };
+}
+
+/** Convert a rectangle from points to rounded pixels. */
+export function rectPtToPx(rect: Rect, dpi: number): Rect {
+  return {
+    x: round(ptToPx(rect.x, dpi)),
+    y: round(ptToPx(rect.y, dpi)),
+    width: round(ptToPx(rect.width, dpi)),
+    height: round(ptToPx(rect.height, dpi)),
+  };
+}
+
+/**
+ * Normalize a transform for the IR: translation components are converted to
+ * pixels; scale/shear components are preserved. All components are rounded.
+ */
+export function normalizeMatrix(m: Matrix, dpi: number): Matrix {
+  return [
+    round(m[0], 6),
+    round(m[1], 6),
+    round(m[2], 6),
+    round(m[3], 6),
+    round(ptToPx(m[4], dpi)),
+    round(ptToPx(m[5], dpi)),
+  ];
+}
+
+/** Whether `inner`'s center lies within `outer`. */
+export function containsCenter(outer: Rect, inner: Rect): boolean {
+  const cx = inner.x + inner.width / 2;
+  const cy = inner.y + inner.height / 2;
+  return (
+    cx >= outer.x && cx <= outer.x + outer.width && cy >= outer.y && cy <= outer.y + outer.height
+  );
+}

--- a/packages/pipeline/src/indesign/warnings.ts
+++ b/packages/pipeline/src/indesign/warnings.ts
@@ -1,0 +1,81 @@
+/**
+ * Parse warnings for the IDML pipeline.
+ *
+ * Warnings record unsupported features, unresolved references, and recoverable
+ * malformations encountered while parsing an `.idml` package. They never abort
+ * the parse — they are accumulated on the {@link import("./ir.js").Document}
+ * intermediate representation and surfaced by the CLI.
+ */
+
+export type WarningSeverity = "info" | "warning" | "error";
+
+/** A single, non-fatal issue encountered while parsing an IDML package. */
+export interface ParseWarning {
+  /** Stable machine-readable code (see {@link WarningCode}). */
+  code: string;
+  /** Human-readable description. */
+  message: string;
+  /** Relative importance; `error` means data was dropped but the parse continued. */
+  severity: WarningSeverity;
+  /** Package-relative source location, e.g. `"Stories/Story_u1.xml"`. */
+  path?: string;
+}
+
+/**
+ * Canonical warning codes. Kept as a const object (not a TS `enum`) so the
+ * values are plain strings that survive JSON serialization unchanged.
+ */
+export const WarningCode = {
+  /** The package `mimetype` entry was missing or did not match the IDML media type. */
+  MIMETYPE_MISMATCH: "MIMETYPE_MISMATCH",
+  /** A file referenced by `designmap.xml` was not present in the package. */
+  MISSING_RESOURCE_FILE: "MISSING_RESOURCE_FILE",
+  /** An XML document failed to parse; its contents were skipped. */
+  MALFORMED_XML: "MALFORMED_XML",
+  /** A page item type is not yet modelled by the IR; a generic frame was emitted. */
+  UNSUPPORTED_PAGE_ITEM: "UNSUPPORTED_PAGE_ITEM",
+  /** A `TextFrame`'s `ParentStory` did not resolve to a known story. */
+  MISSING_PARENT_STORY: "MISSING_PARENT_STORY",
+  /** An image link could not be resolved to a file inside the package. */
+  UNRESOLVED_LINK: "UNRESOLVED_LINK",
+  /** A color used an unknown color space or had no usable color value. */
+  UNKNOWN_COLOR_SPACE: "UNKNOWN_COLOR_SPACE",
+  /** A page item had no usable path geometry; its bounds default to a zero rect. */
+  EMPTY_GEOMETRY: "EMPTY_GEOMETRY",
+  /** A spread, page, or item was missing an expected identifier. */
+  MISSING_IDENTIFIER: "MISSING_IDENTIFIER",
+} as const;
+
+export type WarningCodeValue = (typeof WarningCode)[keyof typeof WarningCode];
+
+/** Mutable accumulator threaded through the parser. */
+export class WarningCollector {
+  private readonly items: ParseWarning[] = [];
+
+  add(code: string, message: string, severity: WarningSeverity = "warning", path?: string): void {
+    const warning: ParseWarning = { code, message, severity };
+    if (path !== undefined) warning.path = path;
+    this.items.push(warning);
+  }
+
+  info(code: string, message: string, path?: string): void {
+    this.add(code, message, "info", path);
+  }
+
+  warn(code: string, message: string, path?: string): void {
+    this.add(code, message, "warning", path);
+  }
+
+  error(code: string, message: string, path?: string): void {
+    this.add(code, message, "error", path);
+  }
+
+  /** Returns a defensive copy of the collected warnings. */
+  all(): ParseWarning[] {
+    return this.items.map((w) => ({ ...w }));
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+}

--- a/packages/pipeline/src/indesign/xml.ts
+++ b/packages/pipeline/src/indesign/xml.ts
@@ -1,0 +1,117 @@
+/**
+ * Thin wrapper around `fast-xml-parser` configured for IDML, plus small
+ * traversal helpers that tolerate the parser's "single value or array" shape.
+ *
+ * IDML stores almost everything in attributes, preserves namespace prefixes
+ * (`idPkg:Spread`), and relies on text content whitespace inside `<Content>`,
+ * so the parser is configured to keep attributes as raw strings, keep prefixes,
+ * and not trim text.
+ */
+import { XMLParser } from "fast-xml-parser";
+
+/** A parsed XML element: attributes are keyed `@_name`, text is `#text`. */
+export type XmlNode = Record<string, unknown>;
+
+const ATTR_PREFIX = "@_";
+const TEXT_KEY = "#text";
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: ATTR_PREFIX,
+  textNodeName: TEXT_KEY,
+  allowBooleanAttributes: true,
+  parseAttributeValue: false,
+  parseTagValue: false,
+  trimValues: false,
+  ignoreDeclaration: true,
+  processEntities: true,
+});
+
+/**
+ * Parse an XML string into a plain object tree. Throws when the input is not
+ * well-formed; callers convert that into a recoverable warning.
+ */
+export function parseXml(text: string): XmlNode {
+  const result = parser.parse(text) as unknown;
+  if (!isRecord(result)) {
+    throw new Error("XML did not parse to an element tree");
+  }
+  return result;
+}
+
+/** Narrow an unknown value to a plain object. */
+export function isRecord(value: unknown): value is XmlNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Coerce a "missing | single | array" value into an array. */
+export function toArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+/** Read a string attribute (`@_name`) from a node. */
+export function getAttr(node: unknown, name: string): string | undefined {
+  if (!isRecord(node)) return undefined;
+  const value = node[ATTR_PREFIX + name];
+  if (value === undefined || value === null) return undefined;
+  return String(value);
+}
+
+/** Read a numeric attribute, returning `undefined` when absent or non-numeric. */
+export function getNumAttr(node: unknown, name: string): number | undefined {
+  const raw = getAttr(node, name);
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Read a boolean attribute (`"true"`/`"false"`), with a default. */
+export function getBoolAttr(node: unknown, name: string, fallback = false): boolean {
+  const raw = getAttr(node, name);
+  if (raw === undefined) return fallback;
+  return raw.toLowerCase() === "true";
+}
+
+/** All child elements with the given tag name, as an array. */
+export function getChildren(node: unknown, name: string): XmlNode[] {
+  if (!isRecord(node)) return [];
+  return toArray(node[name]).filter(isRecord);
+}
+
+/** The first child element with the given tag name, if any. */
+export function getChild(node: unknown, name: string): XmlNode | undefined {
+  return getChildren(node, name)[0];
+}
+
+/**
+ * Collect the plain-text content of a node, concatenating any `#text` values
+ * and the text of nested `Content` elements.
+ */
+export function getTextContent(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return value.map(getTextContent).join("");
+  if (isRecord(value)) {
+    const text = value[TEXT_KEY];
+    if (typeof text === "string") return text;
+    if (text !== undefined) return getTextContent(text);
+  }
+  return "";
+}
+
+/**
+ * Return every attribute of a node as a verbatim `{ name: value }` map,
+ * stripping the `@_` prefix. Useful for "raw passthrough" of style/override data.
+ */
+export function getAttributes(node: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!isRecord(node)) return out;
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith(ATTR_PREFIX) && value !== undefined && value !== null) {
+      out[key.slice(ATTR_PREFIX.length)] = String(value);
+    }
+  }
+  return out;
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Aurelius pipeline package root.
+ *
+ * Currently surfaces the InDesign IDML parser; future design-to-code stages
+ * (style/token mapper, component generator) will be exported here too.
+ */
+export * as indesign from "./indesign/index.js";

--- a/packages/pipeline/tsconfig.build.json
+++ b/packages/pipeline/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/pipeline/vitest.config.ts
+++ b/packages/pipeline/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,28 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))
 
+  packages/pipeline:
+    dependencies:
+      fast-xml-parser:
+        specifier: ^4.5.1
+        version: 4.5.6
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.0
+        version: 20.19.43
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@20.19.43)(vite@8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3))
+
 packages:
 
   '@babel/code-frame@7.29.0':
@@ -702,6 +724,9 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -1197,6 +1222,10 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
+  fast-xml-parser@4.5.6:
+    resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
+    hasBin: true
+
   fast-xml-parser@5.8.0:
     resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
@@ -1209,6 +1238,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2051,6 +2083,9 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
@@ -2136,6 +2171,11 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
@@ -2148,6 +2188,9 @@ packages:
 
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -2319,6 +2362,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3039,6 +3085,10 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -3053,6 +3103,14 @@ snapshots:
       '@vitest/utils': 4.1.2
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.2(vite@8.0.16(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
@@ -3575,6 +3633,10 @@ snapshots:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
 
+  fast-xml-parser@4.5.6:
+    dependencies:
+      strnum: 1.1.2
+
   fast-xml-parser@5.8.0:
     dependencies:
       '@nodable/entities': 2.1.0
@@ -3586,6 +3648,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   figures@3.2.0:
     dependencies:
@@ -4338,6 +4402,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strnum@1.1.2: {}
+
   strnum@2.3.0: {}
 
   supports-color@5.5.0:
@@ -4406,12 +4472,16 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript@5.9.3: {}
+
   typescript@6.0.2: {}
 
   uglify-js@3.19.3:
     optional: true
 
   underscore@1.13.8: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 
@@ -4434,6 +4504,19 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vite@8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      yaml: 2.8.3
+
   vite@8.0.16(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -4446,6 +4529,33 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
+
+  vitest@4.1.2(@types/node@20.19.43)(vite@8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@20.19.43)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.2(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
@@ -4534,5 +4644,7 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"


### PR DESCRIPTION
## Summary

Implements the foundational **IDML parser and intermediate representation (IR)** for the InDesign-to-React pipeline — the first sub-issue of the InDesign epic (#62).

This introduces the repo's first TypeScript workspace package, **`@aurelius/pipeline`** (pnpm workspace + `tsc`/`vitest` toolchain), which reads Adobe InDesign `.idml` packages and emits a normalized, typed, zod-validated IR that downstream stages (mapper, component generator) will consume.

## What's included

- **Parser** (`packages/pipeline/src/indesign/`): unzip + mimetype/designmap validation, resources (swatches, fonts, paragraph/character styles), stories (text + style refs), spreads/master-spreads (frames, pages, composed geometry), and linked/embedded images.
- **Typed IR** (`ir.ts`): `Document`, `Spread`, `MasterSpread`, `Page`, `Frame` (`Text`/`Image`/`Graphic`/`Group`), `Story`, `Style`, `Swatch`, `Font`, `Asset`, …
- **Runtime validation** (`schema.ts`): zod schemas mirroring the IR, with compile-time parity guards so types and schema can't drift.
- **Cross-reference resolution**: `TextFrame.ParentStory` → `Story.Self`; image `LinkResourceURI` → in-package asset path.
- **Unit normalization**: IDML points → pixels at a configurable DPI (default 96).
- **Non-fatal warnings**: collected on `document.warnings` and surfaced by the `aurelius-indesign` CLI (human report + `--json`).
- **CI**: a dedicated `pipeline-tests` job (typecheck + test + build).
- **Docs**: `packages/pipeline/README.md` and `docs/indesign-to-react/README.md`.

## Acceptance criteria

- [x] Fixture `.idml` → valid IR that passes zod schema validation
- [x] All swatches, paragraph styles, character styles, and fonts enumerated (incl. nested style groups)
- [x] Image frames reference resolvable asset paths inside the package
- [x] Unit tests cover happy path + ≥3 malformed/edge-case IDMLs (8 edge cases + nested groups)
- [x] Parse warnings collected on the IR and surfaced by the CLI

## Testing

- `pnpm --filter @aurelius/pipeline typecheck` ✅
- `pnpm --filter @aurelius/pipeline test` ✅ — **52 tests**
- `pnpm --filter @aurelius/pipeline build` ✅
- Repo-wide `eslint .` (0 errors) and `prettier --check .` ✅
- `check-doc-counts` and `--frozen-lockfile` ✅
- Verified the compiled CLI end-to-end against a real on-disk `.idml`

## Notes / decisions

- **Fixtures are built in memory** (readable XML → real zip) rather than committing a binary `.idml`; this exercises every acceptance criterion while keeping edge cases easy to author. The epic's "committed fixtures under `tests/fixtures/indesign/`" remains a separate #62 deliverable.
- Lockfile change is purely additive and compatible with CI's pnpm 9.

Closes #63
Part of #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
