### PR TITLE
feat(pipeline): add PDF as a first-class InDesign input

### DIFF
--- a/docs/indesign-to-react/README.md
+++ b/docs/indesign-to-react/README.md
@@ -5,19 +5,21 @@ typed React components, design tokens, and assets — a print-first sibling to t
 Figma/Canva/Screenshot pipelines.
 
 > **Status:** in progress. This document tracks the epic and details the shipped
-> stages — the **IDML parser + IR** and the **style & design-token mapper**.
+> stages — the **IDML parser + IR**, the **PDF parser** (same IR), and the
+> **style & design-token mapper**.
 > See the epic for the full plan: _Add InDesign-to-React conversion pipeline_.
 
 ## Pipeline shape (target)
 
 ```
 .idml ──▶ [1] IDML parser ──▶ IR ──▶ [2] style/token mapper ──▶ tokens.ts + Tailwind preset
- .pdf ──▶ [1b] PDF fallback ─▶ IR ──┘                      └──▶ [3] component generator ──▶ *.tsx + Storybook
+ .pdf ──▶ [1b] PDF parser ──▶ IR ──┘                      └──▶ [3] component generator ──▶ *.tsx + Storybook
 ```
 
-Both inputs converge on a single normalized **IR**, so every later stage is input
-agnostic. The IDML path (this stage) is the primary, high-fidelity route; a PDF
-fallback is a separate sub-issue.
+Both inputs are **first-class** and converge on a single normalized **IR**, so
+every later stage is source-agnostic. IDML is preferred when available (richer
+style metadata), but the pipeline never assumes it — designers most often hand
+engineering a PDF.
 
 ## Stage 1 — IDML parser and IR (shipped)
 
@@ -76,6 +78,29 @@ node packages/pipeline/dist/indesign/cli.js your-design.idml --json   # full IR 
 See the [package README](../../packages/pipeline/README.md) for the library API,
 options, and known limitations.
 
+## Stage 1b — PDF parser (shipped)
+
+Implemented in [`packages/pipeline/src/pdf`](../../packages/pipeline/src/pdf). PDF
+is a **first-class input** — the artifact designers actually deliver. The parser
+(via `pdfjs-dist`) produces the same IR as the IDML path:
+
+1. **Extracts** text runs (positions, sizes, fonts), fill/stroke colors, and
+   embedded images from each page.
+2. **Clusters** runs → lines → columns → text frames, inferring heading / body /
+   caption buckets from font sizes (synthesized as paragraph styles).
+3. **Derives** a swatch palette from fills and dominant image colors.
+4. **Extracts** embedded images to PNG (with `--assets <dir>`).
+5. **Flips** PDF's bottom-left coordinates to the IR's top-left pixel space.
+6. **Surfaces fidelity warnings** for what was inferred vs. read.
+
+```bash
+# The CLI auto-detects .pdf vs .idml; --source-priority forces a path.
+node packages/pipeline/dist/indesign/cli.js brochure.pdf --emit-tokens ./src/tokens --assets ./public/assets
+```
+
+Fidelity caveats and warning codes are documented in the
+[PDF fidelity guide](../pipeline/indesign-pdf-fidelity.md).
+
 ## Stage 2 — Style & design-token mapper (shipped)
 
 Implemented in [`packages/pipeline/src/tokens`](../../packages/pipeline/src/tokens).
@@ -102,7 +127,6 @@ Font fallbacks and out-of-gamut conversions are listed in the generator report.
 
 ## Roadmap (remaining sub-issues)
 
-- [ ] PDF fallback parser and layout reconstruction (emits the same IR)
 - [ ] React component generator (TSX output, optional Tailwind/CSS Modules,
       Storybook stories)
 - [ ] `indesign-to-react` Claude Code agent + skill + end-to-end CLI command
@@ -110,4 +134,5 @@ Font fallbacks and out-of-gamut conversions are listed in the generator report.
 ## References
 
 - [Adobe IDML File Format Specification](https://www.adobe.com/devnet/indesign/documentation.html)
+- [PDF.js (`pdfjs-dist`)](https://mozilla.github.io/pdf.js/)
 ```

--- a/docs/pipeline/indesign-pdf-fidelity.md
+++ b/docs/pipeline/indesign-pdf-fidelity.md
@@ -1,0 +1,70 @@
+# InDesign PDF Ingestion — Fidelity Guide
+
+PDF is a **first-class input** to the InDesign-to-React pipeline, on equal footing
+with IDML. Designers routinely hand engineering an exported PDF rather than a
+source `.indd`/`.idml`, so the pipeline treats PDF as a normal, supported route.
+
+A PDF is a _presentation_ format: it positions glyphs and draws shapes, but it
+does not carry named paragraph styles, logical text frames, or a swatch palette.
+The parser therefore **reconstructs** structure heuristically. This guide
+documents what is read directly versus inferred, and the fidelity warnings the
+parser emits so downstream stages and humans know which is which.
+
+> We do **not** aim for pixel-perfect reconstruction from PDF. The goal is a
+> usable, styled IR the component generator can turn into React with manual
+> touch-ups. When both an IDML and a PDF are available, prefer IDML — it carries
+> richer style metadata. Force the PDF path with `--source-priority pdf` to
+> verify parity.
+
+## Read vs. inferred
+
+| Aspect          | Source                                   | Confidence |
+| --------------- | ---------------------------------------- | ---------- |
+| Text content    | Glyph runs (`getTextContent`)            | High       |
+| Positions/sizes | Text matrices + media box                | High       |
+| Fill/stroke colors | Operator list                         | High       |
+| Embedded images | Image XObjects (decoded to PNG)          | High       |
+| Text frames     | Positional clustering of runs            | Inferred   |
+| Columns         | Horizontal-gap + left-edge clustering    | Inferred   |
+| Heading/body/caption | Font-size buckets                   | Inferred   |
+| Swatch palette  | Clustered fill/stroke + image colors     | Inferred   |
+| Fonts           | Font names (rarely embedded)             | Name only  |
+
+Geometry is converted from PDF points to pixels at a configurable DPI (default
+96) and flipped from PDF's bottom-left origin to the IR's top-left origin.
+
+## Fidelity warnings
+
+All warnings are collected on `document.warnings` and surfaced in CLI output.
+
+| Code | Meaning | What to do |
+| ---- | ------- | ---------- |
+| `TEXT_FROM_GLYPHS` | Text was reconstructed from positioned glyph runs; line/paragraph grouping is heuristic. | Review long-form copy and paragraph boundaries. |
+| `NO_EMBEDDED_FONTS` | Fonts are referenced by name, not embedded. The mapper resolves them via `config/font-map.json` with web fallbacks. | Confirm the mapped web fonts, or supply a `--font-map`. |
+| `VECTOR_ONLY_PAGE` | A page has no extractable text (outlined type or pure vector art). | Provide IDML, or re-export the PDF without outlining text. |
+| `MULTI_COLUMN_DETECTED` | The page was reconstructed as multiple columns. | Verify column boundaries and reading order. |
+| `IMAGE_NOT_EXTRACTED` | An image was detected but not written (no `--assets` dir, or an unsupported pixel layout). | Pass `--assets <dir>` to extract images. |
+
+## Known limitations
+
+- **Per-run text color** is not correlated back to individual runs; colors feed
+  the swatch palette, and frames carry bounds rather than inline fills.
+- **Outlined text** (type converted to vector paths) is invisible to text
+  extraction and surfaces as `VECTOR_ONLY_PAGE`.
+- **Reading order** across complex, overlapping layouts is approximate.
+- **Spacing tokens** are derived from style metadata (absent in PDF), so the PDF
+  path emits little or no spacing scale; supply IDML for a richer spacing scale.
+
+## Parity with IDML
+
+The same InDesign document exported to both IDML and PDF should produce IRs whose
+page count, frame count, and detected style buckets agree within these
+tolerances:
+
+- **Page count:** exact.
+- **Frame count:** ± a small margin (PDF clustering may merge/split blocks).
+- **Style buckets:** both detect a heading bucket larger than the body bucket;
+  exact sizes may differ by sub-pixel rounding and font-metric differences.
+
+Use `--source-priority pdf` against a document that also has an IDML to compare
+the two paths.

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,13 +1,29 @@
 # @aurelius/pipeline
 
 Core library for the Aurelius design-to-code pipeline. It reads Adobe InDesign
-Markup Language (`.idml`) packages into a normalized, typed intermediate
-representation (IR), and maps that IR to a coherent **design-token set**
-(`tokens.ts`, `tokens.css`, a Tailwind preset, and a Style Dictionary JSON).
+sources — both `.idml` packages and exported `.pdf` files — into a single
+normalized, typed intermediate representation (IR), and maps that IR to a
+coherent **design-token set** (`tokens.ts`, `tokens.css`, a Tailwind preset, and
+a Style Dictionary JSON).
 
 > Part of the [InDesign-to-React pipeline](../../docs/indesign-to-react/README.md)
-> epic. Shipped so far: the IDML parser + IR and the design-token mapper. The
-> React component generator is next.
+> epic. Shipped so far: the IDML parser + IR, the PDF parser (same IR), and the
+> design-token mapper. The React component generator is next.
+
+## Designer hands you a PDF
+
+A designer's normal handoff is a PDF, not an `.idml`. Point the pipeline at it:
+
+```bash
+pnpm --filter @aurelius/pipeline build
+# PDF → IR → design tokens, extracting embedded images to ./public/assets
+node packages/pipeline/dist/indesign/cli.js brochure.pdf \
+  --emit-tokens ./src/tokens --assets ./public/assets
+```
+
+PDF and IDML are **both first-class inputs**; the CLI auto-detects by extension.
+IDML is preferred when available (richer style metadata), but the pipeline never
+assumes it. See the [PDF fidelity guide](../../docs/pipeline/indesign-pdf-fidelity.md).
 
 ## Install / build
 
@@ -60,6 +76,31 @@ const validated = validateDocument(document); // throws ZodError on mismatch
 All geometry is normalized from IDML points to **pixels** at a configurable DPI
 (default 96): `px = pt × dpi / 72`. Transform translation is converted to pixels;
 scale/shear components are preserved.
+
+## PDF input
+
+The PDF parser produces the **same IR**, so the mapper and generator are
+source-agnostic. It clusters positioned glyph runs into text frames, infers
+heading/body/caption buckets from font sizes, derives a swatch palette from fills
+and image colors, and extracts embedded images to PNG.
+
+```ts
+import { parsePdfFile } from "@aurelius/pipeline/pdf";
+import { parseSourceFile } from "@aurelius/pipeline";
+
+// Directly…
+const { document, warnings } = await parsePdfFile("brochure.pdf", {
+  assetDir: "public/assets", // extract embedded images here
+});
+
+// …or source-agnostically (auto-detects .idml vs .pdf; force with sourcePriority).
+const result = await parseSourceFile("brochure.pdf", { sourcePriority: "pdf" });
+```
+
+Because PDF is a presentation format, structure is reconstructed heuristically and
+the parser emits fidelity warnings (`TEXT_FROM_GLYPHS`, `NO_EMBEDDED_FONTS`,
+`VECTOR_ONLY_PAGE`, …). See the
+[PDF fidelity guide](../../docs/pipeline/indesign-pdf-fidelity.md).
 
 ## Design tokens
 

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -20,6 +20,10 @@
     "./tokens": {
       "types": "./dist/tokens/index.d.ts",
       "import": "./dist/tokens/index.js"
+    },
+    "./pdf": {
+      "types": "./dist/pdf/index.d.ts",
+      "import": "./dist/pdf/index.js"
     }
   },
   "files": [
@@ -35,10 +39,14 @@
   "dependencies": {
     "fast-xml-parser": "^4.5.1",
     "fflate": "^0.8.2",
+    "pdfjs-dist": "^6.0.227",
+    "pngjs": "^7.0.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",
+    "@types/pngjs": "^6.0.5",
+    "pdf-lib": "^1.17.1",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2"
   }

--- a/packages/pipeline/src/indesign/__tests__/cli-tokens.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/cli-tokens.test.ts
@@ -35,10 +35,10 @@ const UNMAPPED_FONTS = `<?xml version="1.0"?>
 </idPkg:Fonts>`;
 
 describe("runCli --emit-tokens", () => {
-  it("writes all four token artifacts and prints a report", () => {
+  it("writes all four token artifacts and prints a report", async () => {
     const idml = writeIdml(buildSampleIdml());
     const out = tempDir();
-    const result = runCli([idml, "--emit-tokens", out]);
+    const result = await runCli([idml, "--emit-tokens", out]);
 
     expect(result.code).toBe(0);
     expect(existsSync(join(out, "tokens.ts"))).toBe(true);
@@ -51,22 +51,22 @@ describe("runCli --emit-tokens", () => {
     expect(readFileSync(join(out, "tokens.ts"), "utf-8")).toContain("as const");
   });
 
-  it("skips the Tailwind preset with --no-tailwind", () => {
+  it("skips the Tailwind preset with --no-tailwind", async () => {
     const idml = writeIdml(buildSampleIdml());
     const out = tempDir();
-    const result = runCli([idml, "--emit-tokens", out, "--no-tailwind"]);
+    const result = await runCli([idml, "--emit-tokens", out, "--no-tailwind"]);
 
     expect(result.code).toBe(0);
     expect(existsSync(join(out, "tokens.ts"))).toBe(true);
     expect(existsSync(join(out, "tailwind.preset.ts"))).toBe(false);
   });
 
-  it("surfaces font fallback warnings in the report", () => {
+  it("surfaces font fallback warnings in the report", async () => {
     const files = sampleFiles();
     files["Resources/Fonts.xml"] = UNMAPPED_FONTS;
     const idml = writeIdml(buildIdml(files));
     const out = tempDir();
-    const result = runCli([idml, "--emit-tokens", out]);
+    const result = await runCli([idml, "--emit-tokens", out]);
 
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("FONT_FALLBACK");

--- a/packages/pipeline/src/indesign/__tests__/cli.test.ts
+++ b/packages/pipeline/src/indesign/__tests__/cli.test.ts
@@ -24,46 +24,46 @@ afterEach(() => {
 });
 
 describe("runCli", () => {
-  it("prints usage and exits 2 when no input is given", () => {
-    const result = runCli([]);
+  it("prints usage and exits 2 when no input is given", async () => {
+    const result = await runCli([]);
     expect(result.code).toBe(2);
     expect(result.stderr).toContain("no input file");
   });
 
-  it("prints help on --help", () => {
-    const result = runCli(["--help"]);
+  it("prints help on --help", async () => {
+    const result = await runCli(["--help"]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("Usage:");
   });
 
-  it("exits 1 with an error for a missing file", () => {
-    const result = runCli([join(tmpdir(), "does-not-exist-xyz.idml")]);
+  it("exits 1 with an error for a missing file", async () => {
+    const result = await runCli([join(tmpdir(), "does-not-exist-xyz.idml")]);
     expect(result.code).toBe(1);
     expect(result.stderr).toMatch(/Error/);
   });
 
-  it("prints a human-readable report with counts for a valid package", () => {
+  it("prints a human-readable report with counts for a valid package", async () => {
     const path = writeIdml(buildSampleIdml());
-    const result = runCli([path]);
+    const result = await runCli([path]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("InDesign IDML → IR");
     expect(result.stdout).toContain("swatches:          6");
     expect(result.stdout).toContain("Warnings (0)");
   });
 
-  it("surfaces collected parse warnings in the report", () => {
+  it("surfaces collected parse warnings in the report", async () => {
     const files = sampleFiles();
     delete files["Links/hero.png"];
     const path = writeIdml(buildIdml(files));
-    const result = runCli([path]);
+    const result = await runCli([path]);
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("UNRESOLVED_LINK");
     expect(result.stderr).toContain("warning(s)");
   });
 
-  it("emits valid JSON with --json", () => {
+  it("emits valid JSON with --json", async () => {
     const path = writeIdml(buildSampleIdml());
-    const result = runCli([path, "--json"]);
+    const result = await runCli([path, "--json"]);
     expect(result.code).toBe(0);
     const parsed = JSON.parse(result.stdout);
     expect(parsed.meta.dpi).toBe(96);
@@ -71,8 +71,8 @@ describe("runCli", () => {
     expect(parsed.swatches).toHaveLength(6);
   });
 
-  it("rejects an invalid --dpi value", () => {
-    const result = runCli(["x.idml", "--dpi", "abc"]);
+  it("rejects an invalid --dpi value", async () => {
+    const result = await runCli(["x.idml", "--dpi", "abc"]);
     expect(result.code).toBe(2);
     expect(result.stderr).toContain("Invalid --dpi");
   });

--- a/packages/pipeline/src/indesign/cli.ts
+++ b/packages/pipeline/src/indesign/cli.ts
@@ -9,13 +9,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { parseSourceFile, type SourcePriority } from "../source.js";
 import { emitAll } from "../tokens/emit.js";
 import type { FontMapOverrides } from "../tokens/font-map.js";
 import { mapDocumentToTokens } from "../tokens/mapper.js";
 import type { TokenMapResult } from "../tokens/model.js";
 import { IdmlParseError } from "./errors.js";
 import type { Document, Frame } from "./ir.js";
-import { parseIdmlFile } from "./parser.js";
 import type { ParseWarning } from "./warnings.js";
 
 export interface CliResult {
@@ -24,21 +24,23 @@ export interface CliResult {
   stderr: string;
 }
 
-const USAGE = `aurelius-indesign — parse an InDesign IDML package into a normalized IR
+const USAGE = `aurelius-indesign — parse an InDesign IDML or PDF into a normalized IR
 
 Usage:
-  aurelius-indesign <file.idml> [options]
+  aurelius-indesign <file.idml | file.pdf> [options]
 
 Options:
-  --json               Emit the full IR as JSON on stdout
-  --pretty             Pretty-print JSON (use with --json)
-  --dpi <number>       Pixel conversion DPI (default 96)
-  --no-validate        Skip zod validation of the produced IR
-  --emit-tokens <dir>  Map the IR to design tokens and write tokens.ts,
-                       tokens.css, tailwind.preset.ts, design-tokens.json
-  --no-tailwind        With --emit-tokens, skip tailwind.preset.ts
-  --font-map <file>    JSON file of font fallback overrides
-  -h, --help           Show this help
+  --json                   Emit the full IR as JSON on stdout
+  --pretty                 Pretty-print JSON (use with --json)
+  --dpi <number>           Pixel conversion DPI (default 96)
+  --no-validate            Skip zod validation of the produced IR
+  --source-priority <p>    Force ingestion path: pdf | idml | auto (default auto)
+  --assets <dir>           Extract embedded PDF images into <dir>
+  --emit-tokens <dir>      Map the IR to design tokens and write tokens.ts,
+                           tokens.css, tailwind.preset.ts, design-tokens.json
+  --no-tailwind            With --emit-tokens, skip tailwind.preset.ts
+  --font-map <file>        JSON file of font fallback overrides
+  -h, --help               Show this help
 `;
 
 interface ParsedArgs {
@@ -51,6 +53,8 @@ interface ParsedArgs {
   dpi?: number;
   emitTokens?: string;
   fontMap?: string;
+  sourcePriority?: SourcePriority;
+  assets?: string;
   error?: string;
 }
 
@@ -102,6 +106,19 @@ function parseArgs(argv: string[]): ParsedArgs {
         else args.fontMap = file;
         break;
       }
+      case "--source-priority": {
+        const value = argv[++i];
+        if (value === "pdf" || value === "idml" || value === "auto") args.sourcePriority = value;
+        else
+          args.error = `Invalid --source-priority: ${value ?? "(missing)"} (expected pdf|idml|auto)`;
+        break;
+      }
+      case "--assets": {
+        const dir = argv[++i];
+        if (!dir) args.error = "--assets requires a directory";
+        else args.assets = dir;
+        break;
+      }
       default:
         if (arg && arg.startsWith("-")) {
           args.error = `Unknown option: ${arg}`;
@@ -114,7 +131,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 }
 
 /** Run the CLI against an argv array, returning captured output and exit code. */
-export function runCli(argv: string[]): CliResult {
+export async function runCli(argv: string[]): Promise<CliResult> {
   const args = parseArgs(argv);
 
   if (args.error) {
@@ -129,9 +146,11 @@ export function runCli(argv: string[]): CliResult {
 
   let document: Document;
   try {
-    const result = parseIdmlFile(args.input, {
+    const result = await parseSourceFile(args.input, {
       validate: args.validate,
       ...(args.dpi ? { dpi: args.dpi } : {}),
+      ...(args.sourcePriority ? { sourcePriority: args.sourcePriority } : {}),
+      ...(args.assets ? { assetDir: args.assets } : {}),
     });
     document = result.document;
   } catch (err) {
@@ -186,7 +205,7 @@ function emitTokens(document: Document, args: ParsedArgs): CliResult {
   const allWarnings = [...document.warnings, ...result.warnings];
   return {
     code: 0,
-    stdout: formatTokenReport(result, args.emitTokens!, Object.keys(files)),
+    stdout: formatTokenReport(result, args.emitTokens!, Object.keys(files), document.meta.source),
     stderr: formatWarningSummary(allWarnings),
   };
 }
@@ -218,7 +237,7 @@ export function formatReport(document: Document): string {
     document.masterSpreads.reduce((n, s) => n + s.pages.length, 0);
 
   const lines: string[] = [];
-  lines.push("InDesign IDML → IR");
+  lines.push(`InDesign ${(document.meta.source ?? "idml").toUpperCase()} → IR`);
   if (document.meta.sourcePath) lines.push(`  source:        ${document.meta.sourcePath}`);
   lines.push(`  IDML version:  ${document.meta.idmlVersion ?? "(unknown)"}`);
   lines.push(`  DPI:           ${document.meta.dpi}`);
@@ -248,10 +267,15 @@ export function formatReport(document: Document): string {
 }
 
 /** Build the human-readable design-token report (stdout under --emit-tokens). */
-export function formatTokenReport(result: TokenMapResult, dir: string, files: string[]): string {
+export function formatTokenReport(
+  result: TokenMapResult,
+  dir: string,
+  files: string[],
+  source?: "idml" | "pdf",
+): string {
   const t = result.tokens;
   const lines: string[] = [];
-  lines.push("InDesign IDML → Design Tokens");
+  lines.push(`InDesign ${(source ?? "idml").toUpperCase()} → Design Tokens`);
   lines.push(`  output:        ${dir}`);
   lines.push(`  files:         ${files.join(", ")}`);
   lines.push("");
@@ -312,8 +336,14 @@ function toMessage(err: unknown): string {
 
 const invokedPath = process.argv[1];
 if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
-  const result = runCli(process.argv.slice(2));
-  if (result.stdout) process.stdout.write(result.stdout);
-  if (result.stderr) process.stderr.write(result.stderr);
-  process.exit(result.code);
+  runCli(process.argv.slice(2))
+    .then((result) => {
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.code);
+    })
+    .catch((err: unknown) => {
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
 }

--- a/packages/pipeline/src/indesign/ir.ts
+++ b/packages/pipeline/src/indesign/ir.ts
@@ -36,13 +36,18 @@ export interface RGB {
 
 /** Top-level facts about the parsed document. */
 export interface DocumentMeta {
+  /** Which ingestion path produced this IR. */
+  source?: "idml" | "pdf";
   /** IDML DOM version from `designmap.xml` (`@DOMVersion`), when present. */
   idmlVersion?: string;
-  /** Dots per inch used to convert IDML points to pixels. */
+  /** Dots per inch used to convert source points to pixels. */
   dpi: number;
-  /** Whether the package `mimetype` entry matched the IDML media type. */
+  /**
+   * Container validity. For IDML, whether the `mimetype` entry matched; for PDF,
+   * whether the document loaded successfully.
+   */
   mimetypeValid: boolean;
-  /** Absolute path the package was read from, when parsed from a file. */
+  /** Absolute path the source was read from, when parsed from a file. */
   sourcePath?: string;
 }
 

--- a/packages/pipeline/src/indesign/parser.ts
+++ b/packages/pipeline/src/indesign/parser.ts
@@ -171,7 +171,7 @@ export function parsePackage(pkg: IdmlPackage, options: ParseOptions = {}): Pars
     ...masterSpreads.flatMap((s) => s.frames),
   ]);
 
-  const meta: Document["meta"] = { dpi, mimetypeValid };
+  const meta: Document["meta"] = { source: "idml", dpi, mimetypeValid };
   const idmlVersion = getAttr(documentEl, "DOMVersion");
   if (idmlVersion) meta.idmlVersion = idmlVersion;
   if (options.sourcePath) meta.sourcePath = options.sourcePath;

--- a/packages/pipeline/src/indesign/schema.ts
+++ b/packages/pipeline/src/indesign/schema.ts
@@ -29,6 +29,7 @@ const MatrixSchema = z.tuple([
 const RGBSchema = z.object({ r: z.number(), g: z.number(), b: z.number() });
 
 const DocumentMetaSchema = z.object({
+  source: z.enum(["idml", "pdf"]).optional(),
   idmlVersion: z.string().optional(),
   dpi: z.number(),
   mimetypeValid: z.boolean(),

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,8 +1,17 @@
 /**
  * Aurelius pipeline package root.
  *
- * Surfaces the InDesign IDML parser and the design-token mapper; the React
- * component generator will be exported here too.
+ * Surfaces the InDesign IDML parser, the PDF parser, the design-token mapper,
+ * and a source-agnostic entry point. The React component generator will be
+ * exported here too.
  */
 export * as indesign from "./indesign/index.js";
+export * as pdf from "./pdf/index.js";
 export * as tokens from "./tokens/index.js";
+export {
+  parseSourceFile,
+  resolveSource,
+  type SourcePriority,
+  type ParseSourceOptions,
+  type ResolvedSource,
+} from "./source.js";

--- a/packages/pipeline/src/pdf/__tests__/cli-pdf.test.ts
+++ b/packages/pipeline/src/pdf/__tests__/cli-pdf.test.ts
@@ -1,0 +1,81 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../../indesign/cli.js";
+import { resolveSource } from "../../source.js";
+import * as fx from "./pdf-fixtures.js";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pdf-cli-"));
+  tempDirs.push(dir);
+  return dir;
+}
+function writePdf(buffer: Uint8Array, name = "doc.pdf"): string {
+  const path = join(tempDir(), name);
+  writeFileSync(path, buffer);
+  return path;
+}
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("CLI — PDF as a primary input", () => {
+  it("parses a .pdf and prints a PDF IR report with fidelity warnings", async () => {
+    const path = writePdf(await fx.textHeavyPdf());
+    const result = await runCli([path]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("InDesign PDF → IR");
+    expect(result.stdout).toContain("paragraph styles:");
+    expect(result.stderr).toContain("warning(s)");
+  });
+
+  it("runs PDF → IR → tokens end-to-end with image extraction", async () => {
+    const dir = tempDir();
+    const path = join(dir, "brochure.pdf");
+    writeFileSync(path, await fx.brochurePdf());
+    const out = join(dir, "tokens");
+    const assets = join(dir, "assets");
+
+    const result = await runCli([path, "--emit-tokens", out, "--assets", assets]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Design Tokens");
+    expect(existsSync(join(out, "tokens.ts"))).toBe(true);
+    expect(existsSync(join(out, "tailwind.preset.ts"))).toBe(true);
+    expect(readdirSync(assets).some((f) => f.endsWith(".png"))).toBe(true);
+  });
+
+  it("emits the PDF IR as JSON", async () => {
+    const path = writePdf(await fx.textHeavyPdf());
+    const result = await runCli([path, "--json"]);
+    const doc = JSON.parse(result.stdout);
+    expect(doc.meta.source).toBe("pdf");
+    expect(doc.spreads).toHaveLength(1);
+  });
+
+  it("rejects an invalid --source-priority", async () => {
+    const result = await runCli(["x.pdf", "--source-priority", "docx"]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("Invalid --source-priority");
+  });
+});
+
+describe("resolveSource", () => {
+  it("detects the source by extension", () => {
+    expect(resolveSource("/docs/a.pdf").kind).toBe("pdf");
+    expect(resolveSource("/docs/a.idml").kind).toBe("idml");
+  });
+
+  it("honors --source-priority when both siblings exist", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "doc.pdf"), new Uint8Array([1]));
+    writeFileSync(join(dir, "doc.idml"), new Uint8Array([1]));
+    expect(resolveSource(join(dir, "doc.idml"), "pdf").kind).toBe("pdf");
+    expect(resolveSource(join(dir, "doc.pdf"), "idml").kind).toBe("idml");
+    expect(resolveSource(join(dir, "doc.pdf"), "auto").kind).toBe("pdf");
+  });
+});

--- a/packages/pipeline/src/pdf/__tests__/palette.test.ts
+++ b/packages/pipeline/src/pdf/__tests__/palette.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { derivePalette } from "../palette.js";
+
+describe("derivePalette", () => {
+  it("ranks colors by frequency and emits IR swatches", () => {
+    const swatches = derivePalette(["#ff0000", "#ff0000", "#0000ff"], []);
+    expect(swatches[0]!.hex).toBe("#ff0000");
+    expect(swatches.map((s) => s.hex)).toContain("#0000ff");
+    expect(swatches[0]!.type).toBe("color");
+    expect(swatches[0]!.space).toBe("RGB");
+    expect(swatches[0]!.colorValue).toEqual([255, 0, 0]);
+  });
+
+  it("merges near-duplicate colors within tolerance", () => {
+    const swatches = derivePalette(["#ff0000", "#ff0001", "#ff0000"], [], { tolerance: 5 });
+    expect(swatches).toHaveLength(1);
+    expect(swatches[0]!.hex).toBe("#ff0000");
+  });
+
+  it("includes dominant image colors", () => {
+    const swatches = derivePalette([], ["#00ff00"]);
+    expect(swatches[0]!.hex).toBe("#00ff00");
+  });
+
+  it("caps the palette at maxColors", () => {
+    const colors = ["#111111", "#222222", "#333333", "#444444"];
+    expect(derivePalette(colors, [], { maxColors: 2 })).toHaveLength(2);
+  });
+});

--- a/packages/pipeline/src/pdf/__tests__/parser.test.ts
+++ b/packages/pipeline/src/pdf/__tests__/parser.test.ts
@@ -1,0 +1,131 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSampleIdml } from "../../indesign/__tests__/idml-fixtures.js";
+import { parseIdml } from "../../indesign/parser.js";
+import { safeValidateDocument } from "../../indesign/schema.js";
+import type { ImageFrame } from "../../indesign/ir.js";
+import { mapDocumentToTokens } from "../../tokens/mapper.js";
+import { parsePdf, PdfWarningCode } from "../parser.js";
+import * as fx from "./pdf-fixtures.js";
+
+const tempDirs: string[] = [];
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pdf-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const textFrames = (doc: Awaited<ReturnType<typeof parsePdf>>["document"]) =>
+  doc.spreads.flatMap((s) => s.frames).filter((f) => f.type === "text");
+const imageFrames = (doc: Awaited<ReturnType<typeof parsePdf>>["document"]) =>
+  doc.spreads.flatMap((s) => s.frames).filter((f): f is ImageFrame => f.type === "image");
+
+describe("parsePdf — text-heavy", () => {
+  it("produces a valid IR with heading/body/caption style buckets", async () => {
+    const { document, warnings } = await parsePdf(await fx.textHeavyPdf());
+
+    expect(safeValidateDocument(document).success).toBe(true);
+    expect(document.meta.source).toBe("pdf");
+    expect(document.spreads).toHaveLength(1);
+    expect(document.spreads[0]!.pages).toHaveLength(1);
+
+    const names = document.paragraphStyles.map((s) => s.name).sort();
+    expect(names).toEqual(["Body", "Caption", "Heading"]);
+    expect(textFrames(document).length).toBeGreaterThanOrEqual(3);
+
+    expect(warnings.some((w) => w.code === PdfWarningCode.NO_EMBEDDED_FONTS)).toBe(true);
+    expect(warnings.some((w) => w.code === PdfWarningCode.TEXT_FROM_GLYPHS)).toBe(true);
+  });
+
+  it("feeds the token mapper (PDF → IR → tokens) without an IDML file", async () => {
+    const { document } = await parsePdf(await fx.textHeavyPdf());
+    const { tokens } = mapDocumentToTokens(document);
+    expect(Object.keys(tokens.fontSizes)).toContain("heading");
+    expect(Object.keys(tokens.fontSizes)).toContain("body");
+    expect(Object.keys(tokens.fontFamilies).length).toBeGreaterThan(0);
+  });
+});
+
+describe("parsePdf — image-heavy", () => {
+  it("extracts embedded images to the asset dir and references them from the IR", async () => {
+    const assetDir = tempDir();
+    const { document } = await parsePdf(await fx.imageHeavyPdf(), { assetDir });
+
+    const images = imageFrames(document);
+    expect(images.length).toBe(2);
+    for (const frame of images) {
+      expect(frame.image.resolvedPath).toBeDefined();
+      expect(existsSync(join(assetDir, frame.image.resolvedPath!))).toBe(true);
+    }
+    expect(document.assets.length).toBe(2);
+    expect(document.assets.every((a) => a.bytes > 0)).toBe(true);
+  });
+
+  it("warns when no asset dir is supplied (images detected but not written)", async () => {
+    const { document, warnings } = await parsePdf(await fx.imageHeavyPdf());
+    expect(imageFrames(document).length).toBe(2);
+    expect(warnings.some((w) => w.code === PdfWarningCode.IMAGE_NOT_EXTRACTED)).toBe(true);
+  });
+});
+
+describe("parsePdf — multi-column", () => {
+  it("detects columns and reconstructs separate frames", async () => {
+    const { document, warnings } = await parsePdf(await fx.multiColumnPdf());
+    expect(warnings.some((w) => w.code === PdfWarningCode.MULTI_COLUMN_DETECTED)).toBe(true);
+    expect(textFrames(document).length).toBeGreaterThanOrEqual(3);
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+});
+
+describe("parsePdf — single-page brochure", () => {
+  it("produces text frames, an image, and a derived palette", async () => {
+    const assetDir = tempDir();
+    const { document } = await parsePdf(await fx.brochurePdf(), { assetDir });
+    expect(document.spreads).toHaveLength(1);
+    expect(textFrames(document).length).toBeGreaterThanOrEqual(2);
+    expect(imageFrames(document).length).toBe(1);
+    expect(document.swatches.length).toBeGreaterThanOrEqual(3);
+    expect(document.swatches[0]!.hex).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe("parsePdf — vector-only", () => {
+  it("warns about no extractable text and still derives a palette", async () => {
+    const { document, warnings } = await parsePdf(await fx.vectorOnlyPdf());
+    expect(textFrames(document)).toHaveLength(0);
+    expect(warnings.some((w) => w.code === PdfWarningCode.VECTOR_ONLY_PAGE)).toBe(true);
+    expect(document.swatches.length).toBeGreaterThanOrEqual(2);
+    expect(safeValidateDocument(document).success).toBe(true);
+  });
+});
+
+describe("PDF / IDML parity", () => {
+  it("agrees on page count and produces comparable style buckets", async () => {
+    const pdf = (await parsePdf(await fx.brochurePdf())).document;
+    const idml = parseIdml(buildSampleIdml()).document;
+
+    // Page count parity (both single-page documents).
+    const pdfPages = pdf.spreads.reduce((n, s) => n + s.pages.length, 0);
+    const idmlPages = idml.spreads.reduce((n, s) => n + s.pages.length, 0);
+    expect(pdfPages).toBe(idmlPages);
+
+    // Both detect a heading bucket larger than their body bucket.
+    const headingOf = (doc: typeof pdf) => {
+      const sizes = doc.paragraphStyles
+        .map((s) => s.properties.pointSize)
+        .filter((n): n is number => typeof n === "number")
+        .sort((a, b) => b - a);
+      return sizes[0] ?? 0;
+    };
+    expect(headingOf(pdf)).toBeGreaterThan(0);
+    expect(headingOf(idml)).toBeGreaterThan(0);
+  });
+});

--- a/packages/pipeline/src/pdf/__tests__/pdf-fixtures.ts
+++ b/packages/pipeline/src/pdf/__tests__/pdf-fixtures.ts
@@ -1,0 +1,139 @@
+/**
+ * Programmatic PDF fixtures built with pdf-lib.
+ *
+ * Covers the five document shapes the parser must handle: text-heavy,
+ * image-heavy, multi-column, single-page brochure, and vector-only (no
+ * extractable text). pdf-lib uses the standard-14 fonts (not embedded), which
+ * naturally exercises the "no embedded fonts" fidelity path.
+ */
+import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
+import { PNG } from "pngjs";
+
+const LETTER: [number, number] = [612, 792];
+
+/** A solid-color RGBA PNG, used for embedded-image fixtures. */
+export function solidPng(
+  width: number,
+  height: number,
+  color: [number, number, number],
+): Uint8Array {
+  const png = new PNG({ width, height });
+  const [r, g, b] = color;
+  for (let i = 0; i < width * height; i++) {
+    png.data[i * 4] = r;
+    png.data[i * 4 + 1] = g;
+    png.data[i * 4 + 2] = b;
+    png.data[i * 4 + 3] = 255;
+  }
+  return PNG.sync.write(png);
+}
+
+async function fonts(doc: PDFDocument) {
+  return {
+    regular: await doc.embedFont(StandardFonts.Helvetica),
+    bold: await doc.embedFont(StandardFonts.HelveticaBold),
+  };
+}
+
+/** A text-heavy single page: heading, many body lines, and a caption. */
+export async function textHeavyPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage(LETTER);
+  const { regular, bold } = await fonts(doc);
+
+  page.drawText("Annual Report 2026", {
+    x: 72,
+    y: 720,
+    size: 28,
+    font: bold,
+    color: rgb(0.1, 0.1, 0.1),
+  });
+  let y = 680;
+  for (let i = 0; i < 24; i++) {
+    page.drawText(`Body paragraph line ${i + 1} with enough text to read as flowing copy.`, {
+      x: 72,
+      y,
+      size: 11,
+      font: regular,
+      color: rgb(0, 0, 0),
+    });
+    y -= 16;
+  }
+  page.drawText("Figure 1 — a small caption set in eight point type.", {
+    x: 72,
+    y: y - 8,
+    size: 8,
+    font: regular,
+    color: rgb(0.3, 0.3, 0.3),
+  });
+  return doc.save();
+}
+
+/** An image-heavy single page: two embedded images and a caption. */
+export async function imageHeavyPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage(LETTER);
+  const { regular } = await fonts(doc);
+
+  const hero = await doc.embedPng(solidPng(32, 24, [30, 120, 200]));
+  const inset = await doc.embedPng(solidPng(16, 16, [220, 60, 40]));
+  page.drawImage(hero, { x: 72, y: 480, width: 360, height: 240 });
+  page.drawImage(inset, { x: 72, y: 360, width: 96, height: 96 });
+  page.drawText("Photography by the studio.", { x: 72, y: 340, size: 9, font: regular });
+  return doc.save();
+}
+
+/** A two-column page of body text. */
+export async function multiColumnPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage(LETTER);
+  const { regular, bold } = await fonts(doc);
+
+  page.drawText("Two Column Layout", { x: 72, y: 720, size: 24, font: bold });
+  for (const x of [72, 320]) {
+    let y = 680;
+    for (let i = 0; i < 16; i++) {
+      page.drawText(`Column text ${i + 1} at x=${x}.`, { x, y, size: 10, font: regular });
+      y -= 14;
+    }
+  }
+  return doc.save();
+}
+
+/** A single-page brochure: heading, body, image, and palette swatches. */
+export async function brochurePdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage(LETTER);
+  const { regular, bold } = await fonts(doc);
+
+  page.drawRectangle({ x: 0, y: 712, width: 612, height: 80, color: rgb(0.08, 0.35, 0.78) });
+  page.drawText("Spring Collection", { x: 48, y: 736, size: 30, font: bold, color: rgb(1, 1, 1) });
+  page.drawText("A short introductory paragraph describing the collection.", {
+    x: 48,
+    y: 660,
+    size: 12,
+    font: regular,
+    color: rgb(0.1, 0.1, 0.1),
+  });
+  const hero = await doc.embedPng(solidPng(40, 30, [240, 200, 60]));
+  page.drawImage(hero, { x: 48, y: 400, width: 320, height: 220 });
+  page.drawRectangle({ x: 48, y: 360, width: 24, height: 24, color: rgb(0.9, 0.1, 0.1) });
+  page.drawText("Caption for the hero image.", {
+    x: 48,
+    y: 340,
+    size: 8,
+    font: regular,
+    color: rgb(0.4, 0.4, 0.4),
+  });
+  return doc.save();
+}
+
+/** A vector-only page: shapes, no text. */
+export async function vectorOnlyPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage(LETTER);
+  page.drawRectangle({ x: 72, y: 500, width: 200, height: 200, color: rgb(0.2, 0.6, 0.4) });
+  page.drawRectangle({ x: 320, y: 500, width: 200, height: 200, color: rgb(0.8, 0.3, 0.5) });
+  page.drawCircle({ x: 300, y: 300, size: 80, color: rgb(0.1, 0.1, 0.1) });
+  return doc.save();
+}

--- a/packages/pipeline/src/pdf/__tests__/style-buckets.test.ts
+++ b/packages/pipeline/src/pdf/__tests__/style-buckets.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildStyleBuckets } from "../style-buckets.js";
+import type { ClusterLine, TextBlock } from "../text-cluster.js";
+
+function line(size: number): ClusterLine {
+  return { runs: [], baseline: 0, x0: 0, x1: 0, size, text: "" };
+}
+
+function block(size: number, lineCount: number, fontFamily?: string): TextBlock {
+  const b: TextBlock = {
+    lines: Array.from({ length: lineCount }, () => line(size)),
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    size,
+    columnIndex: 0,
+    text: "",
+  };
+  if (fontFamily) b.fontFamily = fontFamily;
+  return b;
+}
+
+describe("buildStyleBuckets", () => {
+  it("classifies sizes into heading/body/caption with the most line-heavy size as body", () => {
+    const { paragraphStyles, bodySizePt } = buildStyleBuckets(
+      [block(28, 1, "Helvetica"), block(11, 10, "Helvetica"), block(8, 1)],
+      96,
+    );
+    expect(bodySizePt).toBe(11);
+    const names = paragraphStyles.map((s) => s.name);
+    expect(names).toEqual(["Heading", "Body", "Caption"]);
+
+    const heading = paragraphStyles.find((s) => s.name === "Heading");
+    expect(heading?.properties.pointSize).toBeCloseTo((28 * 96) / 72, 1); // ~37.33px
+    expect(heading?.properties.fontFamily).toBe("Helvetica");
+  });
+
+  it("numbers multiple heading levels largest-first", () => {
+    const { paragraphStyles } = buildStyleBuckets([block(48, 1), block(32, 1), block(12, 10)], 96);
+    expect(paragraphStyles.map((s) => s.name)).toEqual(["Heading 1", "Heading 2", "Body"]);
+  });
+
+  it("returns an empty result when no block carries a size", () => {
+    expect(buildStyleBuckets([], 96).paragraphStyles).toHaveLength(0);
+  });
+});

--- a/packages/pipeline/src/pdf/__tests__/text-cluster.test.ts
+++ b/packages/pipeline/src/pdf/__tests__/text-cluster.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { RawTextRun } from "../pdf-document.js";
+import { clusterTextRuns } from "../text-cluster.js";
+
+function run(text: string, x: number, baseline: number, width: number, height: number): RawTextRun {
+  return { text, x, baseline, width, height, fontName: "f1" };
+}
+
+describe("clusterTextRuns", () => {
+  it("returns an empty result for no runs", () => {
+    expect(clusterTextRuns([])).toEqual({ blocks: [], columnCount: 0 });
+  });
+
+  it("splits a single column into blocks at a font-size change", () => {
+    const { blocks, columnCount } = clusterTextRuns([
+      run("Heading", 72, 700, 200, 28),
+      run("Body line one", 72, 660, 150, 11),
+      run("Body line two", 72, 644, 150, 11),
+    ]);
+    expect(columnCount).toBe(1);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.text).toContain("Heading");
+    expect(blocks[1]!.lines).toHaveLength(2);
+  });
+
+  it("separates same-baseline runs with a large gap into two columns", () => {
+    const { blocks, columnCount } = clusterTextRuns([
+      run("L1", 72, 660, 100, 10),
+      run("R1", 360, 660, 100, 10),
+      run("L2", 72, 646, 100, 10),
+      run("R2", 360, 646, 100, 10),
+    ]);
+    expect(columnCount).toBe(2);
+    expect(blocks).toHaveLength(2);
+    expect(blocks.every((b) => b.lines.length === 2)).toBe(true);
+  });
+});

--- a/packages/pipeline/src/pdf/images.ts
+++ b/packages/pipeline/src/pdf/images.ts
@@ -1,0 +1,86 @@
+/**
+ * Encode raster images extracted from a PDF.
+ *
+ * pdfjs hands back decoded pixel buffers in one of a few `ImageKind` layouts;
+ * this module normalizes them to RGBA, encodes a PNG via `pngjs`, and computes
+ * an average color used to seed the swatch palette with dominant image colors.
+ */
+import { PNG } from "pngjs";
+import { rgbToHex } from "../indesign/colors.js";
+import type { RawPixels } from "./pdf-document.js";
+
+const RGB_24BPP = 2;
+const RGBA_32BPP = 3;
+const GRAYSCALE_1BPP = 1;
+
+/** Normalize pdfjs pixel data to a tightly-packed RGBA byte array. */
+function toRgba(pixels: RawPixels): Uint8Array | undefined {
+  const { width, height, kind, data } = pixels;
+  if (width <= 0 || height <= 0) return undefined;
+  const count = width * height;
+  const out = new Uint8Array(count * 4);
+
+  const at = (i: number): number => data[i] ?? 0;
+
+  if (kind === RGBA_32BPP || (kind === 0 && data.length >= count * 4)) {
+    if (data.length < count * 4) return undefined;
+    for (let i = 0; i < count * 4; i++) out[i] = at(i);
+    return out;
+  }
+  if (kind === RGB_24BPP || (kind === 0 && data.length >= count * 3)) {
+    if (data.length < count * 3) return undefined;
+    for (let i = 0, j = 0; i < count; i++) {
+      out[j++] = at(i * 3);
+      out[j++] = at(i * 3 + 1);
+      out[j++] = at(i * 3 + 2);
+      out[j++] = 255;
+    }
+    return out;
+  }
+  if (kind === GRAYSCALE_1BPP) {
+    const rowBytes = Math.ceil(width / 8);
+    if (data.length < rowBytes * height) return undefined;
+    let j = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const byte = at(y * rowBytes + (x >> 3));
+        const value = (byte >> (7 - (x & 7))) & 1 ? 255 : 0;
+        out[j++] = value;
+        out[j++] = value;
+        out[j++] = value;
+        out[j++] = 255;
+      }
+    }
+    return out;
+  }
+  return undefined;
+}
+
+/** Encode extracted pixels to a PNG buffer, or `undefined` if unsupported. */
+export function encodeImageToPng(pixels: RawPixels): Uint8Array | undefined {
+  const rgba = toRgba(pixels);
+  if (!rgba) return undefined;
+  const png = new PNG({ width: pixels.width, height: pixels.height });
+  png.data = Buffer.from(rgba);
+  return PNG.sync.write(png);
+}
+
+/** Average color of an image as `#rrggbb`, sampling for large images. */
+export function averageColor(pixels: RawPixels): string | undefined {
+  const rgba = toRgba(pixels);
+  if (!rgba) return undefined;
+  const pixelCount = rgba.length / 4;
+  const step = Math.max(1, Math.floor(pixelCount / 4096));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let n = 0;
+  for (let i = 0; i < pixelCount; i += step) {
+    r += rgba[i * 4] ?? 0;
+    g += rgba[i * 4 + 1] ?? 0;
+    b += rgba[i * 4 + 2] ?? 0;
+    n++;
+  }
+  if (n === 0) return undefined;
+  return rgbToHex({ r: r / n, g: g / n, b: b / n });
+}

--- a/packages/pipeline/src/pdf/index.ts
+++ b/packages/pipeline/src/pdf/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Public API for the PDF ingestion path.
+ *
+ * Produces the same {@link import("../indesign/ir.js").Document} IR as the IDML
+ * parser, so the token mapper and component generator are source-agnostic.
+ *
+ * @example
+ * ```ts
+ * import { parsePdfFile } from "@aurelius/pipeline/pdf";
+ * import { mapDocumentToTokens } from "@aurelius/pipeline/tokens";
+ *
+ * const { document, warnings } = await parsePdfFile("brochure.pdf", { assetDir: "public/assets" });
+ * const { tokens } = mapDocumentToTokens(document);
+ * ```
+ */
+export {
+  parsePdf,
+  parsePdfFile,
+  PdfWarningCode,
+  DEFAULT_DPI as PDF_DEFAULT_DPI,
+  type PdfParseOptions,
+} from "./parser.js";
+export { derivePalette, type PaletteOptions } from "./palette.js";
+export {
+  clusterTextRuns,
+  type TextBlock,
+  type ClusterLine,
+  type ClusterResult,
+} from "./text-cluster.js";
+export { buildStyleBuckets, type StyleBuckets } from "./style-buckets.js";
+export {
+  loadPdfPages,
+  type RawPage,
+  type RawTextRun,
+  type RawImage,
+  type RawPixels,
+} from "./pdf-document.js";

--- a/packages/pipeline/src/pdf/palette.ts
+++ b/packages/pipeline/src/pdf/palette.ts
@@ -1,0 +1,73 @@
+/**
+ * Derive a swatch palette from a PDF.
+ *
+ * Clusters the fill/stroke colors collected from the operator list together with
+ * dominant image colors, ranks them by frequency, and emits {@link Swatch}
+ * entries in the IR shape so the token mapper can build a color palette without
+ * a companion IDML file.
+ */
+import type { RGB, Swatch } from "../indesign/ir.js";
+
+export interface PaletteOptions {
+  /** Maximum number of swatches to emit. */
+  maxColors?: number;
+  /** sRGB distance under which two colors are merged. */
+  tolerance?: number;
+}
+
+interface Cluster {
+  hex: string;
+  rgb: RGB;
+  weight: number;
+}
+
+/** Build a frequency-ranked, de-duplicated swatch palette. */
+export function derivePalette(
+  fillColors: string[],
+  imageColors: string[],
+  options: PaletteOptions = {},
+): Swatch[] {
+  const maxColors = options.maxColors ?? 12;
+  const tolerance = options.tolerance ?? 12;
+
+  const clusters: Cluster[] = [];
+  const add = (hex: string, weight: number): void => {
+    const normalized = hex.toLowerCase();
+    if (!/^#[0-9a-f]{6}$/.test(normalized)) return;
+    const rgb = hexToRgb(normalized);
+    const match = clusters.find((c) => distance(c.rgb, rgb) <= tolerance);
+    if (match) {
+      match.weight += weight;
+    } else {
+      clusters.push({ hex: normalized, rgb, weight });
+    }
+  };
+
+  for (const hex of fillColors) add(hex, 1);
+  for (const hex of imageColors) add(hex, 1);
+
+  clusters.sort((a, b) => b.weight - a.weight);
+
+  return clusters.slice(0, maxColors).map((cluster, i) => ({
+    id: `Color/pdf-${i + 1}`,
+    name: `Color ${i + 1}`,
+    type: "color" as const,
+    space: "RGB",
+    colorValue: [cluster.rgb.r, cluster.rgb.g, cluster.rgb.b],
+    hex: cluster.hex,
+    rgb: cluster.rgb,
+  }));
+}
+
+function hexToRgb(hex: string): RGB {
+  const h = hex.replace(/^#/, "");
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function distance(a: RGB, b: RGB): number {
+  return Math.sqrt((a.r - b.r) ** 2 + (a.g - b.g) ** 2 + (a.b - b.b) ** 2);
+}

--- a/packages/pipeline/src/pdf/parser.ts
+++ b/packages/pipeline/src/pdf/parser.ts
@@ -1,0 +1,322 @@
+/**
+ * Top-level PDF parser.
+ *
+ * Produces the same {@link Document} IR as the IDML parser, so the token mapper
+ * and component generator are source-agnostic. Per page it clusters text into
+ * frames, synthesizes paragraph styles from font sizes, derives a swatch palette
+ * from fills and image colors, and (when an asset directory is given) extracts
+ * embedded images to PNG. Fidelity warnings record what was inferred vs. read.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { IdmlParseError } from "../indesign/errors.js";
+import type {
+  Document,
+  Font,
+  Frame,
+  ImageFrame,
+  Matrix,
+  Page,
+  Rect,
+  Story,
+  TextFrame,
+} from "../indesign/ir.js";
+import type { ParseResult } from "../indesign/parser.js";
+import { validateDocument } from "../indesign/schema.js";
+import { rectPtToPx } from "../indesign/units.js";
+import { WarningCollector } from "../indesign/warnings.js";
+import { averageColor, encodeImageToPng } from "./images.js";
+import { derivePalette } from "./palette.js";
+import { loadPdfPages, type RawImage, type RawPage } from "./pdf-document.js";
+import { buildStyleBuckets } from "./style-buckets.js";
+import { clusterTextRuns, type TextBlock } from "./text-cluster.js";
+
+export const DEFAULT_DPI = 96;
+const IDENTITY6: Matrix = [1, 0, 0, 1, 0, 0];
+const DEFAULT_CHARACTER_STYLE = "CharacterStyle/[No character style]";
+
+export const PdfWarningCode = {
+  NO_EMBEDDED_FONTS: "NO_EMBEDDED_FONTS",
+  TEXT_FROM_GLYPHS: "TEXT_FROM_GLYPHS",
+  VECTOR_ONLY_PAGE: "VECTOR_ONLY_PAGE",
+  IMAGE_NOT_EXTRACTED: "IMAGE_NOT_EXTRACTED",
+  MULTI_COLUMN_DETECTED: "MULTI_COLUMN_DETECTED",
+} as const;
+
+export interface PdfParseOptions {
+  /** DPI for point→pixel conversion. Default 96. */
+  dpi?: number;
+  /** Run zod validation on the produced IR (default true). */
+  validate?: boolean;
+  /** Recorded on `document.meta.sourcePath`. */
+  sourcePath?: string;
+  /** Directory to write extracted images into; enables image asset extraction. */
+  assetDir?: string;
+  /** Maximum number of palette swatches to derive. */
+  maxColors?: number;
+}
+
+/** Parse a PDF buffer into the IR. */
+export async function parsePdf(
+  data: Uint8Array,
+  options: PdfParseOptions = {},
+): Promise<ParseResult> {
+  const dpi = options.dpi ?? DEFAULT_DPI;
+  const validate = options.validate ?? true;
+  const collector = new WarningCollector();
+
+  let rawPages: RawPage[];
+  try {
+    rawPages = await loadPdfPages(data);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IdmlParseError(`Could not parse PDF: ${reason}`, "PDF_LOAD_ERROR");
+  }
+  if (rawPages.length === 0) {
+    throw new IdmlParseError("PDF has no pages", "PDF_EMPTY");
+  }
+
+  const pages = rawPages.map((raw, index) => ({ raw, index, ...clusterTextRuns(raw.runs) }));
+
+  const allBlocks = pages.flatMap((p) => p.blocks);
+  const { paragraphStyles, styleIdForSize } = buildStyleBuckets(allBlocks, dpi);
+
+  const fonts = collectFonts(rawPages);
+  const swatches = derivePalette(
+    rawPages.flatMap((p) => p.colors),
+    rawPages.flatMap((p) =>
+      p.images.map((im) => (im.pixels ? averageColor(im.pixels) : undefined)).filter(isString),
+    ),
+    options.maxColors ? { maxColors: options.maxColors } : {},
+  );
+
+  if (options.assetDir) mkdirSync(options.assetDir, { recursive: true });
+
+  const stories: Story[] = [];
+  const assets: Document["assets"] = [];
+  const spreads: Document["spreads"] = [];
+  let storyCounter = 0;
+  let imageCounter = 0;
+
+  for (const page of pages) {
+    const pageId = `page-${page.index + 1}`;
+    const pageHeightPt = page.raw.heightPt;
+    const pageBounds = rectPtToPx(
+      { x: 0, y: 0, width: page.raw.widthPt, height: pageHeightPt },
+      dpi,
+    );
+    const irPage: Page = {
+      id: pageId,
+      name: String(page.index + 1),
+      bounds: pageBounds,
+      geometricBounds: pageBounds,
+      transform: IDENTITY6,
+    };
+
+    const frames: Frame[] = [];
+    for (const block of page.blocks) {
+      const storyId = `Story/p${page.index + 1}-${++storyCounter}`;
+      const styleId = styleIdForSize.get(block.size) ?? "ParagraphStyle/Body";
+      stories.push(buildStory(storyId, block, styleId));
+      frames.push(buildTextFrame(storyId, block, pageId, pageHeightPt, dpi));
+    }
+    for (const image of page.raw.images) {
+      frames.push(
+        buildImageFrame(
+          image,
+          pageId,
+          pageHeightPt,
+          dpi,
+          ++imageCounter,
+          options,
+          assets,
+          collector,
+        ),
+      );
+    }
+
+    if (page.blocks.length === 0 && (page.raw.images.length > 0 || page.raw.colors.length > 0)) {
+      collector.warn(
+        PdfWarningCode.VECTOR_ONLY_PAGE,
+        `Page ${page.index + 1} has no extractable text (vector or outlined content only)`,
+        pageId,
+      );
+    }
+    if (page.columnCount > 1) {
+      collector.info(
+        PdfWarningCode.MULTI_COLUMN_DETECTED,
+        `Page ${page.index + 1} reconstructed as ${page.columnCount} columns`,
+        pageId,
+      );
+    }
+
+    spreads.push({ id: `Spread/${page.index + 1}`, pages: [irPage], frames, transform: IDENTITY6 });
+  }
+
+  if (allBlocks.length > 0) {
+    collector.info(
+      PdfWarningCode.TEXT_FROM_GLYPHS,
+      "Text was reconstructed from positioned glyph runs; line and paragraph grouping is heuristic",
+    );
+  }
+  if (fonts.some((f) => !f.embedded)) {
+    const names = fonts.filter((f) => !f.embedded).map((f) => f.family);
+    collector.warn(
+      PdfWarningCode.NO_EMBEDDED_FONTS,
+      `Fonts are not embedded (${names.join(", ")}); mapped by name with web fallbacks`,
+    );
+  }
+
+  const document: Document = {
+    meta: buildMeta(dpi, options.sourcePath),
+    spreads,
+    masterSpreads: [],
+    stories,
+    swatches,
+    fonts: fonts.map((f): Font => ({ family: f.family, name: f.family })),
+    paragraphStyles,
+    characterStyles: [],
+    assets,
+    warnings: collector.all(),
+  };
+
+  const finalDoc = validate ? validateOrThrow(document) : document;
+  return { document: finalDoc, warnings: finalDoc.warnings };
+}
+
+/** Read and parse a PDF file from disk. */
+export async function parsePdfFile(
+  path: string,
+  options: PdfParseOptions = {},
+): Promise<ParseResult> {
+  let data: Uint8Array;
+  try {
+    data = readFileSync(path);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IdmlParseError(`Cannot read PDF file "${path}": ${reason}`, "FILE_READ_ERROR");
+  }
+  return parsePdf(data, { sourcePath: path, ...options });
+}
+
+function buildMeta(dpi: number, sourcePath?: string): Document["meta"] {
+  const meta: Document["meta"] = { source: "pdf", dpi, mimetypeValid: true };
+  if (sourcePath) meta.sourcePath = sourcePath;
+  return meta;
+}
+
+function buildStory(storyId: string, block: TextBlock, styleId: string): Story {
+  const paragraphs = block.lines.map((line) => ({
+    appliedParagraphStyle: styleId,
+    overrides: {},
+    runs: [{ text: line.text, appliedCharacterStyle: DEFAULT_CHARACTER_STYLE, overrides: {} }],
+    text: line.text,
+  }));
+  return {
+    id: storyId,
+    paragraphs,
+    plainText: block.text,
+    appliedStyles: { paragraph: [styleId], character: [DEFAULT_CHARACTER_STYLE] },
+  };
+}
+
+function flipBounds(
+  x: number,
+  yBottom: number,
+  width: number,
+  height: number,
+  pageHeightPt: number,
+  dpi: number,
+): Rect {
+  const top = pageHeightPt - (yBottom + height);
+  return rectPtToPx({ x, y: top, width, height }, dpi);
+}
+
+function buildTextFrame(
+  storyId: string,
+  block: TextBlock,
+  pageId: string,
+  pageHeightPt: number,
+  dpi: number,
+): TextFrame {
+  const frame: TextFrame = {
+    id: storyId.replace("Story/", "TextFrame/"),
+    type: "text",
+    pageId,
+    bounds: flipBounds(block.x, block.y, block.width, block.height, pageHeightPt, dpi),
+    transform: IDENTITY6,
+    visible: true,
+    storyId,
+  };
+  const name = block.lines[0]?.text.slice(0, 48);
+  if (name) frame.name = name;
+  return frame;
+}
+
+function buildImageFrame(
+  image: RawImage,
+  pageId: string,
+  pageHeightPt: number,
+  dpi: number,
+  index: number,
+  options: PdfParseOptions,
+  assets: Document["assets"],
+  collector: WarningCollector,
+): ImageFrame {
+  const frame: ImageFrame = {
+    id: `ImageFrame/${index}`,
+    type: "image",
+    pageId,
+    bounds: flipBounds(image.x, image.y, image.width, image.height, pageHeightPt, dpi),
+    transform: IDENTITY6,
+    visible: true,
+    image: { kind: "image", embedded: true },
+  };
+
+  if (image.pixels && options.assetDir) {
+    const png = encodeImageToPng(image.pixels);
+    if (png) {
+      const filename = `image-${index}.png`;
+      writeFileSync(join(options.assetDir, filename), png);
+      frame.image.resolvedPath = filename;
+      assets.push({ path: filename, bytes: png.length });
+      return frame;
+    }
+  }
+  collector.warn(
+    PdfWarningCode.IMAGE_NOT_EXTRACTED,
+    `Image ${index} could not be extracted to an asset file`,
+    pageId,
+  );
+  return frame;
+}
+
+interface CollectedFont {
+  family: string;
+  embedded: boolean;
+}
+
+function collectFonts(pages: RawPage[]): CollectedFont[] {
+  const fonts = new Map<string, CollectedFont>();
+  for (const page of pages) {
+    for (const font of page.fonts.values()) {
+      const existing = fonts.get(font.family);
+      if (!existing) fonts.set(font.family, { family: font.family, embedded: font.embedded });
+      else if (font.embedded) existing.embedded = true;
+    }
+  }
+  return [...fonts.values()];
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === "string";
+}
+
+function validateOrThrow(document: Document): Document {
+  try {
+    return validateDocument(document);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new IdmlParseError(`Internal IR validation failed: ${reason}`, "IR_VALIDATION_FAILED");
+  }
+}

--- a/packages/pipeline/src/pdf/pdf-document.ts
+++ b/packages/pipeline/src/pdf/pdf-document.ts
@@ -1,0 +1,323 @@
+/**
+ * Low-level PDF extraction via the Node-friendly legacy pdfjs build.
+ *
+ * Loads a PDF and produces, per page, the raw material the parser needs: text
+ * runs (with positions, sizes, and resolved font names), fill/stroke colors from
+ * the operator list, and placed images (bounds via CTM tracking, plus decoded
+ * pixels when pdfjs exposes them). All coordinates are PDF user space (points,
+ * y-up); the parser flips them to the IR's top-left pixel space.
+ */
+import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
+import { cmykToRgb, grayToRgb, rgbToHex } from "../indesign/colors.js";
+import type { Matrix } from "../indesign/ir.js";
+import { applyMatrix, boundsFromPoints, compose, IDENTITY, type Point } from "../indesign/units.js";
+
+export interface RawTextRun {
+  text: string;
+  /** Glyph-run origin x (PDF user space, points). */
+  x: number;
+  /** Glyph-run baseline y (PDF user space, points, y-up). */
+  baseline: number;
+  /** Advance width (points). */
+  width: number;
+  /** Font size (points). */
+  height: number;
+  fontName: string;
+  fontFamily?: string;
+}
+
+export interface RawPixels {
+  width: number;
+  height: number;
+  /** pdfjs ImageKind: 1 = gray 1bpp, 2 = RGB 24bpp, 3 = RGBA 32bpp. */
+  kind: number;
+  data: Uint8Array | Uint8ClampedArray;
+}
+
+export interface RawImage {
+  id: string;
+  /** Bounding box in PDF user space (points, y-up; `y` is the bottom edge). */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  pixels?: RawPixels;
+}
+
+export interface RawFont {
+  family: string;
+  embedded: boolean;
+}
+
+export interface RawPage {
+  widthPt: number;
+  heightPt: number;
+  runs: RawTextRun[];
+  images: RawImage[];
+  /** All fill/stroke colors encountered, as `#rrggbb` (with repeats). */
+  colors: string[];
+  fonts: Map<string, RawFont>;
+}
+
+const STANDARD_14 =
+  /^(Helvetica|Arial|Times|Times New Roman|Courier|Symbol|ZapfDingbats)(-?(Bold|Italic|Oblique|BoldItalic|BoldOblique|Roman|MT|PSMT|PS))*$/i;
+
+/** Load a PDF buffer and extract every page's raw material. */
+export async function loadPdfPages(data: Uint8Array): Promise<RawPage[]> {
+  // pdfjs rejects Node `Buffer`; pass a plain Uint8Array view of the bytes.
+  const bytes =
+    data.constructor === Uint8Array
+      ? data
+      : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  const task = pdfjs.getDocument({
+    data: bytes,
+    useSystemFonts: false,
+    isEvalSupported: false,
+    disableFontFace: true,
+    useWorkerFetch: false,
+    verbosity: pdfjs.VerbosityLevel.ERRORS,
+  });
+  const pdf = await task.promise;
+  try {
+    const pages: RawPage[] = [];
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      try {
+        pages.push(await extractPage(page));
+      } finally {
+        page.cleanup();
+      }
+    }
+    return pages;
+  } finally {
+    await task.destroy();
+  }
+}
+
+async function extractPage(page: pdfjs.PDFPageProxy): Promise<RawPage> {
+  const viewport = page.getViewport({ scale: 1 });
+  const [textContent, opList] = await Promise.all([page.getTextContent(), page.getOperatorList()]);
+
+  const fonts = new Map<string, RawFont>();
+  const runs: RawTextRun[] = [];
+  for (const item of textContent.items) {
+    if (!("str" in item) || item.str.length === 0) continue;
+    const fontName = item.fontName;
+    if (!fonts.has(fontName)) fonts.set(fontName, resolveFont(page, fontName));
+    const run: RawTextRun = {
+      text: item.str,
+      x: item.transform[4] ?? 0,
+      baseline: item.transform[5] ?? 0,
+      width: item.width,
+      height: item.height || fontSizeFromTransform(item.transform),
+      fontName,
+    };
+    const family = fonts.get(fontName)?.family;
+    if (family) run.fontFamily = family;
+    runs.push(run);
+  }
+
+  const { colors, images, xobjectIds } = walkOperators(opList);
+  await resolveImagePixels(page, images, xobjectIds);
+  return { widthPt: viewport.width, heightPt: viewport.height, runs, images, colors, fonts };
+}
+
+/** Resolve image XObject pixels asynchronously (pdfjs populates them lazily). */
+async function resolveImagePixels(
+  page: pdfjs.PDFPageProxy,
+  images: RawImage[],
+  xobjectIds: Map<number, string>,
+): Promise<void> {
+  for (const [index, objId] of xobjectIds) {
+    const image = images[index];
+    if (!image) continue;
+    const raw = (await getObj(page.objs, objId)) ?? (await getObj(page.commonObjs, objId));
+    if (raw && typeof raw === "object" && "data" in raw && "width" in raw && "height" in raw) {
+      const r = raw as RawPixels;
+      if (r.data && r.width && r.height) {
+        image.pixels = { width: r.width, height: r.height, kind: r.kind ?? 0, data: r.data };
+      }
+    }
+  }
+}
+
+/** Get a pdfjs object, awaiting its lazy resolution via the callback form. */
+function getObj(store: pdfjs.ObjStore, id: string): Promise<unknown> {
+  return new Promise((resolve) => {
+    try {
+      if (store.has(id)) {
+        resolve(store.get(id));
+        return;
+      }
+    } catch {
+      // not ready synchronously — fall through to the callback form
+    }
+    let settled = false;
+    const finish = (value: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(null), 3000);
+    try {
+      store.get(id, (obj) => finish(obj));
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+function resolveFont(page: pdfjs.PDFPageProxy, fontName: string): RawFont {
+  try {
+    if (page.commonObjs.has(fontName)) {
+      const font = page.commonObjs.get(fontName) as { name?: string; loadedName?: string } | null;
+      const name = font?.name ?? fontName;
+      return { family: cleanFontName(name), embedded: !STANDARD_14.test(name) };
+    }
+  } catch {
+    // fall through to the raw id
+  }
+  return { family: cleanFontName(fontName), embedded: false };
+}
+
+function cleanFontName(name: string): string {
+  // Subset fonts are tagged "ABCDEF+FamilyName"; drop the tag.
+  return name.replace(/^[A-Z]{6}\+/, "").replace(/[-_](Regular|MT|PS|PSMT)$/i, "");
+}
+
+function fontSizeFromTransform(transform: number[]): number {
+  const a = transform[0] ?? 1;
+  const b = transform[1] ?? 0;
+  return Math.hypot(a, b);
+}
+
+interface WalkResult {
+  colors: string[];
+  images: RawImage[];
+  /** Map of image index → XObject id, resolved to pixels after the walk. */
+  xobjectIds: Map<number, string>;
+}
+
+function walkOperators(opList: pdfjs.OperatorList): WalkResult {
+  const OPS = pdfjs.OPS;
+  const colors: string[] = [];
+  const images: RawImage[] = [];
+  const xobjectIds = new Map<number, string>();
+  let ctm: Matrix = [...IDENTITY];
+  const stack: Matrix[] = [];
+
+  for (let i = 0; i < opList.fnArray.length; i++) {
+    const fn = opList.fnArray[i];
+    const args = opList.argsArray[i];
+    switch (fn) {
+      case OPS.save:
+        stack.push([...ctm]);
+        break;
+      case OPS.restore:
+        ctm = stack.pop() ?? [...IDENTITY];
+        break;
+      case OPS.transform:
+        ctm = compose(ctm, argsToMatrix(args));
+        break;
+      case OPS.setFillRGBColor:
+      case OPS.setStrokeRGBColor: {
+        const hex = rgbArgToHex(args);
+        if (hex) colors.push(hex);
+        break;
+      }
+      case OPS.setFillCMYKColor:
+      case OPS.setStrokeCMYKColor: {
+        const hex = cmykArgToHex(args);
+        if (hex) colors.push(hex);
+        break;
+      }
+      case OPS.setFillGray:
+      case OPS.setStrokeGray: {
+        const hex = grayArgToHex(args);
+        if (hex) colors.push(hex);
+        break;
+      }
+      case OPS.paintImageXObject:
+      case OPS.paintImageXObjectRepeat: {
+        const objId = String((Array.isArray(args) ? args[0] : undefined) ?? "");
+        if (objId) {
+          xobjectIds.set(images.length, objId);
+          images.push({ id: objId, ...imageBounds(ctm) });
+        }
+        break;
+      }
+      case OPS.paintInlineImage: {
+        const image = imageFromInline(Array.isArray(args) ? args[0] : args, ctm, images.length);
+        if (image) images.push(image);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return { colors, images, xobjectIds };
+}
+
+function imageBounds(ctm: Matrix): { x: number; y: number; width: number; height: number } {
+  const corners: Point[] = [
+    applyMatrix(ctm, 0, 0),
+    applyMatrix(ctm, 1, 0),
+    applyMatrix(ctm, 1, 1),
+    applyMatrix(ctm, 0, 1),
+  ];
+  const box = boundsFromPoints(corners) ?? { x: 0, y: 0, width: 0, height: 0 };
+  return box;
+}
+
+function imageFromInline(raw: unknown, ctm: Matrix, index: number): RawImage | undefined {
+  const box = imageBounds(ctm);
+  const image: RawImage = { id: `inline-${index}`, ...box };
+  if (raw && typeof raw === "object" && "data" in raw && "width" in raw && "height" in raw) {
+    const r = raw as RawPixels;
+    if (r.data && r.width && r.height) {
+      image.pixels = { width: r.width, height: r.height, kind: r.kind ?? 0, data: r.data };
+    }
+  }
+  return image;
+}
+
+function num(args: unknown[], i: number): number {
+  const v = args[i];
+  return typeof v === "number" ? v : 0;
+}
+
+function argsToMatrix(args: unknown): Matrix {
+  if (Array.isArray(args) && args.length >= 6 && args.every((n) => typeof n === "number")) {
+    return [num(args, 0), num(args, 1), num(args, 2), num(args, 3), num(args, 4), num(args, 5)];
+  }
+  return [...IDENTITY];
+}
+
+function rgbArgToHex(args: unknown): string | undefined {
+  const first = Array.isArray(args) ? args[0] : args;
+  if (typeof first === "string" && /^#[0-9a-f]{6}$/i.test(first)) return first.toLowerCase();
+  if (Array.isArray(args) && args.length >= 3 && args.every((n) => typeof n === "number")) {
+    const r = num(args, 0);
+    const g = num(args, 1);
+    const b = num(args, 2);
+    const scale = r > 1 || g > 1 || b > 1 ? 1 : 255;
+    return rgbToHex({ r: r * scale, g: g * scale, b: b * scale });
+  }
+  return undefined;
+}
+
+function cmykArgToHex(args: unknown): string | undefined {
+  if (Array.isArray(args) && args.length >= 4 && args.every((n) => typeof n === "number")) {
+    return rgbToHex(
+      cmykToRgb(num(args, 0) * 100, num(args, 1) * 100, num(args, 2) * 100, num(args, 3) * 100),
+    );
+  }
+  return undefined;
+}
+
+function grayArgToHex(args: unknown): string | undefined {
+  const g = Array.isArray(args) ? args[0] : args;
+  if (typeof g === "number") return rgbToHex(grayToRgb((1 - g) * 100));
+  return undefined;
+}

--- a/packages/pipeline/src/pdf/pdfjs.d.ts
+++ b/packages/pipeline/src/pdf/pdfjs.d.ts
@@ -1,0 +1,88 @@
+/**
+ * Minimal, DOM-free ambient types for the Node-friendly legacy pdfjs build.
+ *
+ * pdfjs-dist ships full types for its main entry only (no `exports` map), and
+ * those types drag in browser/DOM lib references. We import the legacy build for
+ * Node and declare just the slice of the API this package uses, keeping the
+ * surface controlled and free of DOM dependencies.
+ */
+declare module "pdfjs-dist/legacy/build/pdf.mjs" {
+  export interface TextItem {
+    str: string;
+    /** Text matrix `[a, b, c, d, e, f]`; `e`/`f` are the glyph-run origin. */
+    transform: number[];
+    width: number;
+    height: number;
+    fontName: string;
+    hasEOL?: boolean;
+  }
+
+  export interface TextMarkedContent {
+    type: string;
+  }
+
+  export interface TextContent {
+    items: Array<TextItem | TextMarkedContent>;
+  }
+
+  export interface PageViewport {
+    width: number;
+    height: number;
+  }
+
+  export interface OperatorList {
+    fnArray: number[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    argsArray: any[];
+  }
+
+  export interface PdfImage {
+    width: number;
+    height: number;
+    kind?: number;
+    data?: Uint8Array | Uint8ClampedArray;
+  }
+
+  export interface ObjStore {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get(id: string, callback?: (obj: any) => void): any;
+    has(id: string): boolean;
+  }
+
+  export interface PDFPageProxy {
+    getViewport(params: { scale: number }): PageViewport;
+    getTextContent(): Promise<TextContent>;
+    getOperatorList(): Promise<OperatorList>;
+    objs: ObjStore;
+    commonObjs: ObjStore;
+    /** `[x1, y1, x2, y2]` page box in PDF units. */
+    view: number[];
+    cleanup(): void;
+  }
+
+  export interface PDFDocumentProxy {
+    numPages: number;
+    getPage(pageNumber: number): Promise<PDFPageProxy>;
+    destroy(): Promise<void>;
+  }
+
+  export interface DocumentInitParameters {
+    data?: Uint8Array | ArrayBuffer;
+    useSystemFonts?: boolean;
+    isEvalSupported?: boolean;
+    disableFontFace?: boolean;
+    verbosity?: number;
+    standardFontDataUrl?: string;
+    useWorkerFetch?: boolean;
+  }
+
+  export interface PDFDocumentLoadingTask {
+    promise: Promise<PDFDocumentProxy>;
+    destroy(): Promise<void>;
+  }
+
+  export function getDocument(src: DocumentInitParameters): PDFDocumentLoadingTask;
+
+  export const OPS: Record<string, number>;
+  export const VerbosityLevel: { ERRORS: number; WARNINGS: number; INFOS: number };
+}

--- a/packages/pipeline/src/pdf/style-buckets.ts
+++ b/packages/pipeline/src/pdf/style-buckets.ts
@@ -1,0 +1,114 @@
+/**
+ * Synthesize paragraph styles from PDF font-size clusters.
+ *
+ * A PDF carries no named styles, so the parser infers them: distinct font sizes
+ * become heading / body / caption buckets (the most line-heavy size is the body
+ * baseline), each emitted as a synthetic {@link Style} with a pixel `pointSize`.
+ * Downstream, the token mapper clusters these exactly as it does IDML styles.
+ */
+import type { Style } from "../indesign/ir.js";
+import { ptToPx, round } from "../indesign/units.js";
+import type { TextBlock } from "./text-cluster.js";
+
+export interface StyleBuckets {
+  paragraphStyles: Style[];
+  /** Map from a block's font size (points, 1-dp) to a synthetic style id. */
+  styleIdForSize: Map<number, string>;
+  bodySizePt: number;
+}
+
+const HEADING_RATIO = 1.05;
+const CAPTION_RATIO = 0.95;
+
+/** Build synthetic paragraph styles from clustered text blocks. */
+export function buildStyleBuckets(blocks: TextBlock[], dpi: number): StyleBuckets {
+  const sizes = collectSizes(blocks);
+  const styleIdForSize = new Map<number, string>();
+  if (sizes.size === 0) return { paragraphStyles: [], styleIdForSize, bodySizePt: 0 };
+
+  const bodySizePt = pickBodySize(sizes);
+  const distinct = [...sizes.keys()].sort((a, b) => b - a);
+
+  const headings = distinct.filter((s) => s > bodySizePt * HEADING_RATIO);
+  const captions = distinct.filter((s) => s < bodySizePt * CAPTION_RATIO);
+
+  const families = dominantFamilies(blocks);
+  const paragraphStyles: Style[] = [];
+
+  headings.forEach((sizePt, i) => {
+    const name = headings.length === 1 ? "Heading" : `Heading ${i + 1}`;
+    paragraphStyles.push(makeStyle(name, sizePt, dpi, families.get(sizePt)));
+    styleIdForSize.set(sizePt, `ParagraphStyle/${name}`);
+  });
+
+  paragraphStyles.push(makeStyle("Body", bodySizePt, dpi, families.get(bodySizePt)));
+  styleIdForSize.set(bodySizePt, "ParagraphStyle/Body");
+
+  captions.forEach((sizePt, i) => {
+    const name = captions.length === 1 ? "Caption" : `Caption ${i + 1}`;
+    paragraphStyles.push(makeStyle(name, sizePt, dpi, families.get(sizePt)));
+    styleIdForSize.set(sizePt, `ParagraphStyle/${name}`);
+  });
+
+  return { paragraphStyles, styleIdForSize, bodySizePt };
+}
+
+function makeStyle(
+  name: string,
+  sizePt: number,
+  dpi: number,
+  fontFamily: string | undefined,
+): Style {
+  const style: Style = {
+    id: `ParagraphStyle/${name}`,
+    name,
+    kind: "paragraph",
+    properties: { pointSize: round(ptToPx(sizePt, dpi)), raw: {} },
+  };
+  if (fontFamily) style.properties.fontFamily = fontFamily;
+  return style;
+}
+
+/** Distinct sizes (points, 1-dp) → total line count at that size. */
+function collectSizes(blocks: TextBlock[]): Map<number, number> {
+  const sizes = new Map<number, number>();
+  for (const block of blocks) {
+    sizes.set(block.size, (sizes.get(block.size) ?? 0) + block.lines.length);
+  }
+  return sizes;
+}
+
+function pickBodySize(sizes: Map<number, number>): number {
+  let best = 0;
+  let bestWeight = -1;
+  for (const [size, weight] of sizes) {
+    if (weight > bestWeight || (weight === bestWeight && size < best)) {
+      best = size;
+      bestWeight = weight;
+    }
+  }
+  return best;
+}
+
+function dominantFamilies(blocks: TextBlock[]): Map<number, string> {
+  const perSize = new Map<number, Map<string, number>>();
+  for (const block of blocks) {
+    if (!block.fontFamily) continue;
+    const counts = perSize.get(block.size) ?? new Map<string, number>();
+    counts.set(block.fontFamily, (counts.get(block.fontFamily) ?? 0) + block.lines.length);
+    perSize.set(block.size, counts);
+  }
+  const out = new Map<number, string>();
+  for (const [size, counts] of perSize) {
+    let best = "";
+    let bestCount = 0;
+    for (const [family, count] of counts) {
+      if (count > bestCount) {
+        best = family;
+        bestCount = count;
+      }
+    }
+    if (best) out.set(size, best);
+  }
+  return out;
+}

--- a/packages/pipeline/src/pdf/text-cluster.ts
+++ b/packages/pipeline/src/pdf/text-cluster.ts
@@ -1,0 +1,209 @@
+/**
+ * Cluster positioned PDF text runs into logical text blocks.
+ *
+ * Runs → lines (same baseline, split on large horizontal gaps so columns don't
+ * merge) → columns (lines grouped by left edge) → blocks (vertically contiguous
+ * lines of compatible size within a column). Bounds are in PDF user space
+ * (points, y-up); the parser flips them to the IR's top-left pixel space.
+ */
+import type { RawTextRun } from "./pdf-document.js";
+
+export interface ClusterLine {
+  runs: RawTextRun[];
+  baseline: number;
+  x0: number;
+  x1: number;
+  /** Dominant font size on the line (points). */
+  size: number;
+  text: string;
+}
+
+export interface TextBlock {
+  lines: ClusterLine[];
+  /** Bounds in PDF user space (points, y-up; `y` is the bottom edge). */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Dominant font size across the block (points). */
+  size: number;
+  fontFamily?: string;
+  columnIndex: number;
+  text: string;
+}
+
+export interface ClusterResult {
+  blocks: TextBlock[];
+  columnCount: number;
+}
+
+const BASELINE_TOL = 0.5; // × line height
+const GAP_SPLIT_MIN = 24; // pt — min horizontal gap that splits a line into columns
+const GAP_SPLIT_RATIO = 3; // × line height
+const COLUMN_BAND_GAP = 80; // pt — min separation between column left edges
+const BLOCK_VGAP_RATIO = 1.9; // × line height — max vertical gap within a block
+const SIZE_BREAK_RATIO = 1.35; // font-size ratio that starts a new block
+const ASCENT = 0.8;
+const DESCENT = 0.2;
+
+/** Cluster raw text runs into blocks and report the detected column count. */
+export function clusterTextRuns(runs: RawTextRun[]): ClusterResult {
+  const lines = buildLines(runs);
+  if (lines.length === 0) return { blocks: [], columnCount: 0 };
+
+  const bands = detectColumnBands(lines);
+  const blocks: TextBlock[] = [];
+  bands.forEach((bandLines, columnIndex) => {
+    for (const block of splitIntoBlocks(bandLines, columnIndex)) blocks.push(block);
+  });
+  return { blocks, columnCount: bands.length };
+}
+
+function buildLines(runs: RawTextRun[]): ClusterLine[] {
+  const sorted = [...runs].sort((a, b) => b.baseline - a.baseline || a.x - b.x);
+  const baselineGroups: RawTextRun[][] = [];
+  for (const run of sorted) {
+    const group = baselineGroups[baselineGroups.length - 1];
+    const ref = group?.[0];
+    if (group && ref && Math.abs(run.baseline - ref.baseline) <= BASELINE_TOL * run.height) {
+      group.push(run);
+    } else {
+      baselineGroups.push([run]);
+    }
+  }
+
+  const lines: ClusterLine[] = [];
+  for (const group of baselineGroups) {
+    const byX = [...group].sort((a, b) => a.x - b.x);
+    let segment: RawTextRun[] = [];
+    const flush = (): void => {
+      if (segment.length > 0) lines.push(makeLine(segment));
+      segment = [];
+    };
+    for (const run of byX) {
+      const prev = segment[segment.length - 1];
+      if (prev) {
+        const gap = run.x - (prev.x + prev.width);
+        const threshold = Math.max(GAP_SPLIT_MIN, GAP_SPLIT_RATIO * run.height);
+        if (gap > threshold) flush();
+      }
+      segment.push(run);
+    }
+    flush();
+  }
+  return lines;
+}
+
+function makeLine(runs: RawTextRun[]): ClusterLine {
+  const x0 = Math.min(...runs.map((r) => r.x));
+  const x1 = Math.max(...runs.map((r) => r.x + r.width));
+  const size = mode(runs.map((r) => round1(r.height)));
+  const baseline = runs[0]?.baseline ?? 0;
+  return { runs, baseline, x0, x1, size, text: joinRuns(runs) };
+}
+
+function joinRuns(runs: RawTextRun[]): string {
+  let text = "";
+  let prevEnd: number | undefined;
+  for (const run of runs) {
+    if (prevEnd !== undefined && run.x - prevEnd > 0.25 * run.height && !text.endsWith(" ")) {
+      text += " ";
+    }
+    text += run.text;
+    prevEnd = run.x + run.width;
+  }
+  return text;
+}
+
+function detectColumnBands(lines: ClusterLine[]): ClusterLine[][] {
+  const edges = [...new Set(lines.map((l) => Math.round(l.x0)))].sort((a, b) => a - b);
+  const bands: number[][] = [];
+  for (const edge of edges) {
+    const last = bands[bands.length - 1];
+    if (last && edge - (last[last.length - 1] ?? edge) <= COLUMN_BAND_GAP) last.push(edge);
+    else bands.push([edge]);
+  }
+
+  // Count lines whose left edge falls in each band; require ≥2 bands with ≥2 lines.
+  const bandLeft = bands.map((b) => Math.min(...b));
+  const assigned: ClusterLine[][] = bands.map(() => []);
+  for (const line of lines) {
+    let bi = 0;
+    for (let i = bands.length - 1; i >= 0; i--) {
+      if (line.x0 + 0.5 >= (bandLeft[i] ?? 0)) {
+        bi = i;
+        break;
+      }
+    }
+    assigned[bi]?.push(line);
+  }
+  const populated = assigned.filter((b) => b.length >= 2);
+  if (populated.length >= 2) return assigned.filter((b) => b.length > 0);
+  return [lines];
+}
+
+function splitIntoBlocks(lines: ClusterLine[], columnIndex: number): TextBlock[] {
+  const sorted = [...lines].sort((a, b) => b.baseline - a.baseline);
+  const blocks: TextBlock[] = [];
+  let current: ClusterLine[] = [];
+
+  const flush = (): void => {
+    if (current.length > 0) blocks.push(makeBlock(current, columnIndex));
+    current = [];
+  };
+
+  for (const line of sorted) {
+    const prev = current[current.length - 1];
+    if (prev) {
+      const vGap = prev.baseline - line.baseline;
+      const sizeRatio =
+        Math.max(prev.size, line.size) / Math.max(1, Math.min(prev.size, line.size));
+      const xOverlap = line.x0 < prev.x1 + 4 && line.x1 > current[0]!.x0 - 4;
+      if (vGap > BLOCK_VGAP_RATIO * line.size || sizeRatio >= SIZE_BREAK_RATIO || !xOverlap) {
+        flush();
+      }
+    }
+    current.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+function makeBlock(lines: ClusterLine[], columnIndex: number): TextBlock {
+  const x0 = Math.min(...lines.map((l) => l.x0));
+  const x1 = Math.max(...lines.map((l) => l.x1));
+  const top = Math.max(...lines.map((l) => l.baseline + ASCENT * l.size));
+  const bottom = Math.min(...lines.map((l) => l.baseline - DESCENT * l.size));
+  const size = mode(lines.map((l) => l.size));
+  const family = lines[0]?.runs[0]?.fontFamily;
+  const block: TextBlock = {
+    lines,
+    x: x0,
+    y: bottom,
+    width: x1 - x0,
+    height: top - bottom,
+    size,
+    columnIndex,
+    text: lines.map((l) => l.text).join("\n"),
+  };
+  if (family) block.fontFamily = family;
+  return block;
+}
+
+function mode(values: number[]): number {
+  const counts = new Map<number, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best = values[0] ?? 0;
+  let bestCount = 0;
+  for (const [value, count] of counts) {
+    if (count > bestCount || (count === bestCount && value > best)) {
+      best = value;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}

--- a/packages/pipeline/src/source.ts
+++ b/packages/pipeline/src/source.ts
@@ -1,0 +1,54 @@
+/**
+ * Source-agnostic entry point: parse either an IDML or a PDF into the IR.
+ *
+ * IDML and PDF are both first-class inputs. With `sourcePriority`, a caller can
+ * force one path even when both a `.idml` and `.pdf` sibling exist — useful for
+ * verifying parity between the two ingestion routes.
+ */
+import { existsSync } from "node:fs";
+import { extname } from "node:path";
+import type { ParseResult } from "./indesign/parser.js";
+import { parseIdmlFile } from "./indesign/parser.js";
+import { parsePdfFile, type PdfParseOptions } from "./pdf/parser.js";
+
+export type SourcePriority = "auto" | "idml" | "pdf";
+
+export interface ParseSourceOptions extends PdfParseOptions {
+  /** Which path to prefer when both an `.idml` and `.pdf` are available. */
+  sourcePriority?: SourcePriority;
+}
+
+export interface ResolvedSource {
+  kind: "idml" | "pdf";
+  path: string;
+}
+
+/** Determine which file to parse from an input path and a priority. */
+export function resolveSource(input: string, priority: SourcePriority = "auto"): ResolvedSource {
+  const ext = extname(input).toLowerCase();
+  const base = input.replace(/\.(pdf|idml)$/i, "");
+  const idmlPath = `${base}.idml`;
+  const pdfPath = `${base}.pdf`;
+
+  if (priority === "idml" && existsSync(idmlPath)) return { kind: "idml", path: idmlPath };
+  if (priority === "pdf" && existsSync(pdfPath)) return { kind: "pdf", path: pdfPath };
+
+  if (ext === ".idml") return { kind: "idml", path: input };
+  if (ext === ".pdf") return { kind: "pdf", path: input };
+
+  if (existsSync(pdfPath)) return { kind: "pdf", path: pdfPath };
+  if (existsSync(idmlPath)) return { kind: "idml", path: idmlPath };
+
+  throw new Error(`Cannot determine source type for "${input}" (expected .idml or .pdf)`);
+}
+
+/** Parse an IDML or PDF file into the IR, auto-detecting (or forcing) the path. */
+export async function parseSourceFile(
+  input: string,
+  options: ParseSourceOptions = {},
+): Promise<ParseResult> {
+  const { sourcePriority, ...parseOptions } = options;
+  const resolved = resolveSource(input, sourcePriority ?? "auto");
+  if (resolved.kind === "idml") return parseIdmlFile(resolved.path, parseOptions);
+  return parsePdfFile(resolved.path, parseOptions);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,12 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
+      pdfjs-dist:
+        specifier: ^6.0.227
+        version: 6.0.227
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -81,6 +87,12 @@ importers:
       '@types/node':
         specifier: ^20.17.0
         version: 20.19.43
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -542,6 +554,81 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    resolution: {integrity: sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    resolution: {integrity: sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.0':
+    resolution: {integrity: sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==}
+    engines: {node: '>= 10'}
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
@@ -553,6 +640,12 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -732,6 +825,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
@@ -1799,6 +1895,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1847,6 +1946,13 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+
+  pdfjs-dist@6.0.227:
+    resolution: {integrity: sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2136,6 +2242,9 @@ packages:
 
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2910,6 +3019,54 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/canvas-android-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@napi-rs/canvas@1.0.0':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-arm64': 1.0.0
+      '@napi-rs/canvas-darwin-x64': 1.0.0
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.0
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.0
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.0
+      '@napi-rs/canvas-linux-x64-musl': 1.0.0
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.0
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.0
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -2920,6 +3077,14 @@ snapshots:
   '@nodable/entities@2.1.0': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -3094,6 +3259,10 @@ snapshots:
       undici-types: 7.18.2
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -4130,6 +4299,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4167,6 +4338,17 @@ snapshots:
       pify: 3.0.0
 
   pathe@2.0.3: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
+
+  pdfjs-dist@6.0.227:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.0
 
   picocolors@1.1.1: {}
 
@@ -4445,6 +4627,8 @@ snapshots:
     dependencies:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary

Makes **PDF a first-class input** to the InDesign-to-React pipeline (#64, part of #62). InDesign-exported PDFs are what designers actually hand engineering, so the parser ingests them into the **same IR** the IDML parser emits — keeping the token mapper (#65) and the upcoming component generator (#66) source-agnostic.

New `packages/pipeline/src/pdf/` subsystem (via `pdfjs-dist`) plus a source-agnostic `parseSourceFile` entry and CLI integration.

## What it does

- **Text** — extracts positioned glyph runs and clusters them: runs → lines (split on large gaps so columns don't merge) → columns → text frames.
- **Styles** — infers a heading/body/caption scale from font-size buckets, synthesized as `ParagraphStyle`s the mapper clusters exactly as IDML styles.
- **Color** — derives a swatch palette from operator-list fills/strokes and dominant image colors (CMYK/RGB/Gray → sRGB), de-duplicated within tolerance.
- **Images** — extracts embedded image XObjects, decodes to PNG (`pngjs`), and writes them to an `--assets` dir, addressable from the IR.
- **Geometry** — flips PDF's bottom-left origin to the IR's top-left pixel space at a configurable DPI.
- **Fidelity** — emits `TEXT_FROM_GLYPHS`, `NO_EMBEDDED_FONTS`, `VECTOR_ONLY_PAGE`, `MULTI_COLUMN_DETECTED`, `IMAGE_NOT_EXTRACTED` warnings, surfaced by the CLI and documented in [`docs/pipeline/indesign-pdf-fidelity.md`](docs/pipeline/indesign-pdf-fidelity.md).

## CLI & API

```bash
# Auto-detects .pdf vs .idml; --source-priority forces a path.
aurelius-indesign brochure.pdf --emit-tokens ./src/tokens --assets ./public/assets
```

```ts
import { parsePdfFile } from "@aurelius/pipeline/pdf";
import { parseSourceFile } from "@aurelius/pipeline";
const { document } = await parseSourceFile("brochure.pdf", { sourcePriority: "pdf", assetDir: "public/assets" });
```

`runCli` is now async; `meta.source` (`"idml" | "pdf"`) was added to the IR.

## Acceptance criteria (#64)

- [x] Fixture PDF → valid IR consumable by the mapper without a companion IDML (PDF → IR → tokens tested)
- [x] CLI accepts `.pdf` as a primary input and runs PDF → IR → tokens end-to-end
- [x] Parity test: same-shape IDML & PDF agree on page count and heading/body buckets within tolerance
- [x] Embedded images extracted and addressable from the IR
- [x] Swatch palette derived from the PDF when no IDML is supplied
- [x] Fidelity warnings in CLI output + documented in `docs/pipeline/indesign-pdf-fidelity.md`
- [x] README + pipeline docs describe PDF as first-class with a "designer hands you a PDF" quickstart
- [x] Unit tests cover text-heavy, image-heavy, multi-column, single-page brochure, and vector-only/outlined PDFs

## Testing

- `pnpm --filter @aurelius/pipeline typecheck` / `test` / `build` ✅ — **117 tests (24 new)**
- Repo-wide `eslint .` (0 errors) and `prettier --check .` ✅; `check-doc-counts` ✅; lockfile in sync (pnpm 9 compatible)
- Verified the compiled CLI on a real PDF: PDF IR report, PDF → tokens, and image extraction (`image-1.png`) all work; `config/font-map.json` resolves from `dist/`

## Notes

- Not pixel-perfect by design — the goal is a usable, styled IR for the generator with manual touch-ups. IDML remains preferred when available (richer style metadata); force PDF with `--source-priority pdf` to verify parity.
- `pdfjs-dist` runs in Node with no worker/canvas (data-extraction only). New deps: `pdfjs-dist`, `pngjs` (runtime), `pdf-lib`, `@types/pngjs` (dev, fixtures).

Closes #64
Part of #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
